### PR TITLE
feat: add additional movement types

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -145,6 +145,13 @@
                 "Humanoid": "Humanoid",
                 "Animal": "Animal"
             },
+            "Movement": {
+                "Type": {
+                    "Walk": "Walk",
+                    "Swim": "Swim",
+                    "Fly": "Fly"
+                }
+            },
             "Sheet": {
                 "Header": {
                     "Editable": "Editable",

--- a/src/system/applications/actor/components/details.ts
+++ b/src/system/applications/actor/components/details.ts
@@ -1,7 +1,12 @@
-import { ActorType } from '@system/types/cosmere';
+import { ActorType, MovementType } from '@system/types/cosmere';
+import { MovementTypeConfig } from '@system/types/config';
 import { ConstructorOf } from '@system/types/utils';
-import { SYSTEM_ID } from '@src/system/constants';
-import { TEMPLATES } from '@src/system/utils/templates';
+
+import { SYSTEM_ID } from '@system/constants';
+import { TEMPLATES } from '@system/utils/templates';
+
+// Fields
+import { Derived } from '@system/data/fields';
 
 // Dialogs
 import { ConfigureMovementRateDialog } from '@system/applications/actor/dialogs/configure-movement-rate';
@@ -91,12 +96,55 @@ export class ActorDetailsComponent extends HandlebarsApplicationComponent<
     ) {
         const actor = this.application.actor;
 
+        // Determine movement type with the highest movement rate
+        const preferredMovementType = (
+            Object.keys(CONFIG.COSMERE.movement.types) as MovementType[]
+        )
+            .map(
+                (type) =>
+                    [
+                        type,
+                        Derived.getValue(actor.system.movement[type].rate),
+                    ] as [MovementType, number],
+            )
+            .filter(([, rate]) => rate > 0)
+            .sort(([, rateA], [, rateB]) => rateB - rateA)[0]?.[0];
+
         return Promise.resolve({
             ...context,
             type: actor.type,
             displayRestButtons: actor.type === ActorType.Character,
             displayRecovery: actor.type === ActorType.Character,
+            preferredMovementType,
+            movementTooltip: this.generateMovementTooltip(),
         });
+    }
+
+    private generateMovementTooltip() {
+        const actor = this.application.actor;
+
+        const entries = (
+            Object.entries(CONFIG.COSMERE.movement.types) as [
+                MovementType,
+                MovementTypeConfig,
+            ][]
+        )
+            .map(([type, config]) => ({
+                type,
+                rate: Derived.getValue(actor.system.movement[type].rate) ?? 0,
+                label: game.i18n!.localize(config.label),
+            }))
+            .filter(({ rate }) => rate > 0)
+            .map(
+                ({ rate, label }) => `
+                <div>
+                    <span><b>${label}:</b></span>
+                    <span>${rate} ft.</span>
+                </div>
+            `,
+            );
+
+        return `${entries.join('')}`;
     }
 }
 

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -32,6 +32,7 @@ import {
     EquipmentType,
     PowerType,
     Theme,
+    MovementType,
 } from './types/cosmere';
 import { AdvantageMode } from './types/roll';
 
@@ -74,6 +75,20 @@ const COSMERE: CosmereRPGConfig = {
         },
         [CreatureType.Animal]: {
             label: 'COSMERE.Actor.Type.Animal',
+        },
+    },
+
+    movement: {
+        types: {
+            [MovementType.Walk]: {
+                label: 'COSMERE.Actor.Movement.Type.Walk',
+            },
+            [MovementType.Swim]: {
+                label: 'COSMERE.Actor.Movement.Type.Swim',
+            },
+            [MovementType.Fly]: {
+                label: 'COSMERE.Actor.Movement.Type.Fly',
+            },
         },
     },
 

--- a/src/system/data/actor/common.ts
+++ b/src/system/data/actor/common.ts
@@ -1,6 +1,7 @@
 import {
     Size,
     CreatureType,
+    MovementType,
     Attribute,
     Resource,
     AttributeGroup,
@@ -105,9 +106,10 @@ export interface CommonActorData {
             total: Derived<number>;
         }
     >;
-    movement: {
-        rate: Derived<number>;
-    };
+    // movement: {
+    //     rate: Derived<number>;
+    // };
+    movement: Record<MovementType, { rate: Derived<number> }>;
     encumbrance: {
         lift: Derived<number>;
         carry: Derived<number>;
@@ -212,17 +214,7 @@ export class CommonActorDataModel<
                     },
                 },
             ),
-            movement: new foundry.data.fields.SchemaField({
-                rate: new DerivedValueField(
-                    new foundry.data.fields.NumberField({
-                        required: true,
-                        nullable: false,
-                        integer: true,
-                        min: 0,
-                        initial: 0,
-                    }),
-                ),
-            }),
+            movement: this.getMovementSchema(),
             injuries: new DerivedValueField(
                 new foundry.data.fields.NumberField({
                     required: true,
@@ -507,6 +499,30 @@ export class CommonActorDataModel<
         });
     }
 
