### PR TITLE
feat: animate accordion for toggling between full damage and graze

### DIFF
--- a/src/style/chat/module.scss
+++ b/src/style/chat/module.scss
@@ -418,8 +418,9 @@
                         .dice-total {
                             font-weight: bold;
                             font-size: var(--font-size-24);
-                            padding: 0;
                             font-family: var(--plotweaver-font-normal);
+                            color: var(--plotweaver-color-dark-1);
+                            padding: 0;
                             position: relative;
 
                             &.ignored {
@@ -446,6 +447,9 @@
                         }
 
                         .dice-subtotal {
+                            border-right: 1px solid var(--plotweaver-color-light-4);
+                            transition: all 200ms ease;
+
                             padding: 0 0.5rem;
                             font-weight: 600;
                             display: flex;
@@ -465,12 +469,34 @@
                                 text-transform: uppercase;
                             }
 
-                            &.right {
-                                border-left: 1px solid var(--plotweaver-color-light-4);
+                            &:last-child {
+                                border-right: 0;
                             }
 
-                            &.left {
-                                border-right: 1px solid var(--plotweaver-color-light-4);
+                            &.active {
+                                padding: 0;
+                                font-weight: bold;
+                                display: flex;
+                                flex-direction: column;
+                                width: 80%;
+
+                                &.pad-left {                                    
+                                    padding-left: 20%;
+                                }
+
+                                &.pad-right {
+                                    padding-right: 20%;
+                                }
+
+                                .value {
+                                    color: var(--plotweaver-color-dark-1);
+                                    font-size: var(--font-size-24);
+                                    font-family: var(--plotweaver-font-normal);
+                                }
+
+                                .label {
+                                    display: none;
+                                }
                             }
                         }
                     }

--- a/src/system/documents/chat-message.ts
+++ b/src/system/documents/chat-message.ts
@@ -580,19 +580,14 @@ export class CosmereChatMessage extends ChatMessage {
     private onSwitchDamageMode(event: JQuery.ClickEvent) {
         const toggle = $(event.currentTarget as HTMLElement);
 
-        if (toggle.css('opacity') === '0') return;
+        if (toggle.hasClass('active')) return;
 
         event.preventDefault();
         event.stopPropagation();
 
         this.useGraze = !this.useGraze;
-        toggle.attr('style', 'opacity: 0;');
-        toggle.siblings('.dice-subtotal').attr('style', '');
-        toggle
-            .siblings('p')
-            .text(
-                this.useGraze ? this.totalDamageGraze : this.totalDamageNormal,
-            );
+        toggle.addClass('active');
+        toggle.siblings('.dice-subtotal').removeClass('active');
     }
 
     /**

--- a/src/templates/chat/roll-damage.hbs
+++ b/src/templates/chat/roll-damage.hbs
@@ -14,12 +14,11 @@
         </div>
         <div class="dice-roll-damage">            
             <h4 class="dice-total">
-                <div class="dice-subtotal left" style="opacity: 0">
+                <div class="dice-subtotal pad-left active">
                     <span class="label">{{localize "DICE.Damage.Full"}}</span>
-                    <span class="value">{{totalNormal}}</span>       
+                    <span class="value">{{totalNormal}}</span>
                 </div>
-                <p>{{totalNormal}}</p>
-                <div class="dice-subtotal right">
+                <div class="dice-subtotal pad-right ">
                     <span class="label">{{localize "DICE.Damage.Graze"}}</span>
                     <span class="value">{{totalGraze}}</span>
                 </div>


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Creates a simple accordion animation on the damage total to make the swap more evident.

**Related Issue**  
Completes a leftover from #138

**How Has This Been Tested?**  
Tested toggling between modes.

**Screenshots (if applicable)**  
![test](https://github.com/user-attachments/assets/62695a25-89f4-4c3b-a55c-9ede7a0c64b8)

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: [insert version here].
