### PR TITLE
feat(combat): support simultaneous fast and slow turns for boss adversaries

### DIFF
--- a/src/system/applications/combat/combat-tracker.ts
+++ b/src/system/applications/combat/combat-tracker.ts
@@ -2,6 +2,7 @@ import { ActorType, AdversaryRole, TurnSpeed } from '@src/system/types/cosmere';
 import { CosmereCombatant } from '@src/system/documents/combatant';
 import { SYSTEM_ID } from '@src/system/constants';
 import { AdversaryActor } from '@src/system/documents';
+import { combat } from '..';
 
 /**
  * Overrides default tracker template to implement slow/fast buckets and combatant activation button.
@@ -43,6 +44,10 @@ export class CosmereCombatTracker extends CombatTracker {
                 type: combatant.actor.type,
                 activated: combatant.getFlag(SYSTEM_ID, 'activated') as boolean,
                 isBoss: combatant.getFlag(SYSTEM_ID, 'isBoss') as boolean,
+                bossFastActivated: combatant.getFlag(
+                    SYSTEM_ID,
+                    'bossFastActivated',
+                ) as boolean,
             };
             //strips active player formatting
             newTurn.css = '';
@@ -132,7 +137,12 @@ export class CosmereCombatTracker extends CombatTracker {
             li.dataset.combatantId!,
             {},
         ) as CosmereCombatant;
-        void combatant.setFlag(SYSTEM_ID, 'activated', true);
+        // Toggle the correct activation flag for bosses and nonbosses
+        if (!combatant.isBoss() || li.classList.contains(TurnSpeed.Slow)) {
+            void combatant.setFlag(SYSTEM_ID, 'activated', true);
+        } else {
+            void combatant.setFlag(SYSTEM_ID, 'bossFastActivated', true);
+        }
     }
 
     /**
@@ -157,6 +167,7 @@ export class CosmereCombatTracker extends CombatTracker {
             {},
         ) as CosmereCombatant;
         void combatant.setFlag(SYSTEM_ID, 'activated', false);
+        void combatant.setFlag(SYSTEM_ID, 'bossFastActivated', false);
     }
 
     /**
@@ -189,7 +200,7 @@ export class CosmereCombatTracker extends CombatTracker {
     }
 }
 
-interface CosmereTurn {
+export interface CosmereTurn {
     id: string;
     css: string;
     pending: number;
@@ -198,4 +209,5 @@ interface CosmereTurn {
     turnSpeed?: TurnSpeed;
     activated?: boolean;
     isBoss?: boolean;
+    bossFastActivated?: boolean;
 }

--- a/src/system/applications/combat/combat-tracker.ts
+++ b/src/system/applications/combat/combat-tracker.ts
@@ -47,6 +47,8 @@ export class CosmereCombatTracker extends CombatTracker {
                     (combatant.actor as AdversaryActor).system.role ===
                         AdversaryRole.Boss,
             };
+            //strips active player formatting
+            newTurn.css = '';
             // ensure boss adversaries have both a fast and slow turn
             if (newTurn.isBoss) {
                 newTurn.turnSpeed = TurnSpeed.Fast;
@@ -56,8 +58,7 @@ export class CosmereCombatTracker extends CombatTracker {
                 };
                 return [newTurn, bossAltTurn];
             }
-            //strips active player formatting
-            newTurn.css = '';
+            // provide current turn for non-boss combatants
             return newTurn;
         });
 

--- a/src/system/applications/combat/combat-tracker.ts
+++ b/src/system/applications/combat/combat-tracker.ts
@@ -42,21 +42,18 @@ export class CosmereCombatTracker extends CombatTracker {
                 ) as TurnSpeed,
                 type: combatant.actor.type,
                 activated: combatant.getFlag(SYSTEM_ID, 'activated') as boolean,
-                isBoss:
-                    combatant.actor.type === ActorType.Adversary &&
-                    (combatant.actor as AdversaryActor).system.role ===
-                        AdversaryRole.Boss,
+                isBoss: combatant.getFlag(SYSTEM_ID, 'isBoss') as boolean,
             };
             //strips active player formatting
             newTurn.css = '';
             // ensure boss adversaries have both a fast and slow turn
             if (newTurn.isBoss) {
-                newTurn.turnSpeed = TurnSpeed.Fast;
-                const bossAltTurn = {
+                newTurn.turnSpeed = TurnSpeed.Slow;
+                const bossFastTurn = {
                     ...newTurn,
-                    turnSpeed: TurnSpeed.Slow,
+                    turnSpeed: TurnSpeed.Fast,
                 };
-                return [newTurn, bossAltTurn];
+                return [newTurn, bossFastTurn];
             }
             // provide current turn for non-boss combatants
             return newTurn;

--- a/src/system/documents/combat.ts
+++ b/src/system/documents/combat.ts
@@ -15,6 +15,11 @@ export class CosmereCombat extends Combat {
                 'activated',
                 combatant.isDefeated ? true : false,
             );
+            void combatant.setFlag(
+                SYSTEM_ID,
+                'bossFastActivated',
+                combatant.isDefeated ? true : false,
+            );
         }
     }
 

--- a/src/system/documents/combatant.ts
+++ b/src/system/documents/combatant.ts
@@ -1,7 +1,7 @@
 import { DocumentModificationOptions } from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/abstract/document.mjs';
 import { SchemaField } from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/fields.mjs';
-import { CosmereActor } from './actor';
-import { ActorType, TurnSpeed } from '@src/system/types/cosmere';
+import { AdversaryActor, CosmereActor } from './actor';
+import { ActorType, AdversaryRole, TurnSpeed } from '@src/system/types/cosmere';
 import { SYSTEM_ID } from '../constants';
 
 export class CosmereCombatant extends Combatant {
@@ -20,6 +20,13 @@ export class CosmereCombatant extends Combatant {
         super._onCreate(data, options, userID);
         void this.setFlag(SYSTEM_ID, 'turnSpeed', TurnSpeed.Slow);
         void this.setFlag(SYSTEM_ID, 'activated', false);
+        void this.setFlag(
+            SYSTEM_ID,
+            'isBoss',
+            this.actor.isAdversary() &&
+                (this.actor as AdversaryActor).system.role ===
+                    AdversaryRole.Boss,
+        );
         void this.combat?.setInitiative(
             this.id!,
             this.generateInitiative(this.actor.type, TurnSpeed.Slow),

--- a/src/system/documents/combatant.ts
+++ b/src/system/documents/combatant.ts
@@ -20,13 +20,9 @@ export class CosmereCombatant extends Combatant {
         super._onCreate(data, options, userID);
         void this.setFlag(SYSTEM_ID, 'turnSpeed', TurnSpeed.Slow);
         void this.setFlag(SYSTEM_ID, 'activated', false);
-        void this.setFlag(
-            SYSTEM_ID,
-            'isBoss',
-            this.actor.isAdversary() &&
-                (this.actor as AdversaryActor).system.role ===
-                    AdversaryRole.Boss,
-        );
+        void this.setFlag(SYSTEM_ID, 'isBoss', this.isBoss());
+        // Track a separate activation for a boss's other turn
+        void this.setFlag(SYSTEM_ID, 'bossFastActivated', false);
         void this.combat?.setInitiative(
             this.id!,
             this.generateInitiative(this.actor.type, TurnSpeed.Slow),
@@ -56,6 +52,16 @@ export class CosmereCombatant extends Combatant {
         void this.combat?.setInitiative(
             this.id!,
             this.generateInitiative(this.actor.type, newSpeed),
+        );
+    }
+
+    /**
+     * Utility function to check if the current combatant is a boss adversary
+     */
+    isBoss(): boolean {
+        return (
+            this.actor.isAdversary() &&
+            (this.actor as AdversaryActor).system.role === AdversaryRole.Boss
         );
     }
 }

