### PR TITLE
feat(actor): add power scaling to roll data

### DIFF
--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -1007,14 +1007,38 @@ const COSMERE: CosmereRPGConfig = {
         },
     },
 
-    unarmedDamageScaling: {
-        strengthRanges: [
-            { min: 0, max: 2, formula: '1' },
-            { min: 3, max: 4, formula: '1d4' },
-            { min: 5, max: 6, formula: '1d8' },
-            { min: 7, max: 8, formula: '2d6' },
-            { min: 9, max: Infinity, formula: '2d10' },
-        ],
+    scaling: {
+        damage: {
+            unarmed: {
+                strength: [
+                    { min: 0, max: 2, formula: '1' },
+                    { min: 3, max: 4, formula: '1d4' },
+                    { min: 5, max: 6, formula: '1d8' },
+                    { min: 7, max: 8, formula: '2d6' },
+                    { min: 9, max: Infinity, formula: '2d10' },
+                ],
+            },
+        },
+        power: {
+            die: {
+                ranks: [
+                    { value: 1, formula: 'd4' },
+                    { value: 2, formula: 'd6' },
+                    { value: 3, formula: 'd8' },
+                    { value: 4, formula: 'd10' },
+                    { value: 5, formula: 'd12' },
+                ],
+            },
+            effectSize: {
+                ranks: [
+                    { value: 1, formula: Size.Small },
+                    { value: 2, formula: Size.Medium },
+                    { value: 3, formula: Size.Large },
+                    { value: 4, formula: Size.Huge },
+                    { value: 5, formula: Size.Garguantuan },
+                ],
+            },
+        },
     },
 
     dice: {

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -115,7 +115,7 @@ export type CosmereActorRollData<T extends CommonActorData = CommonActorData> =
                 string,
                 {
                     die: string;
-                    effectSize: Size;
+                    'effect-size': Size;
                 }
             >;
         };
@@ -942,7 +942,7 @@ export class CosmereActor<
                                     skill.rank,
                                     CONFIG.COSMERE.scaling.power.die.ranks,
                                 ),
-                                effectSize: this.getFormulaFromScalar(
+                                'effect-size': this.getFormulaFromScalar(
                                     skill.rank,
                                     CONFIG.COSMERE.scaling.power.effectSize
                                         .ranks,
@@ -951,7 +951,10 @@ export class CosmereActor<
 
                             return scaling;
                         },
-                        {} as Record<string, { die: string; effectSize: Size }>,
+                        {} as Record<
+                            string,
+                            { die: string; 'effect-size': Size }
+                        >,
                     ),
                 },
             },

--- a/src/system/types/config.ts
+++ b/src/system/types/config.ts
@@ -284,11 +284,17 @@ export interface AdvancementRuleConfig {
     skillRanksOrTalents?: number;
 }
 
-export interface AttributeScale {
-    min: number;
-    max: number;
-    formula: string;
-}
+export type AttributeScale<T extends string = string> = {
+    formula: T;
+} & (
+    | {
+          min: number;
+          max: number;
+      }
+    | {
+          value: number;
+      }
+);
 
 export interface MovementTypeConfig {
     label: string;
@@ -404,11 +410,23 @@ export interface CosmereRPGConfig {
         distance: Record<string, string>;
     };
 
-    unarmedDamageScaling: {
-        strengthRanges: AttributeScale[];
-    };
-
     dice: {
         advantageModes: Record<AdvantageMode, string>;
+    };
+
+    scaling: {
+        damage: {
+            unarmed: {
+                strength: AttributeScale[];
+            };
+        };
+        power: {
+            die: {
+                ranks: AttributeScale[];
+            };
+            effectSize: {
+                ranks: AttributeScale<Size>[];
+            };
+        };
     };
 }


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR adds scalar properties for powers. It exposes both the die size and effect size fields through `@scalar.power.<id>.die` & `@scalar.power.<id>.effect-size`.

**Related Issue**  
Closes #215 

**How Has This Been Tested?**  
1. Add the Adhesion power from the playtest materials to a character
2. Use `/r 1@scalar.power.adh.die`
3. 1d4 gets rolled
4. Add Windrunner radiant path to same character
5. Adjust adhesion rank to 2
6. Use `/r 1@scalar.power.adh.die`
7. 1d6 gets rolled

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331