### PR TITLE
fix(compendium): fix incorrect string for vicious injury in compendium

### DIFF
--- a/src/packs/tables/injury-duration.json
+++ b/src/packs/tables/injury-duration.json
@@ -53,7 +53,7 @@
             "flags": {
                 "cosmere-rpg": {
                     "injury-data": {
-                        "type": "ViciousInjury",
+                        "type": "vicious_injury",
                         "durationFormula": "6d6"
                     }
                 }

--- a/src/system/documents/chat-message.ts
+++ b/src/system/documents/chat-message.ts
@@ -347,10 +347,6 @@ export class CosmereChatMessage extends ChatMessage {
             (r) => !(r instanceof D20Roll) && !(r instanceof DamageRoll),
         );
 
-        // Current required because of a bug in the roll table
-        if ((data.type as string) === 'ViciousInjury')
-            data.type = InjuryType.ViciousInjury;
-
         let title;
         const actor = this.associatedActor?.name ?? 'Actor';
         switch (data.type) {


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
The vicious injury entry in the Injury Duration roll table had the incorrect string assigned, which led to issues when enriching injury rolls. I had a bandaid fix there in the card styling PR, but we might as well push the actual fix.

**Related Issue**  
No related issue, very minor change.

**How Has This Been Tested?**  
Have to repack the compendium of course, but other than that all behaviour should continue working the same.

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: [insert version here].
