### PR TITLE
fix(active effects): apply formula total to value rather than evaluated formula

### DIFF
--- a/src/system/documents/active-effect.ts
+++ b/src/system/documents/active-effect.ts
@@ -21,7 +21,7 @@ function tryApplyRollData(actor: Actor, value: string): string {
         const data = actor.getRollData() as AnyObject;
 
         // Treat the change value as a formula and evaluate it
-        value = new Roll(value, data).evaluateSync().formula;
+        value = new Roll(value, data).evaluateSync().total.toString();
         return value;
     } catch {
         return value;


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR fixes a bug causing math expressions in active effect values to result in `NaN`.

**Related Issue**  
Closes #259 

**How Has This Been Tested?**  
1. Open character sheet
2. Add active effect
3. Set attribute key to `system.resources.inv.max.bonus` and value to `1 + 1`
4. Investiture max increases by 2

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331