### PR TITLE
Feat/description expansion default setting #274

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -596,7 +596,7 @@
                         "Y": {
                             "Label": "Y"
                         }
-                    }  
+                    }
                 }
             },
             "Activation": {
@@ -879,7 +879,7 @@
               "ShortHeader": "Short Description",
               "ChatHeader": "Chat Description",
               "Collapsible": "Toggle Collapsible",
-              "Edit": "Edit Description"  
+              "Edit": "Edit Description"
             },
             "Effects": {
                 "Label": "Effects",
@@ -1067,7 +1067,7 @@
                 "OutOfBounds": "The selected bounds would place at least one talent outside the tree."
             },
             "Notification": {
-                
+
             }
         },
         "PickDiceResult": {
@@ -1208,7 +1208,7 @@
         "enableOverlayButtons": {
             "name": "Enable Overlay Buttons",
             "hint": "When outputting a skill test or damage roll, enable overlay buttons on the chat message that offer additional functionality for the roll."
-        },         
+        },
         "enableApplyButtons": {
             "name": "Enable Apply Buttons",
             "hint": "When outputting a damage roll, enable buttons on the chat message that allow for damage or healing to be applied to tokens, or to reduce focus from those tokens."
@@ -1228,6 +1228,10 @@
                 "PrioritiseTargeted": "Prioritise Targeted Tokens"
             }
         },
+		"expandDescriptionByDefault": {
+			"name": "Expand Item Description By Default",
+			"hint": "Determines whether the description section of an item should be expanded by default when opening the item sheet."
+		},
         "systemTheme": {
             "name": "Preferred System Theme",
             "hint": "Specify the themed set of colours to use for system documents and interface elements. The selected theme will respect the prefered Dark/Light mode selected in the core settings."

--- a/src/system/applications/item/base.ts
+++ b/src/system/applications/item/base.ts
@@ -328,6 +328,9 @@ export class BaseItemSheet extends TabsApplicationMixin(
                 this.item.system.description!.chat!,
             );
         }
+        const expandDefaultSetting =
+            game.settings?.get('cosmere-rpg', 'expandDescriptionByDefault') ??
+            false;
         return {
             ...(await super._prepareContext(options)),
             item: this.item,
@@ -341,6 +344,7 @@ export class BaseItemSheet extends TabsApplicationMixin(
             chatDescHtml: enrichedChatDescValue,
             proseDescName: this.proseDescName,
             proseDescHtml: this.proseDescHtml,
+            expandDefault: expandDefaultSetting,
         };
     }
 

--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -13,7 +13,7 @@ export const SETTINGS = {
     CHAT_ENABLE_APPLY_BUTTONS: 'enableApplyButtons',
     CHAT_ALWAYS_SHOW_BUTTONS: 'alwaysShowApplyButtons',
     APPLY_BUTTONS_TO: 'applyButtonsTo',
-    DESCRIPTION_EXPAND_DEFAULT: 'expandDescriptionByDefault',
+    SHEET_EXPAND_DESCRIPTION_DEFAULT: 'expandDescriptionByDefault',
     SYSTEM_THEME: 'systemTheme',
 } as const;
 
@@ -45,20 +45,25 @@ export function registerSystemSettings() {
         type: String,
     });
 
-    // SHEET SETTINGS (temporarily disabled since there are no sheet options for now)
-    // const sheetOptions = [
-    // ];
+    // SHEET SETTINGS
+    const sheetOptions = [
+        {
+            name: SETTINGS.SHEET_EXPAND_DESCRIPTION_DEFAULT,
+            default: false,
+            scope: 'client',
+        },
+    ];
 
