### PR TITLE
feat(data model): improve the way derived fields are used

### DIFF
--- a/src/system/applications/actor/components/details.ts
+++ b/src/system/applications/actor/components/details.ts
@@ -102,10 +102,10 @@ export class ActorDetailsComponent extends HandlebarsApplicationComponent<
         )
             .map(
                 (type) =>
-                    [
-                        type,
-                        Derived.getValue(actor.system.movement[type].rate),
-                    ] as [MovementType, number],
+                    [type, actor.system.movement[type].rate.value] as [
+                        MovementType,
+                        number,
+                    ],
             )
             .filter(([, rate]) => rate > 0)
             .sort(([, rateA], [, rateB]) => rateB - rateA)[0]?.[0];
@@ -131,7 +131,7 @@ export class ActorDetailsComponent extends HandlebarsApplicationComponent<
         )
             .map(([type, config]) => ({
                 type,
-                rate: Derived.getValue(actor.system.movement[type].rate) ?? 0,
+                rate: actor.system.movement[type].rate.value ?? 0,
                 label: game.i18n!.localize(config.label),
             }))
             .filter(({ rate }) => rate > 0)

--- a/src/system/applications/actor/components/resource.ts
+++ b/src/system/applications/actor/components/resource.ts
@@ -100,7 +100,7 @@ export class ActorResourceComponent extends HandlebarsApplicationComponent<
 
         // Get value and max
         const value = resource.value;
-        const max = Derived.getValue(resource.max);
+        const max = resource.max.value;
 
         return Promise.resolve({
             ...context,

--- a/src/system/applications/actor/dialogs/configure-defense.ts
+++ b/src/system/applications/actor/dialogs/configure-defense.ts
@@ -73,11 +73,9 @@ export class ConfigureDefenseDialog extends HandlebarsApplicationMixin(
         });
 
         this.defenseData = this.actor.system.defenses[group];
-        this.defenseData.value.override =
-            this.defenseData.value.override ??
-            this.defenseData.value.value ??
-            10;
-        this.mode = Derived.getMode(this.defenseData.value);
+        this.defenseData.override =
+            this.defenseData.override ?? this.defenseData.value ?? 10;
+        this.mode = this.defenseData.mode;
     }
 
     /* --- Statics --- */
@@ -110,13 +108,13 @@ export class ConfigureDefenseDialog extends HandlebarsApplicationMixin(
         this.mode = formData.object.mode as Derived.Mode;
 
         if (this.mode === Derived.Mode.Override && target.name === 'formula')
-            this.defenseData.value.override = formData.object.formula as number;
+            this.defenseData.override = formData.object.formula as number;
 
         if (target.name === 'bonus')
             this.defenseData.bonus = formData.object.bonus as number;
 
         // Assign mode
-        Derived.setMode(this.defenseData.value, this.mode);
+        this.defenseData.mode = this.mode;
 
         // Render
         void this.render(true);
@@ -146,7 +144,7 @@ export class ConfigureDefenseDialog extends HandlebarsApplicationMixin(
             formula,
             mode: this.mode,
             modes: Derived.Modes,
-            override: this.defenseData.value.override!,
+            override: this.defenseData.override!,
             bonus: this.defenseData.bonus,
         });
     }

--- a/src/system/applications/actor/dialogs/configure-deflect.ts
+++ b/src/system/applications/actor/dialogs/configure-deflect.ts
@@ -64,11 +64,10 @@ export class ConfigureDeflectDialog extends HandlebarsApplicationMixin(
         });
 
         this.data = actor.system.deflect;
-        this.data.value ??= 0;
         this.data.natural ??= 0;
         this.data.override ??= this.data.value ?? 0;
         this.data.bonus ??= 0;
-        this.mode = Derived.getMode(this.data);
+        this.mode = this.data.mode;
     }
 
     /* --- Statics --- */
