### PR TITLE
feat(adversary sheet): make tier editable

### DIFF
--- a/src/templates/actors/adversary/parts/header.hbs
+++ b/src/templates/actors/adversary/parts/header.hbs
@@ -40,7 +40,16 @@
                 <div class="background"></div>
                 <div class="star"></div>
                 <div class="border"></div>
-                <span class="value">{{actor.system.tier}}</span>
+                <input class="value"
+                    type="number"
+                    name="system.tier",
+                    value="{{actor.system.tier}}",
+                    min="1",
+                    step="1"
+                    {{#if (not isEditMode)}}
+                    readonly
+                    {{/if}}
+                >
             </div>
         </div>
     </div>


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR makes the tier field on the adversary sheet editable.

**Related Issue**  
Closes #230 

**How Has This Been Tested?**  
1. Open adversary sheet
2. Toggle edit mode
3. Edit tier
4. Refresh
5. Check tier

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/752b4347-1c4c-4bbf-988b-f2f19d664845)

**Checklist:**  
- [ ] I have commented on my code, particularly in hard-to-understand areas. N/A
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331