-    // sheetOptions.forEach((option) => {
-    //     game.settings!.register(SYSTEM_ID, option.name, {
-    //         name: game.i18n!.localize(`SETTINGS.${option.name}.name`),
-    //         hint: game.i18n!.localize(`SETTINGS.${option.name}.hint`),
-    //         scope: 'world',
-    //         config: true,
-    //         type: Boolean,
-    //         default: option.default,
-    //     });
-    // });
+    sheetOptions.forEach((option) => {
+        game.settings!.register(SYSTEM_ID, option.name, {
+            name: game.i18n!.localize(`SETTINGS.${option.name}.name`),
+            hint: game.i18n!.localize(`SETTINGS.${option.name}.hint`),
+            scope: option.scope as 'client' | 'world' | undefined,
+            config: true,
+            type: Boolean,
+            default: option.default,
+        });
+    });
 
     // ROLL SETTINGS
     const rollOptions = [
@@ -120,19 +125,6 @@ export function registerSystemSettings() {
                 `SETTINGS.${SETTINGS.APPLY_BUTTONS_TO}.choices.PrioritiseTargeted`,
             ),
         },
-    });
-
-    game.settings!.register(SYSTEM_ID, SETTINGS.DESCRIPTION_EXPAND_DEFAULT, {
-        name: game.i18n!.localize(
-            `SETTINGS.${SETTINGS.DESCRIPTION_EXPAND_DEFAULT}.name`,
-        ),
-        hint: game.i18n!.localize(
-            `SETTINGS.${SETTINGS.DESCRIPTION_EXPAND_DEFAULT}.hint`,
-        ),
-        scope: 'client',
-        config: true,
-        type: Boolean,
-        default: false,
     });
 }
 

--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -13,6 +13,7 @@ export const SETTINGS = {
     CHAT_ENABLE_APPLY_BUTTONS: 'enableApplyButtons',
     CHAT_ALWAYS_SHOW_BUTTONS: 'alwaysShowApplyButtons',
     APPLY_BUTTONS_TO: 'applyButtonsTo',
+    DESCRIPTION_EXPAND_DEFAULT: 'expandDescriptionByDefault',
     SYSTEM_THEME: 'systemTheme',
 } as const;
 
@@ -119,6 +120,19 @@ export function registerSystemSettings() {
                 `SETTINGS.${SETTINGS.APPLY_BUTTONS_TO}.choices.PrioritiseTargeted`,
             ),
         },
+    });
+
+    game.settings!.register(SYSTEM_ID, SETTINGS.DESCRIPTION_EXPAND_DEFAULT, {
+        name: game.i18n!.localize(
+            `SETTINGS.${SETTINGS.DESCRIPTION_EXPAND_DEFAULT}.name`,
+        ),
+        hint: game.i18n!.localize(
+            `SETTINGS.${SETTINGS.DESCRIPTION_EXPAND_DEFAULT}.hint`,
+        ),
+        scope: 'client',
+        config: true,
+        type: Boolean,
+        default: false,
     });
 }
 

--- a/src/templates/item/partials/item-description-tab.hbs
+++ b/src/templates/item/partials/item-description-tab.hbs
@@ -1,5 +1,5 @@
 {{#with (lookup tabsMap "description") as |tab|}}
-<div class="tab tab-content {{tab.cssClass}}" data-tab="description" data-group="primary">    
+<div class="tab tab-content {{tab.cssClass}}" data-tab="description" data-group="primary">
     {{#if @root.isUpdatingDescription}}
     <prose-mirror name="{{@root.proseDescName}}" data-document-u-u-i-d="{{@root.item.uuid}}"
          value = "{{@root.proseDescHtml}}" collaborate="true">
@@ -7,7 +7,7 @@
     </prose-mirror>
     {{else}}
     <div class="description-list">
-        <div class="description collapsible" description-type="value">
+        <div class="description collapsible {{#if @root.expandDefault}}expanded{{/if}}" description-type="value">
             <h2 class="header">
                 <span class="title">{{localize "COSMERE.Sheet.Descriptions.DescriptionHeader"}}</span>
                 {{#if @root.editable}}


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Implements the ability to toggle whether the item sheet's main description field is expanded by default or not (defaults to false).

**Related Issue**
Closes #274.

**How Has This Been Tested?**  
Tested by toggling the setting and opening any item sheet.

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/9d7b2117-2b40-420f-b7d7-0df79931f4dc)
![image](https://github.com/user-attachments/assets/514a8a81-97cb-474f-805b-c64a1d76c2fe)


**Checklist:**  
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331.

**Additional context**  
N/A
