### PR TITLE
fix(data models): fix issue causing derived statistics not to be updated when a bonus is applied

### DIFF
--- a/src/system/data/actor/common.ts
+++ b/src/system/data/actor/common.ts
@@ -56,7 +56,7 @@ interface CurrencyDenominationData {
     convertedValue: Derived<number>;
 }
 
-interface AttributeData {
+export interface AttributeData {
     value: number;
     bonus: number;
 }

--- a/src/system/data/actor/common.ts
+++ b/src/system/data/actor/common.ts
@@ -56,6 +56,11 @@ interface CurrencyDenominationData {
     convertedValue: Derived<number>;
 }
 
+interface AttributeData {
+    value: number;
+    bonus: number;
+}
+
 export interface CommonActorData {
     size: Size;
     type: {
@@ -71,7 +76,7 @@ export interface CommonActorData {
         damage: DamageType[];
         condition: Condition[];
     };
-    attributes: Record<Attribute, { value: number; bonus: number }>;
+    attributes: Record<Attribute, AttributeData>;
     defenses: Record<AttributeGroup, { value: Derived<number>; bonus: number }>;
     deflect: DeflectData;
     resources: Record<
@@ -510,9 +515,7 @@ export class CommonActorDataModel<
     public prepareDerivedData(): void {
         super.prepareDerivedData();
 
-        this.senses.range.value = awarenessToSensesRange(
-            this.attributes.awa.value,
-        );
+        this.senses.range.value = awarenessToSensesRange(this.attributes.awa);
 
         // Derive defenses
         (Object.keys(this.defenses) as AttributeGroup[]).forEach((group) => {
@@ -594,9 +597,7 @@ export class CommonActorDataModel<
         }
 
         // Movement
-        this.movement.rate.value = speedToMovementRate(
-            this.attributes.spd.value,
-        );
+        this.movement.rate.value = speedToMovementRate(this.attributes.spd);
 
         // Injury count
         this.injuries.value = this.parent.items.filter(
@@ -648,37 +649,41 @@ export class CommonActorDataModel<
 
         // Lifting & Carrying
         this.encumbrance.lift.value = strengthToLiftingCapacity(
-            this.attributes.str.value,
+            this.attributes.str,
         );
         this.encumbrance.carry.value = strengthToCarryingCapacity(
-            this.attributes.str.value,
+            this.attributes.str,
         );
     }
 }
 
 const SENSES_RANGES = [5, 10, 20, 50, 100, Number.MAX_VALUE];
-function awarenessToSensesRange(awareness: number) {
+function awarenessToSensesRange(attr: AttributeData) {
+    const awareness = attr.value + attr.bonus;
     return SENSES_RANGES[
         Math.min(Math.ceil(awareness / 2), SENSES_RANGES.length)
     ];
 }
 
 const MOVEMENT_RATES = [20, 25, 30, 40, 60, 80];
-function speedToMovementRate(speed: number) {
+function speedToMovementRate(attr: AttributeData) {
+    const speed = attr.value + attr.bonus;
     return MOVEMENT_RATES[
         Math.min(Math.ceil(speed / 2), MOVEMENT_RATES.length)
     ];
 }
 
 const LIFTING_CAPACITIES = [100, 200, 500, 1000, 5000, 10000];
-function strengthToLiftingCapacity(strength: number) {
+function strengthToLiftingCapacity(attr: AttributeData) {
+    const strength = attr.value + attr.bonus;
     return LIFTING_CAPACITIES[
         Math.min(Math.ceil(strength / 2), LIFTING_CAPACITIES.length)
     ];
 }
 
 const CARRYING_CAPACITIES = [50, 100, 250, 500, 2500, 5000];
-function strengthToCarryingCapacity(strength: number) {
+function strengthToCarryingCapacity(attr: AttributeData) {
+    const strength = attr.value + attr.bonus;
     return CARRYING_CAPACITIES[
         Math.min(Math.ceil(strength / 2), CARRYING_CAPACITIES.length)
     ];

--- a/src/system/data/actor/index.ts
+++ b/src/system/data/actor/index.ts
@@ -10,3 +10,4 @@ export const config = {
 
 export { AdversaryActorData } from './adversary';
 export { CharacterActorData } from './character';
+export { CommonActorData, AttributeData } from './common';

--- a/src/system/utils/handlebars/index.ts
+++ b/src/system/utils/handlebars/index.ts
@@ -14,6 +14,7 @@ import {
 
 import { CharacterActor, CosmereActor } from '@system/documents/actor';
 import { CosmereItem } from '@system/documents/item';
+import { AttributeData } from '@system/data/actor';
 import { Derived } from '@system/data/fields';
 
 import { AnyObject } from '@src/system/types/utils';
@@ -111,13 +112,10 @@ Handlebars.registerHelper(
     },
 );
 
-Handlebars.registerHelper(
-    'bonus',
-    (obj?: { value: number; bonus?: number }) => {
-        if (!obj) return;
-        return obj.value + (obj.bonus ?? 0);
-    },
-);
+Handlebars.registerHelper('bonus', (obj?: AttributeData) => {
+    if (!obj) return;
+    return obj.value + (obj.bonus ?? 0);
+});
 
 Handlebars.registerHelper(
     'skillMod',


### PR DESCRIPTION
*Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**
This PR makes it so the attribute bonus is correctly applied to derived statistics (e.g. movement rate)

**Related Issue**  
Closes #217 

**How Has This Been Tested?**  
1. Add effect that modifies an attribute bonus (`system.attributes.spd.bonus` to +2)
2. Toggle effect on
3. See movement rate increase

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331
