### PR TITLE
fix(item sheets): fix ctrl-s functionality on item descriptions

### DIFF
--- a/src/system/applications/item/talent-sheet.ts
+++ b/src/system/applications/item/talent-sheet.ts
@@ -58,7 +58,7 @@ export class TalentItemSheet extends BaseItemSheet {
 
     /* --- Form --- */
 
-    protected static onFormEvent(
+    protected static async onFormEvent(
         this: TalentItemSheet,
         event: Event,
         form: HTMLFormElement,
@@ -71,7 +71,7 @@ export class TalentItemSheet extends BaseItemSheet {
             formData.set('system.path', null);
 
         // Invoke super
-        super.onFormEvent(event, form, formData);
+        await super.onFormEvent(event, form, formData);
     }
 
     /* --- Context --- */


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR restores ctrl-s functionality to item sheet descriptions, immediately closing the editor when the user saves its content.

**Related Issue**  
Closes #241 

**How Has This Been Tested?**  
1. Create any item
2. Go to edit all three descriptions
3. Enter some content
4. Hit ctrl-s (or cmd-s if on a Mac)
5. Confirm that the editor view closes, and you are returned to the main description view
6. Edit and save again to confirm that the values update as expected

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: 12.331.
