### PR TITLE
feat(styling): add styling to injury rolls to auto-roll days

### DIFF
--- a/src/packs/tables/injury-duration.json
+++ b/src/packs/tables/injury-duration.json
@@ -47,7 +47,7 @@
             "drawn": false,
             "_id": "abMYSaKItDQ6UCpO",
             "_key": "!tables.results!qOXZSTYaP6jhnvBV.abMYSaKItDQ6UCpO",
-            "text": "<strong>Vicious Injury.</strong> The character suffers a temporary injury with a duration of 6d6 days.",
+            "text": "<strong>Vicious Injury.</strong> The character suffers a temporary injury with a duration of [[6d6]] days.",
             "img": "icons/skills/wounds/injury-hand-blood-red.webp",
             "documentId": null,
             "flags": {
@@ -66,7 +66,7 @@
             "drawn": false,
             "_id": "WnBhe042FZVoih9R",
             "_key": "!tables.results!qOXZSTYaP6jhnvBV.WnBhe042FZVoih9R",
-            "text": "<strong>Shallow Injury.</strong> The character suffers a temporary injury with a duration of 1d6 days.",
+            "text": "<strong>Shallow Injury.</strong> The character suffers a temporary injury with a duration of [[1d6]] days.",
             "img": "icons/skills/wounds/blood-spurt-spray-red.webp",
             "documentId": null,
             "flags": {


### PR DESCRIPTION


<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
_A clear and concise description of the changes you are making. What does this PR implement or fix?_
This adds double square brackets around the duration dice in two of the injury options so that the user doesn't need to manually roll the dice.

**Related Issue**  
_This PR must be linked to an existing issue. Please specify the related issue number and whether this PR fully or partially resolves it. Use the format `Closes #<issue-number>` or `Partially addresses #<issue-number>`._
Partially addresses #120

**How Has This Been Tested?**  
_Describe how you tested the changes and how others can replicate the testing steps._
Using the same text in FVTT roll table causes the dice to automatically be rolled in the chat.

**Screenshots (if applicable)**  
_Add screenshots or GIFs that help illustrate the changes, especially if they affect the UI or user-facing aspects of the system._
Original: 
![image](https://github.com/user-attachments/assets/def22755-eaf5-4902-b020-684f24280f48)
This PR:
![image](https://github.com/user-attachments/assets/0c176a9c-0cbc-41a1-9a43-310dbd3c4cef)


**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12 stable build 331.

**Additional context**  
_Add any other context or information here that would be useful for reviewers._
