### PR TITLE
feat: allow chat cards to repeat

### DIFF
--- a/src/style/chat/module.scss
+++ b/src/style/chat/module.scss
@@ -600,7 +600,7 @@
         position: static;
 
         button {
-            width: 44px;
+            width: 46px;
             height: 22px;
             font-size: var(--font-size-14);
             font-weight: 600;

--- a/src/system/documents/chat-message.ts
+++ b/src/system/documents/chat-message.ts
@@ -109,6 +109,10 @@ export class CosmereChatMessage extends ChatMessage {
             .find('.message-metadata')
             .find('.message-delete');
         if (!game.user!.isGM) deleteButton?.remove();
+
+        html.find('.message-repeat').on('click', (event) => {
+            void this.onClickRepeat(event);
+        });
     }
 
     protected async enrichCardContent(html: JQuery) {
@@ -593,6 +597,26 @@ export class CosmereChatMessage extends ChatMessage {
             .text(
                 this.useGraze ? this.totalDamageGraze : this.totalDamageNormal,
             );
+    }
+
+    /**
+     * Handles a repeat button click event.
+     * @param {JQuery.ClickEvent} event The originating event of the button click.
+     */
+    private async onClickRepeat(event: JQuery.ClickEvent) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        const clone = await Promise.all(
+            this.rolls.map(async (roll) => await roll.reroll()),
+        );
+
+        void ChatMessage.create({
+            user: game.user!.id,
+            speaker: this.speaker,
+            flags: this.flags,
+            rolls: clone,
+        });
     }
 
     /**


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Allows the repeat icon on chat cards to create a new chat message with the exact same configuration as the existing message, but with all rolls rerolled.

**Related Issue**  
Closes #154 

**How Has This Been Tested?**  
Tested on all repeatable chat cards (i.e. chat cards that have rolls).

**Screenshots (if applicable)**  
_Add screenshots or GIFs that help illustrate the changes, especially if they affect the UI or user-facing aspects of the system._

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: [insert version here].