@@ -111,10 +110,10 @@ export class ConfigureDeflectDialog extends HandlebarsApplicationMixin(
 
         if (isNaN(this.data.override!)) this.data.override = 0;
         if (isNaN(this.data.natural!)) this.data.natural = 0;
-        if (isNaN(this.data.bonus!)) this.data.bonus = 0;
+        if (isNaN(this.data.bonus)) this.data.bonus = 0;
 
         // Assign mode
-        Derived.setMode(this.data, this.mode);
+        this.data.mode = this.mode;
 
         // Render
         void this.render(true);

--- a/src/system/applications/actor/dialogs/configure-movement-rate.ts
+++ b/src/system/applications/actor/dialogs/configure-movement-rate.ts
@@ -107,7 +107,7 @@ export class ConfigureMovementRateDialog extends HandlebarsApplicationMixin(
                     Derived.Mode.Override) as Derived.Mode;
 
                 // Assign mode
-                Derived.setMode(this.movementData[type].rate, mode);
+                this.movementData[type].rate.mode = mode;
 
                 // Assign rate
                 if (
@@ -140,7 +140,7 @@ export class ConfigureMovementRateDialog extends HandlebarsApplicationMixin(
             Object.keys(CONFIG.COSMERE.movement.types) as MovementType[]
         ).map((type) => ({
             ...this.movementData[type].rate,
-            mode: Derived.getMode(this.movementData[type].rate),
+            mode: this.movementData[type].rate.mode,
             type,
             label: CONFIG.COSMERE.movement.types[type].label,
         }));

--- a/src/system/applications/actor/dialogs/configure-recovery-die.ts
+++ b/src/system/applications/actor/dialogs/configure-recovery-die.ts
@@ -68,7 +68,7 @@ export class ConfigureRecoveryDieDialog extends HandlebarsApplicationMixin(
         this.recoveryData = this.actor.system.recovery;
         this.recoveryData.die.override ??=
             this.recoveryData.die.value ?? RECOVERY_DICE[0];
-        this.mode = Derived.getMode(this.recoveryData.die);
+        this.mode = this.recoveryData.die.mode;
     }
 
     /* --- Statics --- */
@@ -103,7 +103,7 @@ export class ConfigureRecoveryDieDialog extends HandlebarsApplicationMixin(
         this.mode = formData.object.mode as Derived.Mode;
 
         // Assign mode
-        Derived.setMode(this.recoveryData.die, this.mode);
+        this.recoveryData.die.mode = this.mode;
 
         // Assign rate
         if (this.mode === Derived.Mode.Override && target.name === 'die')

--- a/src/system/applications/actor/dialogs/configure-resource.ts
+++ b/src/system/applications/actor/dialogs/configure-resource.ts
@@ -74,7 +74,7 @@ export class ConfigureResourceDialog extends HandlebarsApplicationMixin(
 
         this.resourceData = this.actor.system.resources[resourceId];
         this.resourceData.max.override ??= this.resourceData.max.value ?? 0;
-        this.mode = Derived.getMode(this.resourceData.max);
+        this.mode = this.resourceData.max.mode;
     }
 
     /* --- Statics --- */
@@ -109,7 +109,7 @@ export class ConfigureResourceDialog extends HandlebarsApplicationMixin(
         this.mode = formData.object.mode as Derived.Mode;
 
         // Assign mode
-        Derived.setMode(this.resourceData.max, this.mode);
+        this.resourceData.max.mode = this.mode;
 
         // Assign rate
         if (this.mode === Derived.Mode.Override && target.name === 'max')

--- a/src/system/applications/actor/dialogs/configure-senses-range.ts
+++ b/src/system/applications/actor/dialogs/configure-senses-range.ts
@@ -64,7 +64,7 @@ export class ConfigureSensesRangeDialog extends HandlebarsApplicationMixin(
 
         this.sensesData = this.actor.system.senses;
         this.sensesData.range.override ??= this.sensesData.range.value ?? 0;
-        this.mode = Derived.getMode(this.sensesData.range);
+        this.mode = this.sensesData.range.mode;
     }
 
     /* --- Statics --- */
@@ -99,7 +99,7 @@ export class ConfigureSensesRangeDialog extends HandlebarsApplicationMixin(
         this.mode = formData.object.mode as Derived.Mode;
 
         // Assign mode
-        Derived.setMode(this.sensesData.range, this.mode);
+        this.sensesData.range.mode = this.mode;
 
         // Assign range
         if (this.mode === Derived.Mode.Override && target.name === 'range')

--- a/src/system/applications/actor/dialogs/short-rest.ts
+++ b/src/system/applications/actor/dialogs/short-rest.ts
@@ -90,7 +90,7 @@ export class ShortRestDialog extends foundry.applications.api.DialogV2 {
                 ),
             },
             tendedBy: options.tendedBy?.id ?? 'none',
-            formula: Derived.getValue(actor.system.recovery.die),
+            formula: actor.system.recovery.die.value,
         });
 
         // Render dialog and wrap as promise
@@ -136,10 +136,7 @@ export class ShortRestDialog extends foundry.applications.api.DialogV2 {
                     // Set formula
                     $(this.element)
                         .find('input[name="formula"]')
-                        .val(
-                            Derived.getValue(this.actor.system.recovery.die) ??
-                                '',
-                        );
+                        .val(this.actor.system.recovery.die.value ?? '');
                 } else {
                     // Get the character
                     const character = CosmereActor.get(
@@ -147,14 +144,13 @@ export class ShortRestDialog extends foundry.applications.api.DialogV2 {
                     ) as CharacterActor;
 
                     // Get the medicine modifier
-                    const mod =
-                        Derived.getValue(character.system.skills.med.mod) ?? 0;
+                    const mod = character.system.skills.med.mod.value ?? 0;
 
                     // Set formula
                     $(this.element)
                         .find('input[name="formula"]')
                         .val(
-                            `${Derived.getValue(this.actor.system.recovery.die)} + ${mod}`,
+                            `${this.actor.system.recovery.die.value} + ${mod}`,
                         );
                 }
             });

--- a/src/system/data/actor/character.ts
+++ b/src/system/data/actor/character.ts
@@ -136,7 +136,7 @@ export class CharacterActorDataModel extends CommonActorDataModel<CharacterActor
         this.maxSkillRank = currentAdvancementRule.maxSkillRanks;
 
         // Derive the recovery die based on the character's willpower
-        this.recovery.die.value = willpowerToRecoveryDie(
+        this.recovery.die.derived = willpowerToRecoveryDie(
             this.attributes.wil.value,
         );
 
@@ -151,20 +151,21 @@ export class CharacterActorDataModel extends CommonActorDataModel<CharacterActor
                     this.attributes.str.value + this.attributes.str.bonus;
 
                 // Assign max
-                resource.max.value =
-                    Advancement.deriveMaxHealth(advancementRules, strength) +
-                    (resource.max.bonus ?? 0);
+                resource.max.derived = Advancement.deriveMaxHealth(
+                    advancementRules,
+                    strength,
+                );
             } else if (key === Resource.Focus) {
                 // Get willpower mod
                 const willpower =
                     this.attributes.wil.value + this.attributes.wil.bonus;
 
                 // Assign max
-                resource.max.value = 2 + willpower + (resource.max.bonus ?? 0);
+                resource.max.derived = 2 + willpower;
             }
 
             // Get max
-            const max = Derived.getValue(resource.max)!;
+            const max = resource.max.value;
 
             // Ensure resource value is between max mand min
             resource.value = Math.max(0, Math.min(max, resource.value));

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -145,7 +145,7 @@ export class CosmereActor<
     }
 
     public get deflect(): number {
-        return Derived.getValue(this.system.deflect) ?? 0;
+        return this.system.deflect.value;
     }
 
     public get ancestry(): AncestryItem | undefined {
@@ -256,7 +256,7 @@ export class CosmereActor<
                 max: Derived<number>;
             };
             const current = attr.value;
