### PR TITLE
Add apply injury functionality

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -861,7 +861,10 @@
                 "ReduceFocus": "Click to reduce focus from selected token(s).",
                 "RollCrit": "Click to roll critical damage.",
                 "RollAdvantage": "Click to roll with advantage.",
-                "RollDisadvantage": "Click to roll with disadvantage."
+                "RollDisadvantage": "Click to roll with disadvantage.",
+                "ApplyInjury": "Click to apply injury to character.",
+                "UndoDamage": "Click to undo damage taken.",
+                "UndoHealing": "Click to undo healing."
             },
             "Trays": {
                 "Targets": "Targets"
@@ -875,8 +878,6 @@
             "ApplyDamage": "{actor} takes <strong>{amount} damage</strong>.",
             "ApplyHealing": "{actor} recovers <strong>{amount} health</strong>.",
             "DamageCalculation": "Damage Calculation: {calculation}",
-            "UndoDamage": "Click to undo damage taken.",
-            "UndoHealing": "Click to undo healing.",
             "ViewRollsDetails": "Roll Details",
             "Welcome": "<h2>Welcome to the Cosmere RPG System!</h2> <p>Thank you for trying out the community-developed Cosmere Roleplaying Game system! You're currently using version <strong>{version}</strong>. As this is an early release, some bugs or missing features are to be expected, but your feedback will help us improve the system. </p> <p>For discussions, updates, and support, join us on the <a href=\"{discordLink}\">Metalworks Discord</a> server.</p> <p>If you encounter any issues or have suggestions, we'd love to hear from you! Please report them on our <a href=\"{issuesLink}\">GitHub Issues page</a> or on the <a href=\"{discordLink}\">Metalworks Discord</a>. Be sure to review the <a href=\"{contributingLink}\">contribution guidelines</a> if you'd like to get involved in development. </p> <p>We're excited to have you on board and hope you enjoy playing in the Cosmere!</p>"
         },

--- a/src/system/documents/chat-message.ts
+++ b/src/system/documents/chat-message.ts
@@ -1,4 +1,9 @@
-import { DamageType, InjuryType, Resource } from '@system/types/cosmere';
+import {
+    DamageType,
+    InjuryType,
+    ItemType,
+    Resource,
+} from '@system/types/cosmere';
 import { D20Roll } from '@system/dice/d20-roll';
 import { DamageRoll } from '@system/dice/damage-roll';
 
@@ -402,6 +407,35 @@ export class CosmereChatMessage extends ChatMessage {
         this.enrichD20Tooltip(injuryRoll, tooltip[0]);
         tooltip.prepend(section.find('.dice-formula'));
 
+        if (game.user!.isGM || this.isAuthor) {
+            section.find('.icon.clickable').on('click', async (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+
+                const button = event.currentTarget;
+                const action = button.dataset.action;
+
+                if (action === 'apply') {
+                    await Item.create(
+                        {
+                            type: ItemType.Injury,
+                            name: game.i18n!.localize(
+                                CONFIG.COSMERE.injury.types[data.type].label,
+                            ),
+                            system: {
+                                duration: {
+                                    remaining: durationRoll?.total ?? 0,
+                                },
+                            },
+                        },
+                        { parent: this.associatedActor },
+                    );
+                }
+            });
+        } else {
+            section.find('.icon.clickable').remove();
+        }
+
         html.find('.chat-card').append(section);
     }
 
@@ -459,8 +493,8 @@ export class CosmereChatMessage extends ChatMessage {
                           { calculation },
                       ),
                 tooltip: isHealing
-                    ? 'COSMERE.ChatMessage.UndoHealing'
-                    : 'COSMERE.ChatMessage.UndoDamage',
+                    ? 'COSMERE.ChatMessage.Buttons.UndoHealing'
+                    : 'COSMERE.ChatMessage.Buttons.UndoDamage',
                 undo,
             },
         );

--- a/src/templates/chat/card-injury.hbs
+++ b/src/templates/chat/card-injury.hbs
@@ -4,6 +4,7 @@
         <div class="name-stacked">
             <span class="title">{{{title}}}</span>
         </div>
+        <span class="icon clickable" data-action="apply" data-tooltip="{{localize "COSMERE.ChatMessage.Buttons.ApplyInjury"}}"><i class="fas fa-reply-all fa-flip-horizontal"></i></span>
     </header>
     <section class="details collapsible-content">
         <div class="wrapper">


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Adds a button to the injury roll chat cards that allows automatically adding the injury that was rolled to the actor that rolled it.

**Related Issue**  
Closes #178

**How Has This Been Tested?**  
Tested with all kinds of injuries.

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/e7746a7c-d130-4188-b713-ee5fb4821458)

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: [insert version here].
