### PR TITLE
fix(actor roll data): fix scalar attributes not correctly applying attribute bonuses

### DIFF
--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -936,7 +936,7 @@ export class CosmereActor<
         attr: Attribute,
         scale: AttributeScale[],
     ) {
-        const value = this.system.attributes[attr]?.value ?? 0;
+        const value = Derived.getValue(this.system.attributes[attr]) ?? 0;
         for (const range of scale) {
             if (value >= range.min && value <= range.max) {
                 return range.formula;


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR makes it so scalar attributes in the roll data correctly apply attribute bonuses.

**Related Issue**  
Closes #212 

**How Has This Been Tested?**  
1. Create a character with unarmed. Set their STR to 4
2. Roll to see expected scale of 1d4+Athletics
3. Use effect to add bonus to STR attribute
4. Roll unarmed attack again, note scaling

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331