-            const max = Derived.getValue(attr.max)!;
+            const max = attr.max.value;
             const update = Math.clamp(
                 isDelta ? current + value : value,
                 0,
@@ -476,8 +476,7 @@ export class CosmereActor<
         const bonus = this.system.injuryRollBonus;
 
         // Get injuries modifier
-        const injuriesModifier =
-            (Derived.getValue(this.system.injuries) ?? 0) * -5;
+        const injuriesModifier = this.system.injuries.value * -5;
 
         // Build formula
         const formula = ['1d20', this.deflect, bonus, injuriesModifier].join(
@@ -665,7 +664,7 @@ export class CosmereActor<
         const data = this.getRollData() as Partial<D20RollData>;
 
         // Add attribute mod
-        data.mod = Derived.getValue(skill.mod)!;
+        data.mod = skill.mod.value;
         data.skill = {
             id: skillId,
             rank: skill.rank,
@@ -795,11 +794,11 @@ export class CosmereActor<
 
         // Get Medicine mod, if required
         const mod = options.tendedBy
-            ? Derived.getValue(options.tendedBy.system.skills.med.mod)
+            ? options.tendedBy.system.skills.med.mod.value
             : undefined;
 
         // Construct formula
-        const formula = [Derived.getValue(this.system.recovery.die), mod]
+        const formula = [this.system.recovery.die.value, mod]
             .filter((v) => !!v)
             .join(' + ');
 
@@ -868,12 +867,8 @@ export class CosmereActor<
 
         // Update the actor
         await this.update({
-            'system.resources.hea.value': Derived.getValue(
-                this.system.resources.hea.max,
-            ),
-            'system.resources.foc.value': Derived.getValue(
-                this.system.resources.foc.max,
-            ),
+            'system.resources.hea.value': this.system.resources.hea.max.value,
+            'system.resources.foc.value': this.system.resources.foc.max.value,
         });
     }
 
@@ -898,9 +893,7 @@ export class CosmereActor<
                     ...data,
                     [skillId]: {
                         rank: this.system.skills[skillId].rank,
-                        mod:
-                            Derived.getValue(this.system.skills[skillId].mod) ??
-                            0,
+                        mod: this.system.skills[skillId].mod.value,
                     },
                 }),
                 {} as Record<Skill, { rank: number; mod: number }>,