+    private static getMovementSchema() {
+        const movementTypeConfigs = CONFIG.COSMERE.movement.types;
+
+        return new foundry.data.fields.SchemaField(
+            Object.entries(movementTypeConfigs).reduce(
+                (schema, [type, config]) => ({
+                    ...schema,
+                    [type]: new foundry.data.fields.SchemaField({
+                        rate: new DerivedValueField(
+                            new foundry.data.fields.NumberField({
+                                required: true,
+                                nullable: false,
+                                integer: true,
+                                min: 0,
+                                initial: 0,
+                            }),
+                        ),
+                    }),
+                }),
+                {} as Record<string, foundry.data.fields.SchemaField>,
+            ),
+        );
+    }
+
     public prepareDerivedData(): void {
         super.prepareDerivedData();
 
@@ -594,9 +610,14 @@ export class CommonActorDataModel<
         }
 
         // Movement
-        this.movement.rate.value = speedToMovementRate(
+        this.movement[MovementType.Walk].rate.value = speedToMovementRate(
             this.attributes.spd.value,
         );
+
+        // Lock other movement types to always use override
+        (Object.keys(CONFIG.COSMERE.movement.types) as MovementType[])
+            .filter((type) => type !== MovementType.Walk)
+            .forEach((type) => (this.movement[type].rate.useOverride = true));
 
         // Injury count
         this.injuries.value = this.parent.items.filter(

--- a/src/system/types/config.ts
+++ b/src/system/types/config.ts
@@ -31,6 +31,7 @@ import {
     EquipmentType,
     PowerType,
     Theme,
+    MovementType,
 } from './cosmere';
 import { AdvantageMode } from './roll';
 
@@ -289,10 +290,17 @@ export interface AttributeScale {
     formula: string;
 }
 
+export interface MovementTypeConfig {
+    label: string;
+}
+
 export interface CosmereRPGConfig {
     themes: Record<Theme, string>;
     sizes: Record<Size, SizeConfig>;
     creatureTypes: Record<CreatureType, CreatureTypeConfig>;
+    movement: {
+        types: Record<MovementType, MovementTypeConfig>;
+    };
     conditions: Record<Condition, ConditionConfig>;
     injury: {
         types: Record<InjuryType, InjuryConfig>;

--- a/src/system/types/cosmere.ts
+++ b/src/system/types/cosmere.ts
@@ -251,6 +251,12 @@ export const enum DamageType {
     Healing = 'heal',
 }
 
+export const enum MovementType {
+    Walk = 'walk',
+    Swim = 'swim',
+    Fly = 'fly',
+}
+
 /* --- System --- */
 
 export const enum ActorType {

--- a/src/templates/actors/components/details.hbs
+++ b/src/templates/actors/components/details.hbs
@@ -49,10 +49,10 @@
 <div class="derived-statistics flexrow">
     {{!-- Movement --}}
     <div class="sheet-stack derived-stat movement">
-        <div class="container">
+        <div class="container" data-tooltip="{{movementTooltip}}">
             <div class="background"></div>
             <div class="border"></div>
-            <span class="value">{{derived actor.system.movement.rate}}</span>
+            <span class="value">{{derived (lookup (lookup actor.system.movement preferredMovementType) "rate")}}</span>
             <span class="unit">ft</span>
         </div>
         <span class="label">

--- a/src/templates/actors/dialogs/configure-movement-rate.hbs
+++ b/src/templates/actors/dialogs/configure-movement-rate.hbs
@@ -1,22 +1,37 @@
 <form>
-    <div class="form-group">
-        <input name="rate"
-            style="text-align: center; font-size: 15pt"
-            type="number"
-            value="{{derived rate}}"
-            min="0"
-            step="1"
-            {{#if (eq mode 'derived')}}
-            readonly
+    {{#each movementRates as |rate|}}
+        <div class="form-group">
+            {{#if (not (eq rate.type "walk"))}}
+                <label>{{localize rate.label}}</label>
             {{/if}}
-        >
-    </div>
-    <div class="form-group">
-        <label>{{localize "GENERIC.Mode"}}</label>
-        <select name="mode">
-            {{selectOptions modes selected=mode localize=true}}
-        </select>
-    </div>
+
+            <div class="form-group">
+                <input name="{{concat rate.type ".value"}}"
+                    style="text-align: center; font-size: 15pt"
+                    type="number"
+                    value="{{derived rate}}"
+                    min="0"
+                    step="1"
+                    {{#if (eq rate.mode 'derived')}}
+                    readonly
+                    {{/if}}
+                >
+            </div>
+        </div>
+
+        {{#if (eq rate.type "walk")}}
+            <div class="form-group">
+                <label>{{localize "GENERIC.Mode"}}</label>
+                <div class="form-group">
+                    <select name="{{concat rate.type ".mode"}}">
+                        {{selectOptions @root.modes selected=rate.mode localize=true}}
+                    </select>
+                </div>
+            </div>
+            <br>
+        {{/if}}
+    {{/each}}
+
     <br>
     <div class="form-group">
         <button data-action="update-movement" type="submit">


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR adds support for additional movement types.

**Related Issue**  
Closes #214 

**How Has This Been Tested?**  
1. Create actor
2. Toggle edit mode
3. Click configure movement rate
4. Edit each type to have a value
5. Hover over movement 

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/d24d1fb7-90d9-4e11-b6b2-904f91a8632c)
![image](https://github.com/user-attachments/assets/ae6820e8-f9c6-4bab-bc56-97141f5e50f9)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331