### PR TITLE
Update issue templates to use Types instead of Labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
+type: Bug
 assignees: ''
 
 ---
@@ -26,8 +26,11 @@ _If applicable, add screenshots to help explain your problem._
 **Foundry VTT Version**  
 _Please specify the version of Foundry you are using._
 
-**Cosmere RPG System Version**  
-_Please specify the version of the Cosmere RPG system._
+**Cosmere RPG System & Module Versions**  
+|**Name**|**Version**|
+|---|---|
+|**System**|_Please specify the version of the Cosmere RPG system._|
+||_Please specify the version of any of the other Metalworks official modules._|
 
 **Browser**  
 _If applicable, include the browser you're using (Chrome, Firefox, etc.)._

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,18 @@
+---
+name: "INTERNAL: Chore / Enhancement"
+about: A small piece of work that needs doing to keep the system building well or enhancing a process
+title: ''
+type: Task
+label: Enhancement
+assignees: ''
+
+---
+
+**What needs changing?**  
+_A clear and concise description of what the task is. Ex. We need to support latest Node LTS / Foundry v##, It would be nice if [...]_
+
+**Describe the solution you'd like**  
+_A clear and concise description of what you want to happen._
+
+**Describe alternatives you've considered**  
+_A clear and concise description of any alternative solutions or features you've considered._

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -11,8 +11,5 @@ assignees: ''
 **What needs changing?**  
 _A clear and concise description of what the task is. Ex. We need to support latest Node LTS / Foundry v##, It would be nice if [...]_
 
-**Describe the solution you'd like**  
-_A clear and concise description of what you want to happen._
-
 **Describe alternatives you've considered**  
 _A clear and concise description of any alternative solutions or features you've considered._

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: feature request
+type: Feature
 assignees: ''
 
 ---


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Other (please describe): github admin

**Description**  
I notice that github has issue types now so maybe we replace the pre-configures feature/bug/etc labels with these.