### PR TITLE
chore(github actions): add release and pre-release pipelines

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,92 @@
+name: prerelease
+run-name: Create prerelease
+on:
+  push:
+    branches:
+        - 'release-*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
+
+      # Load the manifest into memory
+      - name: Load system manifest
+        id: manifest
+        uses: zoexx/github-action-json-file-properties@release
+        with:
+          file_path: "./src/system.json"
+
+      # Set up variables
+      - name: Set up vars
+        run: |
+          BRANCH=${{github.ref_name}}
+          RELEASE_VERSION=$(echo ${{github.ref_name}} | cut -d'-' -f2)
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+          echo "ZIP_NAME=cosmere-rpg-prerelease-$RELEASE_VERSION.zip" >> $GITHUB_ENV
+          echo "DOWNLOAD_URL=https://github.com/${{github.repository}}/releases/download/prerelease-$RELEASE_VERSION/cosmere-rpg-prerelease-$RELEASE_VERSION.zip" >> $GITHUB_ENV
+          echo "MANIFEST_URL=https://github.com/${{github.repository}}/releases/download/prerelease-$RELEASE_VERSION/system.json" >> $GITHUB_ENV
+
+      # Verify manifest
+      - name: Verify manifest
+        run: |
+          # Verify that the manifest version matches the branch
+          if [[ ! "${{env.RELEASE_VERSION}}" == $PACKAGE_VERSION ]]; then
+            echo "Manifest version does not match tag brach."
+            echo "Manifest version: $PACKAGE_VERSION"
+            echo "Branch: ${{env.RELEASE_VERSION}}"
+            echo "Please update the manifest version to match the branch."
+            exit 1
+          fi
+        env:
+          PACKAGE_VERSION: ${{ steps.manifest.outputs.version }}
+
+      # Update manifest
+      - name: Update manifest
+        uses: TomaszKandula/variable-substitution@v1.0.2
+        with:
+          files: "./src/system.json"
+        env:
+          version: "prerelease-${{ env.RELEASE_VERSION }}"
+          manifest: ${{ env.MANIFEST_URL }}
+          download: ${{ env.DOWNLOAD_URL }}
+
+      # Set up node 
+      - name: Use Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Install dependencies
+      - name: NPM install
+        run: |
+          npm ci
+
+      # Build
+      - name: Build release
+        run: |
+          npm run build:release
+
+      # Create release
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: "Pre-release ${{ env.RELEASE_VERSION }}"
+          tag: prerelease-${{ env.RELEASE_VERSION }}
+          artifacts: "./src/system.json, ./${{ env.ZIP_NAME }}"
+          draft: false
+          prerelease: true
+          allowUpdates: true
+          body: |
+            Pre-release build of ${{ env.RELEASE_VERSION }}. 
+            This build is automatically generated from the latest changes targeting the ${{ env.RELEASE_VERSION }} release.  
+            ⚠️ **This is a pre-release build and may contain bugs or incomplete features.** ⚠️  
+              
+            **Manifest url:** ${{ env.MANIFEST_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,123 @@
+name: release
+run-name: Create release
+on:
+  push:
+    tags:
+      - 'release-*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      # Load the manifest into memory
+      - name: Load system manifest
+        id: manifest
+        uses: zoexx/github-action-json-file-properties@release
+        with:
+          file_path: "./src/system.json"
+
+      # Set up variables
+      - name: Set up vars
+        run: |
+          TAG=${{github.ref_name}}
+          echo "ZIP_NAME=cosmere-rpg-$TAG.zip" >> $GITHUB_ENV
+          echo "DOWNLOAD_URL=https://github.com/${{github.repository}}/releases/download/$TAG/cosmere-rpg-$TAG.zip" >> $GITHUB_ENV
+
+      # Verify manifest
+      - name: Verify manifest
+        run: |
+          # Verify that the manifest version matches the tag
+          if [[ ! "${{github.ref_name}}" == release-$PACKAGE_VERSION ]]; then
+            echo "Manifest version does not match tag name."
+            echo "Manifest version: $PACKAGE_VERSION"
+            echo "Tag name: $TAG"
+            echo "Please update the manifest version to match the tag name."
+            exit 1
+          fi
+
+          # Verify that the download URL matches the release asset
+          if [[ ! "${{ env.DOWNLOAD_URL }}" == $PACKAGE_DOWNLOAD ]]; then
+            echo "Download URL does not match release asset."
+            echo "Download URL: $DOWNLOAD_URL"
+            echo "Release asset: $PACKAGE_DOWNLOAD"
+            echo "Please update the manifest download URL to match the release asset."
+            exit 1
+          fi
+        env:
+          PACKAGE_VERSION: ${{ steps.manifest.outputs.version }}
+          PACKAGE_DOWNLOAD: ${{  steps.manifest.outputs.download }}
+
+      # Set up node 
+      - name: Use Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Install dependencies
+      - name: NPM install
+        run: |
+          npm ci
+
+      # Build
+      - name: Build release
+        run: |
+          npm run build:release
+
+      # Fetch latest release
+      - name: Fetch latest release
+        id: latest_release
+        uses: cardinalby/git-get-release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          latest: true
+          doNotFailIfNotFound: true
+
+      # Determine whether this is a patch or a major/minor release
+      - name: Determine release type
+        id: release_type
+        run: |
+          if [[ -z "${{ steps.latest_release.outputs.tag_name }}" ]]; then
+            echo "RELEASE_TYPE=major-minor" >> $GITHUB_ENV
+            echo "RELEASE_NOTES=./src/release-notes.md" >> $GITHUB_ENV
+            echo "No previous releases found. Release is a major or minor release."
+          else
+            # Get the current version info
+            CURRENT_VERSION=$(echo ${{github.ref_name}} | cut -d'-' -f2)
+            CURRENT_VERSION_MAJOR=$(echo $CURRENT_VERSION | cut -d'.' -f1)
+            CURRENT_VERSION_MINOR=$(echo $CURRENT_VERSION | cut -d'.' -f2)
+            CURRENT_VERSION_PATCH=$(echo $CURRENT_VERSION | cut -d'.' -f3)
+
+            # Get the latest version info
+            LATEST_VERSION=$(echo ${{steps.latest_release.outputs.tag_name}} | cut -d'-' -f2)
+            LATEST_VERSION_MAJOR=$(echo $LATEST_VERSION | cut -d'.' -f1)
+            LATEST_VERSION_MINOR=$(echo $LATEST_VERSION | cut -d'.' -f2)
+            LATEST_VERSION_PATCH=$(echo $LATEST_VERSION | cut -d'.' -f3)
+
+            # Determine the release type
+            if [[ $CURRENT_VERSION_MAJOR -gt $LATEST_VERSION_MAJOR ]] || [[ $CURRENT_VERSION_MINOR -gt $LATEST_VERSION_MINOR ]]; then
+              echo "RELEASE_TYPE=major-minor" >> $GITHUB_ENV
+              echo "RELEASE_NOTES=./src/release-notes.md" >> $GITHUB_ENV
+              echo "Release is a major or minor release."
+            else
+              echo "RELEASE_TYPE=patch" >> $GITHUB_ENV
+              echo "RELEASE_NOTES=./src/patch-notes.md" >> $GITHUB_ENV
+              echo "Release is a patch release."
+            fi
+          fi
+
+      # Create release
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: ${{ github.ref_name }}
+          tag: ${{ github.ref_name }}
+          bodyFile: ${{ env.RELEASE_NOTES }}
+          artifacts: "./${{ env.ZIP_NAME }}"
+          draft: true


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x]  Other (please describe): github actions

**Description**  
Adds two new github actions; The first creates a (draft) release when the version tag is created. The second creates pre-releases on pushes against release branches (release-*).

**Related Issue**  
-

**How Has This Been Tested?**  
Created a private copy of the repo and tested the actions there.

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/86cda451-4d35-4579-9ae5-a694f0797141)
![image](https://github.com/user-attachments/assets/167b694e-0133-4fe0-9647-c0e7aaa77e0d)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [ ] I have tested my changes on Foundry VTT version:. N/A