### PR TITLE
feat(character sheet): add favorite context menu option for actions and items

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1036,7 +1036,9 @@
             "Edit": "Edit",
             "Save": "Save",
             "Cancel": "Cancel",
-            "Update": "Update"
+            "Update": "Update",
+            "RemoveFavorite": "Remove Favorite",
+            "Favorite":  "Favorite"
         },
         "Notification": {
             "GrazeFocusSpent": "Reduced focus by 1",


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR adds a context menu option to favorite/un-favorite actions and items.

**Related Issue**  
Closes #134 

**How Has This Been Tested?**  
1. Open character sheet
2. Navigate to actions tab
3. Open context menu
4. Select "Favorite"
5. Item gets added to favorites list
6. Open context menu again
7. Select "Remove favorite"
8. Item gets removed from favorites list

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/327586a3-749c-4a18-9999-917641013ad7)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331.