### PR TITLE
feat(active effects): make actor roll data available in active effect values

### DIFF
--- a/src/declarations/foundry/client/data/documents/active-effect.d.ts
+++ b/src/declarations/foundry/client/data/documents/active-effect.d.ts
@@ -217,4 +217,15 @@ declare class ActiveEffect<
      * Returns "None" (localized) if it has no origin, and "Unknown" (localized) if the origin cannot be resolved.
      */
     get sourceName(): string;
+
+    /**
+     * Apply this ActiveEffect to a provided Actor.
+     * @param actor     The Actor to whom this effect should be applied
+     * @param change    The change data being applied
+     * @returns          An object of property paths and their updated values.
+     */
+    public apply(
+        actor: Actor,
+        change: ActiveEffect.EffectChangeData,
+    ): Record<string, any>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,9 +56,10 @@ Hooks.once('init', async () => {
 
     CONFIG.Token.documentClass = documents.CosmereTokenDocument;
 
-    Roll.TOOLTIP_TEMPLATE = `systems/${SYSTEM_ID}/templates/${TEMPLATES.CHAT_ROLL_TOOLTIP}`;
-
+    CONFIG.ActiveEffect.documentClass = documents.CosmereActiveEffect;
     CONFIG.ActiveEffect.legacyTransferral = false;
+
+    Roll.TOOLTIP_TEMPLATE = `systems/${SYSTEM_ID}/templates/${TEMPLATES.CHAT_ROLL_TOOLTIP}`;
 
     // Add fonts
     configureFonts();

--- a/src/system/documents/active-effect.ts
+++ b/src/system/documents/active-effect.ts
@@ -1,0 +1,22 @@
+import { AnyObject } from '@system/types/utils';
+
+export class CosmereActiveEffect<
+    D extends foundry.abstract.DataModel = foundry.abstract.DataModel,
+> extends ActiveEffect<D> {
+    public override apply(actor: Actor, change: ActiveEffect.EffectChangeData) {
+        // Grab the roll data from the actor
+        const data = actor.getRollData() as AnyObject;
+
+        // Treat the change value as a formula and evaluate it
+        const value = new Roll(change.value, data).evaluateSync().formula;
+
+        // Update the change
+        const newChange = {
+            ...change,
+            value: value,
+        };
+
+        // Execute the standard ActiveEffect application logic
+        return super.apply(actor, newChange);
+    }
+}

--- a/src/system/documents/index.ts
+++ b/src/system/documents/index.ts
@@ -4,3 +4,4 @@ export * from './combat';
 export * from './combatant';
 export * from './chat-message';
 export * from './token';
+export * from './active-effect';


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR adds the ability to use actor roll data (`@fields`) in active effect values.

**Related Issue**  
Closes #226 

**How Has This Been Tested?**  
1. Open character
2. Add active effect for key `system.resources.hea.max.bonus` with value `@level`
3. Toggle the effect on
4. Max health increases by the level (Note: because the level increases the base health will also go up so account for that)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331