@@ -936,7 +929,7 @@ export class CosmereActor<
         attr: Attribute,
         scale: AttributeScale[],
     ) {
-        const value = Derived.getValue(this.system.attributes[attr]) ?? 0;
+        const value = this.system.attributes[attr].value;
         for (const range of scale) {
             if (value >= range.min && value <= range.max) {
                 return range.formula;

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -1194,7 +1194,7 @@ export class CosmereItem<
     ): D20RollData {
         const skill = skillId
             ? actor.system.skills[skillId]
-            : { attribute: null, rank: 0, mod: {} };
+            : { attribute: null, rank: 0, mod: 0 };
         const attribute = attributeId
             ? actor.system.attributes[attributeId]
             : { value: 0, bonus: 0 };
@@ -1206,7 +1206,8 @@ export class CosmereItem<
             skill: {
                 id: skillId ?? null,
                 rank: skill.rank,
-                mod: Derived.getValue(skill.mod) ?? 0,
+                mod:
+                    typeof skill.mod === 'number' ? skill.mod : skill.mod.value,
                 attribute: attributeId ? attributeId : skill.attribute,
             },
             attribute: attribute.value,
@@ -1238,7 +1239,7 @@ export class CosmereItem<
                 ? {
                       id: skillId!,
                       rank: skill.rank,
-                      mod: Derived.getValue(skill.mod) ?? 0,
+                      mod: skill.mod.value,
                       attribute: attributeId! ? attributeId : skill.attribute,
                   }
                 : undefined,

--- a/src/system/documents/token.ts
+++ b/src/system/documents/token.ts
@@ -18,7 +18,7 @@ export class CosmereTokenDocument extends TokenDocument {
             ) as { max: number | Derived<number> };
 
             if (typeof data.max === 'object') {
-                attr.max = Derived.getValue(data.max) ?? 0;
+                attr.max = data.max.value;
             }
         }
 

--- a/src/system/utils/generic.ts
+++ b/src/system/utils/generic.ts
@@ -234,9 +234,9 @@ export function getTargetDescriptors() {
     const targets = new Map();
     for (const token of game.user!.targets) {
         const { name, img, system, uuid } = (token.actor as CosmereActor) ?? {};
-        const phy = system.defenses.phy.value.value ?? 10;
-        const cog = system.defenses.cog.value.value ?? 10;
-        const spi = system.defenses.spi.value.value ?? 10;
+        const phy = system.defenses.phy.value ?? 10;
+        const cog = system.defenses.cog.value ?? 10;
+        const spi = system.defenses.spi.value ?? 10;
 
         if (uuid) {
             targets.set(uuid, { name, img, uuid, def: { phy, cog, spi } });

--- a/src/system/utils/handlebars/index.ts
+++ b/src/system/utils/handlebars/index.ts
@@ -108,7 +108,7 @@ Handlebars.registerHelper(
     'derived',
     (derived?: Derived<string | number>, includeBonus = true) => {
         if (!derived) return;
-        return Derived.getValue(derived, includeBonus);
+        return includeBonus ? derived.value : derived.base;
     },
 );
 

--- a/src/templates/actors/components/attributes.hbs
+++ b/src/templates/actors/components/attributes.hbs
@@ -43,7 +43,7 @@
                         <i class="fa-solid fa-gear"></i>
                     </a>
                     {{/if}}                     
-                    <span class="value">{{ derived defense.value }}</span>
+                    <span class="value">{{ defense.value }}</span>
                 </div>
             </div>
             {{/with}}


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [x] Refactor (partial)
- [ ] Other (please describe):

**Description**  
This PR fixes an issue causing the health value to include the bonus twice. This PR solves the more general problem of how the derived fields are meant to be used. It simplifies use into always using the `.value` property.

**Related Issue**  
Closes #225 

**How Has This Been Tested?**  
1. Create Active Effect set to Add 1 on `system.resources.hea.max.bonus`
2. Toggle on new effect
3. Health is increased by 1 (only)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331