### PR TITLE
feat(dice): implement dialog to select plot die roll result

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -998,13 +998,10 @@
         "PickDiceResult": {
             "Title": "Pick result",
             "Header": {
-                "Plural": "Pick {num} rolls to keep",
+                "Plural": "Pick up to {num} rolls to keep",
                 "Singular": "Pick 1 roll to keep"
             },
             "SelectRoll": "Select roll",
-            "Warning": {
-                "PickedLessThanTotal": "Only {picked} of {total} picked"
-            },
             "Error": {
                 "TooManyPicked": "Cannot pick more than {max} rolls"
             }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1004,6 +1004,9 @@
             "SelectRoll": "Select roll",
             "Warning": {
                 "PickedLessThanTotal": "Only {picked} of {total} picked"
+            },
+            "Error": {
+                "TooManyPicked": "Cannot pick more than {max} rolls"
             }
         }
     },

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -994,6 +994,17 @@
             "Notification": {
                 "TalentPicked": "Added talent {talent} to {actor}"
             }
+        },
+        "PickDiceResult": {
+            "Title": "Pick result",
+            "Header": {
+                "Plural": "Pick {num} rolls to keep",
+                "Singular": "Pick 1 roll to keep"
+            },
+            "SelectRoll": "Select roll",
+            "Warning": {
+                "PickedLessThanTotal": "Only {picked} of {total} picked"
+            }
         }
     },
     "COMPONENT": {

--- a/src/style/dialog.scss
+++ b/src/style/dialog.scss
@@ -25,7 +25,7 @@ dialog.application ul {
         padding: 0.2rem 0;
 
         &.form-group {
-            > a {
+            >a {
                 flex: unset;
                 margin-left: 0.5rem;
             }
@@ -65,5 +65,88 @@ dialog.application.roll-configuration {
 
     .window-content {
         overflow: auto;
+    }
+}
+
+.dialog.application.pick-dice-result {
+    h4 {
+        text-align: center;
+    }
+
+    .rolls {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        .roll {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+
+            width: 48px;
+            height: 48px;
+            line-height: 48px;
+            float: left;
+            margin-right: 1px;
+            background-repeat: no-repeat;
+            background-size: 48px 48px;
+            font-size: var(--font-size-16);
+            color: #000;
+            font-weight: bold;
+            text-align: center;
+
+            cursor: pointer;
+            transition: .3s;
+
+            &.success, &.max {                                            
+                color: var(--cosmere-color-opportunity);
+                filter: sepia(1) hue-rotate(180deg);
+            }
+
+            &.failure, &.min {
+                color: var(--cosmere-color-complication);
+                filter: sepia(0.8) hue-rotate(-50deg);
+            }
+
+            &.discarded:not(:hover) {
+                color: inherit;
+                filter: sepia(0.5) contrast(0.75) opacity(0.4);
+            }
+
+            &.plotdie {
+                > img {
+                    width: 40px;
+                    border: none;
+                }
+            }
+
+            &:hover {
+                transform: scale(1.1);
+            }
+        }
+
+        .roll.d4 {
+            background-image: url("../../icons/svg/d4-grey.svg");
+        }
+
+        .roll.d6 {
+            background-image: url("../../icons/svg/d6-grey.svg");
+        }
+
+        .roll.d8 {
+            background-image: url("../../icons/svg/d8-grey.svg");
+        }
+
+        .roll.d10 {
+            background-image: url("../../icons/svg/d10-grey.svg");
+        }
+
+        .roll.d12 {
+            background-image: url("../../icons/svg/d12-grey.svg");
+        }
+
+        .roll.d20 {
+            background-image: url("../../icons/svg/d20-grey.svg");
+        }
     }
 }

--- a/src/system/applications/dialogs/pick-dice-result.ts
+++ b/src/system/applications/dialogs/pick-dice-result.ts
@@ -110,6 +110,15 @@ export class PickDiceResultDialog extends ComponentHandlebarsApplicationMixin(
         // Get selected result
         const result = this.rolls[index];
 
+        // Ensure the amount picked is less than the amount to pick
+        if (this.picked.length >= this.data.amount && !!result.discarded) {
+            return void ui.notifications.error(
+                game.i18n!.format('DIALOG.PickDiceResult.Error.TooManyPicked', {
+                    max: this.data.amount,
+                }),
+            );
+        }
+
         // Toggle discarded
         result.discarded = !result.discarded;
 

--- a/src/system/applications/dialogs/pick-dice-result.ts
+++ b/src/system/applications/dialogs/pick-dice-result.ts
@@ -1,0 +1,194 @@
+import { AnyObject } from '@system/types/utils';
+
+// Dice
+import { PlotDie } from '@system/dice/plot-die';
+
+// Mixins
+import { ComponentHandlebarsApplicationMixin } from '@system/applications/component-system';
+
+const { ApplicationV2 } = foundry.applications.api;
+
+// Constants
+import { IMPORTED_RESOURCES } from '@system/constants';
+
+export namespace PickDiceResultDialog {
+    export interface Data {
+        /**
+         * The term for which to pick results
+         */
+        term: foundry.dice.terms.DiceTerm;
+
+        /**
+         * The amount of dice to pick
+         */
+        amount: number;
+    }
+}
+
+export class PickDiceResultDialog extends ComponentHandlebarsApplicationMixin(
+    ApplicationV2<AnyObject>,
+) {
+    /**
+     * NOTE: Unbound methods is the standard for defining actions and forms
+     * within ApplicationV2
+     */
+    /* eslint-disable @typescript-eslint/unbound-method */
+    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
+        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
+        {
+            window: {
+                minimizable: false,
+                resizable: true,
+                title: 'DIALOG.PickDiceResult.Title',
+            },
+            classes: ['dialog', 'pick-dice-result'],
+            tag: 'dialog',
+            position: {
+                width: 400,
+            },
+            actions: {
+                'select-result': this.onSelectResult,
+            },
+        },
+    );
+    /* eslint-enable @typescript-eslint/unbound-method */
+
+    static PARTS = foundry.utils.mergeObject(
+        foundry.utils.deepClone(super.PARTS),
+        {
+            form: {
+                template:
+                    'systems/cosmere-rpg/templates/roll/dialogs/pick-dice-result.hbs',
+            },
+        },
+    );
+
+    private rolls: foundry.dice.terms.DiceTerm.Result[];
+    private submitted = false;
+
+    private constructor(
+        private data: PickDiceResultDialog.Data,
+        private resolve: (
+            results: foundry.dice.terms.DiceTerm.Result[] | null,
+        ) => void,
+    ) {
+        super({});
+
+        // Mark all results as discarded to begin with
+        this.rolls = foundry.utils
+            .deepClone(this.data.term.results)
+            .map((result) => ({
+                ...result,
+                discarded: true,
+            }));
+    }
+
+    /* --- Statics --- */
+
+    public static show(data: PickDiceResultDialog.Data) {
+        return new Promise<foundry.dice.terms.DiceTerm.Result[] | null>(
+            (resolve) => void new this(data, resolve).render(true),
+        );
+    }
+
+    /* --- Accessors --- */
+
+    get picked() {
+        return this.data.term.results.filter((result) => !result.discarded);
+    }
+
+    /* --- Actions --- */
+
+    private static onSelectResult(this: PickDiceResultDialog, event: Event) {
+        console.log('ON SELECT RESULT', event);
+
+        // Get index
+        const index = $(event.target!)
+            .closest('[data-index]')
+            .data('index') as number;
+        if (index === undefined) return;
+
+        // Get selected result
+        const result = this.rolls[index];
+
+        // Toggle discarded
+        result.discarded = !result.discarded;
+
+        // If only 1 result needs to be selected, submit immediately
+        if (!result.discarded && this.data.amount === 1) {
+            PickDiceResultDialog.onSubmit.call(this);
+        }
+    }
+
+    private static onSubmit(this: PickDiceResultDialog) {
+        // Show warning if the amount picked was less than the amount to pick
+        if (this.picked.length < this.data.amount) {
+            ui.notifications.warn(
+                game.i18n!.format(
+                    'DIALOG.PickDiceResult.Warning.PickedLessThanTotal',
+                    {
+                        picked: this.picked.length,
+                        total: this.data.amount,
+                    },
+                ),
+            );
+        }
+
+        // Apply to term
+        this.data.term.results.forEach((result, index) => {
+            const match = this.rolls[index];
+
+            result.discarded = match.discarded;
+            result.active = match.discarded ? false : result.active;
+        });
+
+        // Set submitted
+        this.submitted = true;
+
+        // Resolve
+        this.resolve(this.data.term.results);
+
+        // Close
+        void this.close();
+    }
+
+    /* --- Lifecycle --- */
+
+    protected _onRender(context: AnyObject, options: AnyObject) {
+        super._onRender(context, options);
+
+        $(this.element).prop('open', true);
+    }
+
+    protected _onClose() {
+        if (!this.submitted) this.resolve(null);
+    }
+
+    /* --- Context --- */
+
+    protected _prepareContext() {
+        const isPlotDie = this.data.term instanceof PlotDie;
+
+        return Promise.resolve({
+            isPlotDie,
+            die: isPlotDie ? 'd6' : this.data.term.denomination,
+            faces: this.data.term.faces ?? 0,
+            rolls: this.rolls,
+            amountToPick: this.data.amount,
+            amountPicked: this.picked.length,
+            headerText:
+                this.data.amount > 1
+                    ? game.i18n!.format('DIALOG.PickDiceResult.Header.Plural', {
+                          num: this.data.amount,
+                      })
+                    : game.i18n!.localize(
+                          'DIALOG.PickDiceResult.Header.Singular',
+                      ),
+            plotDie: {
+                c2: IMPORTED_RESOURCES.PLOT_DICE_C2_IN_CHAT,
+                c4: IMPORTED_RESOURCES.PLOT_DICE_C4_IN_CHAT,
+                op: IMPORTED_RESOURCES.PLOT_DICE_OP_IN_CHAT,
+            },
+        });
+    }
+}

--- a/src/system/applications/dialogs/pick-dice-result.ts
+++ b/src/system/applications/dialogs/pick-dice-result.ts
@@ -48,6 +48,7 @@ export class PickDiceResultDialog extends ComponentHandlebarsApplicationMixin(
             },
             actions: {
                 'select-result': this.onSelectResult,
+                submit: this.onSubmit,
             },
         },
     );
@@ -94,14 +95,12 @@ export class PickDiceResultDialog extends ComponentHandlebarsApplicationMixin(
     /* --- Accessors --- */
 
     get picked() {
-        return this.data.term.results.filter((result) => !result.discarded);
+        return this.rolls.filter((result) => !result.discarded);
     }
 
     /* --- Actions --- */
 
     private static onSelectResult(this: PickDiceResultDialog, event: Event) {
-        console.log('ON SELECT RESULT', event);
-
         // Get index
         const index = $(event.target!)
             .closest('[data-index]')
@@ -117,6 +116,8 @@ export class PickDiceResultDialog extends ComponentHandlebarsApplicationMixin(
         // If only 1 result needs to be selected, submit immediately
         if (!result.discarded && this.data.amount === 1) {
             PickDiceResultDialog.onSubmit.call(this);
+        } else {
+            void this.render(true);
         }
     }
 

--- a/src/system/applications/dialogs/pick-dice-result.ts
+++ b/src/system/applications/dialogs/pick-dice-result.ts
@@ -131,19 +131,6 @@ export class PickDiceResultDialog extends ComponentHandlebarsApplicationMixin(
     }
 
     private static onSubmit(this: PickDiceResultDialog) {
-        // Show warning if the amount picked was less than the amount to pick
-        if (this.picked.length < this.data.amount) {
-            ui.notifications.warn(
-                game.i18n!.format(
-                    'DIALOG.PickDiceResult.Warning.PickedLessThanTotal',
-                    {
-                        picked: this.picked.length,
-                        total: this.data.amount,
-                    },
-                ),
-            );
-        }
-
         // Apply to term
         this.data.term.results.forEach((result, index) => {
             const match = this.rolls[index];

--- a/src/system/dice/d20-roll.ts
+++ b/src/system/dice/d20-roll.ts
@@ -440,20 +440,19 @@ export class D20Roll extends foundry.dice.Roll<D20RollData> {
                 this.terms.push(
                     new foundry.dice.terms.OperatorTerm({
                         operator: '+',
-                    }) as foundry.dice.terms.RollTerm,
-                    new PlotDie() as foundry.dice.terms.RollTerm,
+                    }),
+                    new PlotDie(),
                 );
             }
 
-            // TODO: Figure out how to handle plot die advantage/disadvantage
-            // const plotDieTerm = this.terms.find((t) => t instanceof PlotDie)!;
-            // if (this.hasPlotAdvantage) {
-            //     plotDieTerm.number = 2;
-            //     plotDieTerm.modifiers.push('kh');
-            // } else if (this.hasPlotDisadvantage) {
-            //     plotDieTerm.number = 2;
-            //     plotDieTerm.modifiers.push('kl');
-            // }
+            const plotDieTerm = this.terms.find((t) => t instanceof PlotDie)!;
+            if (this.hasPlotAdvantage) {
+                plotDieTerm.number = 2;
+                plotDieTerm.modifiers.push('p');
+            } else if (this.hasPlotDisadvantage) {
+                plotDieTerm.number = 2;
+                plotDieTerm.modifiers.push('gmp');
+            }
         }
 
         // NOTE: Unused right now

--- a/src/system/dice/index.ts
+++ b/src/system/dice/index.ts
@@ -1,5 +1,6 @@
 import { Attribute } from '@system/types/cosmere';
 
+import './modifiers';
 import { D20Roll, D20RollOptions, D20RollData } from './d20-roll';
 import { DamageRoll, DamageRollOptions, DamageRollData } from './damage-roll';
 import {

--- a/src/system/dice/modifiers.ts
+++ b/src/system/dice/modifiers.ts
@@ -1,0 +1,27 @@
+// Dialogs
+import { PickDiceResultDialog } from '@system/applications/dialogs/pick-dice-result';
+
+// Consants
+const PICK_MODIFIER_REGEX = /(gm)?p(\d+)?/i;
+
+(foundry.dice.terms.Die.MODIFIERS as unknown) = {
+    ...foundry.dice.terms.Die.MODIFIERS,
+    p: pick,
+    gmp: pick,
+};
+
+async function pick(this: foundry.dice.terms.Die, modifier: string) {
+    const rgx = new RegExp(PICK_MODIFIER_REGEX);
+    const match = rgx.exec(modifier);
+    if (!match) return false;
+
+    const [gm, numStr] = match.slice(1);
+    const isGm = !!gm; // NOTE: Unused at this time
+    const amount = Math.min(parseInt(numStr) || 1, this.number ?? 0);
+
+    // Show dialog
+    await PickDiceResultDialog.show({
+        term: this,
+        amount,
+    });
+}

--- a/src/system/dice/plot-die.ts
+++ b/src/system/dice/plot-die.ts
@@ -51,6 +51,7 @@ export class PlotDie extends foundry.dice.terms.DiceTerm {
         dh: foundry.dice.terms.Die.prototype.drop.bind(this),
         dl: foundry.dice.terms.Die.prototype.drop.bind(this),
         p: 'pick',
+        gmp: 'pick',
     };
 
     /* --- Accessors --- */

--- a/src/system/dice/plot-die.ts
+++ b/src/system/dice/plot-die.ts
@@ -1,3 +1,7 @@
+// Dialogs
+import { PickDiceResultDialog } from '@system/applications/dialogs/pick-dice-result';
+
+// Constants
 import { IMPORTED_RESOURCES } from '@system/constants';
 
 const SIDES: Record<number, string> = {
@@ -8,6 +12,8 @@ const SIDES: Record<number, string> = {
     5: `<img src="${IMPORTED_RESOURCES.PLOT_DICE_OP_IN_CHAT}" />`,
     6: `<img src="${IMPORTED_RESOURCES.PLOT_DICE_OP_IN_CHAT}" />`,
 };
+
+const PICK_MODIFIER_REGEX = /(gm)?p(\d+)?/i;
 
 export interface PlotDieData
     extends Partial<foundry.dice.terms.DiceTerm.TermData> {
@@ -44,6 +50,7 @@ export class PlotDie extends foundry.dice.terms.DiceTerm {
         d: foundry.dice.terms.Die.prototype.drop.bind(this),
         dh: foundry.dice.terms.Die.prototype.drop.bind(this),
         dl: foundry.dice.terms.Die.prototype.drop.bind(this),
+        p: 'pick',
     };
 
     /* --- Accessors --- */
@@ -85,5 +92,26 @@ export class PlotDie extends foundry.dice.terms.DiceTerm {
         result: foundry.dice.terms.DiceTerm.Result,
     ): string {
         return SIDES[result.result];
+    }
+
+    /* --- Modifiers --- */
+
+    /**
+     * Shows a pop-up that allows the user to pick the result
+     */
+    async pick(modifier: string) {
+        const rgx = new RegExp(PICK_MODIFIER_REGEX);
+        const match = rgx.exec(modifier);
+        if (!match) return false;
+
+        const [gm, numStr] = match.slice(1);
+        const isGm = !!gm; // NOTE: Unused at this time
+        const amount = Math.min(parseInt(numStr) || 1, this.number ?? 0);
+
+        // Show dialog
+        await PickDiceResultDialog.show({
+            term: this,
+            amount,
+        });
     }
 }

--- a/src/system/dice/plot-die.ts
+++ b/src/system/dice/plot-die.ts
@@ -1,6 +1,3 @@
-// Dialogs
-import { PickDiceResultDialog } from '@system/applications/dialogs/pick-dice-result';
-
 // Constants
 import { IMPORTED_RESOURCES } from '@system/constants';
 
@@ -13,10 +10,7 @@ const SIDES: Record<number, string> = {
     6: `<img src="${IMPORTED_RESOURCES.PLOT_DICE_OP_IN_CHAT}" />`,
 };
 
-const PICK_MODIFIER_REGEX = /(gm)?p(\d+)?/i;
-
-export interface PlotDieData
-    extends Partial<foundry.dice.terms.DiceTerm.TermData> {
+export interface PlotDieData extends Partial<foundry.dice.terms.Die.TermData> {
     /**
      * The number of dice of this term to roll
      * @default 1
@@ -29,7 +23,7 @@ export interface PlotDieData
     results?: foundry.dice.terms.DiceTerm.Result[];
 }
 
-export class PlotDie extends foundry.dice.terms.DiceTerm {
+export class PlotDie extends foundry.dice.terms.Die {
     public readonly isPlotDie = true;
 
     constructor(data: PlotDieData = {}) {
@@ -40,19 +34,6 @@ export class PlotDie extends foundry.dice.terms.DiceTerm {
     }
 
     static DENOMINATION = 'p';
-
-    static MODIFIERS = {
-        r: foundry.dice.terms.Die.prototype.reroll.bind(this),
-        rr: foundry.dice.terms.Die.prototype.rerollRecursive.bind(this),
-        k: foundry.dice.terms.Die.prototype.keep.bind(this),
-        kh: foundry.dice.terms.Die.prototype.keep.bind(this),
-        kl: foundry.dice.terms.Die.prototype.keep.bind(this),
-        d: foundry.dice.terms.Die.prototype.drop.bind(this),
-        dh: foundry.dice.terms.Die.prototype.drop.bind(this),
-        dl: foundry.dice.terms.Die.prototype.drop.bind(this),
-        p: 'pick',
-        gmp: 'pick',
-    };
 
     /* --- Accessors --- */
 
@@ -93,26 +74,5 @@ export class PlotDie extends foundry.dice.terms.DiceTerm {
         result: foundry.dice.terms.DiceTerm.Result,
     ): string {
         return SIDES[result.result];
-    }
-
-    /* --- Modifiers --- */
-
-    /**
-     * Shows a pop-up that allows the user to pick the result
-     */
-    async pick(modifier: string) {
-        const rgx = new RegExp(PICK_MODIFIER_REGEX);
-        const match = rgx.exec(modifier);
-        if (!match) return false;
-
-        const [gm, numStr] = match.slice(1);
-        const isGm = !!gm; // NOTE: Unused at this time
-        const amount = Math.min(parseInt(numStr) || 1, this.number ?? 0);
-
-        // Show dialog
-        await PickDiceResultDialog.show({
-            term: this,
-            amount,
-        });
     }
 }

--- a/src/templates/roll/dialogs/pick-dice-result.hbs
+++ b/src/templates/roll/dialogs/pick-dice-result.hbs
@@ -21,4 +21,14 @@
             </div>
         {{/each}}
     </div>
+
+    {{#if (gt amountToPick 1)}}
+        <div class="form-group">
+            <button data-action="submit" 
+                type="submit"
+            >
+                {{ localize "GENERIC.Button.Continue" }}
+            </button>
+        </div>
+    {{/if}}
 </div>

--- a/src/templates/roll/dialogs/pick-dice-result.hbs
+++ b/src/templates/roll/dialogs/pick-dice-result.hbs
@@ -1,0 +1,24 @@
+<div>
+    <h4>{{headerText}}</h4>
+    <div class="rolls">
+        {{#each rolls as |roll index|}}
+            <div class="roll die {{#if @root.isPlotDie}}plotdie{{/if}} {{@root.die}} {{#if (not roll.discarded)}}selected{{/if}} {{#if roll.success}}success{{/if}} {{#if roll.failure}}failure{{/if}} {{#if (eq result 1)}}min{{/if}} {{#if (eq result @root.faces)}}max{{/if}} {{#if roll.discarded}}discarded{{/if}}"
+                data-index="{{index}}"
+                data-action="select-result"
+                data-tooltip="DIALOG.PickDiceResult.SelectRoll"
+            >
+                {{#if (not @root.isPlotDie)}}
+                    {{roll.result}}
+                {{else}}
+                    {{#if (eq result 1)}}
+                        <img src="{{@root.plotDie.c2}}">
+                    {{else if (eq result 2)}}
+                        <img src="{{@root.plotDie.c4}}">
+                    {{else if (or (eq result 5) (eq result 6))}}
+                        <img src="{{@root.plotDie.op}}">
+                    {{/if}}
+                {{/if}}
+            </div>
+        {{/each}}
+    </div>
+</div>


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR adds the ability to use advantage/disadvantage with plot dice by adding a new dice term "pick" modifier (`p`). When evaluated, this modifier brings up a dialog window to pick a number of dice to keep.  
Also adds "gm pick" (`gmp`) modifier, though resolves the same as the "pick" modifier for now.

**Related Issue**  
Closes #231 

**How Has This Been Tested?**  
1. Open an actor sheet with a weapon
2. Bring up the attack configuration dialog
3. Select "Raise the stakes" and apply advantage (or disadvantage) to the plot die
4. The dice result pick dialog comes up, pick a result
5. The chosen result is kept, the other discarded

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/2171a0a4-d22d-46d1-bde8-afe6e0b0435e)
![image](https://github.com/user-attachments/assets/339b2258-436d-4c03-8d0a-e13a17f4f411)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331