### PR TITLE
Unarmed Damage Die Implementation

### DIFF
--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -747,6 +747,15 @@ const COSMERE: CosmereRPGConfig = {
         },
     },
 
+    unarmedDamageScaling: {
+        strengthRanges: [
+            { min: 0, max: 2, formula: '1' }, // No die roll, just 1 point of damage
+            { min: 3, max: 4, formula: '1d4' },
+            { min: 5, max: 6, formula: '1d8' },
+            { min: 7, max: 8, formula: '2d6' },
+            { min: 9, max: Infinity, formula: '2d10' },
+        ],
+    },
     cultures: {},
     ancestries: {},
 

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -749,7 +749,7 @@ const COSMERE: CosmereRPGConfig = {
 
     unarmedDamageScaling: {
         strengthRanges: [
-            { min: 0, max: 2, formula: '1' }, // No die roll, just 1 point of damage
+            { min: 0, max: 2, formula: '1' },
             { min: 3, max: 4, formula: '1d4' },
             { min: 5, max: 6, formula: '1d8' },
             { min: 7, max: 8, formula: '2d6' },

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -373,6 +373,7 @@ export class CosmereItem<
                 data: actor.getRollData(),
             });
         } else {
+            // Handle non-unarmed strikes
             const activatable = this.hasActivation();
 
             // Get the skill id
@@ -409,6 +410,8 @@ export class CosmereItem<
             const speaker =
                 options.speaker ??
                 (ChatMessage.getSpeaker({ actor }) as ChatSpeakerData);
+
+            // Create chat message
             await roll.toMessage({ speaker });
         }
 

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -968,17 +968,15 @@ export class CosmereItem<
         };
     }
     protected getUnarmedDamageDie(str: number): string {
-        if (str >= 9) {
-            return '2d10';
-        } else if (str >= 7) {
-            return '2d6';
-        } else if (str >= 5) {
-            return '1d8';
-        } else if (str >= 3) {
-            return '1d4';
-        } else {
-            return '1'; // No die roll, just 1 point of impact damage
+        const scaling = CONFIG.COSMERE.unarmedDamageScaling.strengthRanges;
+
+        // Find correct scaling for unarmed damage die based on config range.
+        for (const tier of scaling) {
+            if (str >= tier.min && str <= tier.max) {
+                return tier.formula;
+            }
         }
+        return '1';
     }
 }
 

--- a/src/system/types/config.ts
+++ b/src/system/types/config.ts
@@ -294,7 +294,13 @@ export interface CosmereRPGConfig {
     };
 
     damageTypes: Record<DamageType, DamageTypeConfig>;
-
+    unarmedDamageScaling: {
+        strengthRanges: {
+            min: number;
+            max: number;
+            formula: string;
+        }[];
+    };
     cultures: Record<string, CultureConfig>;
     ancestries: Record<string, AncestriesConfig>;
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Add logic to calculate damage die for unarmed strikes.

**Related Issue**  
[Closes #91](https://github.com/stanavdb/cosmere-rpg/issues/91)

**How Has This Been Tested?**  
Built and ran on local foundry. Screenshots below.

**Screenshots (if applicable)** 
**I had one rank in Athletics** to confirm damage scales with `Athletics` but die scales with `Str` attribute.

#### Str 6
![image](https://github.com/user-attachments/assets/9b851f73-9bab-4dae-8c0b-a2bfa95e2d31)
#### Str 1
![image](https://github.com/user-attachments/assets/2a992123-21f1-4f87-9f6f-bb0c0cdaea04)
#### Str 4
![image](https://github.com/user-attachments/assets/b4b38e29-e603-47dd-b5b1-c2a55a2aa973)
#### Str 8
![image](https://github.com/user-attachments/assets/c3867a16-4c00-4412-babe-9a0654107b93)
#### Str 9 
![image](https://github.com/user-attachments/assets/812a1b09-507f-4b6d-a8c3-912978015a5f)

**Checklist:**  
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes do not introduce any new warnings or errors.
- [ ] My PR does not contain any copyrighted works that I do not have permission to use.
- [ ] I have tested my changes on Foundry VTT version: [insert version here].

**Additional context**  
_Add any other context or information here that would be useful for reviewers._