--- a/src/system/utils/handlebars/index.ts
+++ b/src/system/utils/handlebars/index.ts
@@ -10,6 +10,7 @@ import {
     DamageType,
     HoldType,
     AttackType,
+    TurnSpeed,
 } from '@src/system/types/cosmere';
 
 import { CharacterActor, CosmereActor } from '@system/documents/actor';
@@ -22,6 +23,7 @@ import { AnyObject } from '@src/system/types/utils';
 import { ItemContext, ItemContextOptions } from './types';
 import { TEMPLATES } from '../templates';
 import { SYSTEM_ID } from '@src/system/constants';
+import { CosmereTurn } from '@src/system/applications/combat';
 
 Handlebars.registerHelper('add', (a: number, b: number) => a + b);
 Handlebars.registerHelper('sub', (a: number, b: number) => a - b);
@@ -478,6 +480,16 @@ Handlebars.registerHelper(
 
 Handlebars.registerHelper('damageTypeConfig', (type: DamageType) => {
     return CONFIG.COSMERE.damageTypes[type];
+});
+
+Handlebars.registerHelper('getCombatActedState', (turn: CosmereTurn) => {
+    // use default activated for boss slow turns, and all other combatants' turns
+    if (!turn.isBoss || turn.turnSpeed === TurnSpeed.Slow) {
+        return turn.activated;
+    }
+
+    // track a boss's additional fast turn separately
+    return turn.bossFastActivated;
 });
 
 export async function preloadHandlebarsTemplates() {

--- a/src/templates/combat/combatant.hbs
+++ b/src/templates/combat/combatant.hbs
@@ -1,4 +1,4 @@
-<li class="combatant actor directory-item flexrow {{this.css}}" data-combatant-id="{{this.id}}">
+<li class="combatant actor directory-item flexrow {{this.css}} {{this.turnSpeed}}" data-combatant-id="{{this.id}}">
     <img class="token-image" data-src="{{this.img}}" alt="{{this.name}}" />
     <div class="token-name flexcol">
         <h4>{{this.name}}</h4>
@@ -45,6 +45,6 @@
         <a class="cosmere-turn-speed-control" role="button" data-tooltip="COSMERE.Combat.ToggleTurn" data-control="toggleSpeed"></a>
         {{/unless}} 
         {{/if}}
-        <a class="cosmere-activate-control {{#if this.activated}}cosmere-activate-control-activated{{/if}}" data-tooltip="COSMERE.Combat.Activate" {{#if this.owner}}data-control="activateCombatant"{{/if}}></a>    
+        <a class="cosmere-activate-control {{#if (getCombatActedState this)}}cosmere-activate-control-activated{{/if}}" data-tooltip="COSMERE.Combat.Activate" {{#if this.owner}}data-control="activateCombatant"{{/if}}></a>    
     </div>
 </li>

--- a/src/templates/combat/combatant.hbs
+++ b/src/templates/combat/combatant.hbs
@@ -41,7 +41,9 @@
     {{/if}}
     <div class="cosmere-combatant-buttons">
         {{#if this.owner}}
-        <a class="cosmere-turn-speed-control" role="button" data-tooltip="COSMERE.Combat.ToggleTurn" data-control="toggleSpeed"></a>  
+        {{#unless this.isBoss}}
+        <a class="cosmere-turn-speed-control" role="button" data-tooltip="COSMERE.Combat.ToggleTurn" data-control="toggleSpeed"></a>
+        {{/unless}} 
         {{/if}}
         <a class="cosmere-activate-control {{#if this.activated}}cosmere-activate-control-activated{{/if}}" data-tooltip="COSMERE.Combat.Activate" {{#if this.owner}}data-control="activateCombatant"{{/if}}></a>    
     </div>


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
For combatants that are adversaries with the boss role, this PR introduces two turns (one fast, one slow) to the combat tracker, rather than the usual one. The turn speed toggle is removed because it's unnecessary. Because both turns are tied to the same combatant, both turns are removed when the combatant is removed. Turn activation is tracked separately.

**Related Issue**  
Closes #218 

**How Has This Been Tested?**  
1. Create an adversary actor
2. Change the adversary's role to Boss
3. Add the actor to a scene, then toggle combat state on the token
4. Behold!
5. Create additional actors of various types (characters, and adversaries of other roles) to confirm that there is no regression, and that they continue to work as expected.
6. Toggle different turn activations, and confirm that they act independently and reset correctly.

**Screenshots (if applicable)**
The boss on the tracker:
![A boss added to the combat tracker](https://github.com/user-attachments/assets/120aaa98-49f0-4d21-b1b9-8f9ad962e711)
The boss with a slow character:
![A boss on the combat tracker with a slow character](https://github.com/user-attachments/assets/68f221df-8052-43df-bc61-7d0f48708152)
The boss with a fast character:
![A boss on the combat tracker with a fast character](https://github.com/user-attachments/assets/d08b0e9b-df17-4d6f-95fb-de7604bdb910)
The boss with a character and other adversaries of different roles:
![A boss, character, and other adversaries on the combat tracker](https://github.com/user-attachments/assets/acc343b4-f3a4-462d-89f7-084fdcc0af7b)
Differing activation status for properly tracking boss turns:
![A boss with differing activation status between its turns](https://github.com/user-attachments/assets/ed3c7083-e2a3-4615-9a11-5d1189a53bdd)


**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: 12.331


