### PR TITLE
fix(chat cards): different damage dice in tooltip

### DIFF
--- a/src/system/dice/damage-roll.ts
+++ b/src/system/dice/damage-roll.ts
@@ -127,7 +127,28 @@ export class DamageRoll extends foundry.dice.Roll<DamageRollData> {
 
     public override async getTooltip(): Promise<string> {
         const tooltip = await super.getTooltip();
-        if (tooltip) return tooltip;
+
+        if (tooltip) {
+            const diceRolls = $(tooltip).find('.roll.die');
+            const firstPart = $(tooltip).find('.tooltip-part').first();
+
+            let total = 0;
+            $(tooltip)
+                .find('.value')
+                .each((_index, value) => {
+                    total += Number($(value).text());
+                });
+
+            firstPart.find('.dice-rolls').empty().append(diceRolls);
+            firstPart.find('.value').text(total);
+
+            const tooltipFinal = $(tooltip)
+                .find('.dice-tooltip')
+                .empty()
+                .append(firstPart);
+
+            return tooltipFinal[0].outerHTML;
+        }
 
         // Get dice terms
         const parts = [


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue discussed in #175 where damage rolls with multiple different dice types would only show the first dice type in the tooltip.

**Related Issue**  
Relates to #175.

**How Has This Been Tested?**  
Rolled base damage and graze with different dice types, both work as expected now.

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/2f03a89b-bd96-49bf-91dc-69ee6775d995)

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: [insert version here].
