### PR TITLE
fix(common actor data): fix issue causing defense bonus to be included twice in defense value

### DIFF
--- a/src/system/data/actor/common.ts
+++ b/src/system/data/actor/common.ts
@@ -527,9 +527,6 @@ export class CommonActorDataModel<
 
         // Derive defenses
         (Object.keys(this.defenses) as AttributeGroup[]).forEach((group) => {
-            // Get bonus
-            const bonus = this.defenses[group].bonus;
-
             // Get attributes
             const attrs = CONFIG.COSMERE.attributeGroups[group].attributes;
 
@@ -540,7 +537,7 @@ export class CommonActorDataModel<
             const attrsSum = attrValues.reduce((sum, v) => sum + v, 0);
 
             // Assign defense
-            this.defenses[group].derived = 10 + attrsSum + bonus;
+            this.defenses[group].derived = 10 + attrsSum;
         });
 
         // Derive skill modifiers


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR fixes a bug causing any defense bonus to be applied twice.

**Related Issue**  
Closes #255 

**How Has This Been Tested?**  
1. Open character sheet
2. Add effect with attribute key `system.defenses.phy.bonus` and value `1`
3. Toggle effect on
4. Physical defense goes up by 1

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: [insert version here].