### PR TITLE
fix: html field event propogation

### DIFF
--- a/src/system/applications/actor/base.ts
+++ b/src/system/applications/actor/base.ts
@@ -214,6 +214,8 @@ export class BaseActorSheet<
     }
 
     private static async editHtmlField(this: BaseActorSheet, event: Event) {
+        event.stopPropagation();
+
         // Get html field element
         const fieldElement = $(event.target!).closest('[field-type]');
 
@@ -381,7 +383,6 @@ export class BaseActorSheet<
     /* --- Event handlers --- */
 
     protected onClickCollapsibleHtmlField(event: JQuery.ClickEvent) {
-        event.stopPropagation();
         const target = event.currentTarget as HTMLElement;
         target?.classList.toggle('expanded');
     }

--- a/src/system/applications/item/base.ts
+++ b/src/system/applications/item/base.ts
@@ -360,6 +360,8 @@ export class BaseItemSheet extends TabsApplicationMixin(
     /* --- Actions --- */
 
     private static async editDescription(this: BaseItemSheet, event: Event) {
+        event.stopPropagation();
+
         // Get description element
         const descElement = $(event.target!).closest('[description-type]');
 
@@ -405,7 +407,6 @@ export class BaseItemSheet extends TabsApplicationMixin(
     /* --- Event handlers --- */
 
     private onClickCollapsible(event: JQuery.ClickEvent) {
-        event.stopPropagation();
         const target = event.currentTarget as HTMLElement;
         target?.classList.toggle('expanded');
     }


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue where event propagation on html fields prevented the edit buttons from being clicked.

**Related Issue**  
Fixes regression caused by #281.

**How Has This Been Tested?**  
Ensured edit buttons work on actor and item html fields.

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: [insert version here].
