### PR TITLE
feat(talent trees): add support for nested talent trees

### DIFF
--- a/src/style/module.scss
+++ b/src/style/module.scss
@@ -3,6 +3,7 @@
 @import './style/sidebar/combat.scss';
 @import './style/dialog.scss';
 @import './style/components.scss';
+@import './tooltip.scss';
 
 .application.sheet,
 .application.dialog {
@@ -314,37 +315,6 @@
             color: var(--cosmere-color-text-accent);
             width: 24px;
             text-align: center;
-        }
-    }
-
-    .prerequisites {
-        display: flex;
-        flex-wrap: wrap;
-        margin: 0.5em 0;
-
-        .prerequisite {
-            border: 1px solid var(--cosmere-color-dark-5);
-            background-color: var(--cosmere-color-dark-2);
-            border-radius: .2rem;
-            padding: 0 .2rem;
-            margin: 0 .2rem;
-
-            > i {
-                font-size: .8rem;
-                line-height: 1.3;
-            }
-
-            &.unmet {
-                color: var(--cosmere-color-complication-text);
-                border-color: var(--cosmere-color-complication-text);
-                background-color: var(--cosmere-color-complication-background-dark);
-            }
-
-            &.met {
-                color: var(--cosmere-color-opportunity-text);
-                border-color: var(--cosmere-color-opportunity-text);
-                background-color: var(--cosmere-color-opportunity-background-dark);
-            }
         }
     }
 }

--- a/src/style/sheets/item/talent-tree.scss
+++ b/src/style/sheets/item/talent-tree.scss
@@ -1,4 +1,4 @@
-.sheet.item.talent-tree {
+.application.sheet.item.talent-tree {
     .window-content {
         padding: 0;
 
@@ -10,6 +10,8 @@
 }
 
 app-talent-tree-view{
+    position: relative;
+
     > .view {
         width: 100%;
         height: 100%;

--- a/src/style/tooltip.scss
+++ b/src/style/tooltip.scss
@@ -1,0 +1,63 @@
+#tooltip {
+    .talenttip {
+        .header {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            position: relative;
+    
+            height: 3rem;
+    
+            h4 {
+                font-size: 2rem;
+                font-weight: bold;
+                margin: 0;
+                text-shadow: 0 0 0.5rem black;
+            }
+    
+            .bg-image {
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+                background-size: cover;
+                background-position: center;
+                background-repeat: no-repeat;
+                filter: blur(5px);
+                z-index: -1;
+            }
+        }
+
+        .prerequisites {
+            display: flex;
+            flex-wrap: wrap;
+            margin: 0.5em 0;
+    
+            .prerequisite {
+                border: 1px solid var(--cosmere-color-dark-5);
+                background-color: var(--cosmere-color-dark-2);
+                border-radius: .2rem;
+                padding: 0 .2rem;
+                margin: 0 .2rem;
+    
+                > i {
+                    font-size: .8rem;
+                    line-height: 1.3;
+                }
+    
+                &.unmet {
+                    color: var(--cosmere-color-complication-text);
+                    border-color: var(--cosmere-color-complication-text);
+                    background-color: var(--cosmere-color-complication-background-dark);
+                }
+    
+                &.met {
+                    color: var(--cosmere-color-opportunity-text);
+                    border-color: var(--cosmere-color-opportunity-text);
+                    background-color: var(--cosmere-color-opportunity-background-dark);
+                }
+            }
+        }
+    }
+}

--- a/src/system/applications/item/components/talent-tree/canvas/elements/connection.ts
+++ b/src/system/applications/item/components/talent-tree/canvas/elements/connection.ts
@@ -5,16 +5,20 @@ import { GlowFilter } from '@pixi/filter-glow';
 import { PIXICanvasApplication, Drawable } from '@system/applications/canvas';
 import { TalentTreeWorld } from '../world';
 
+// Nodes
+import { BaseNode, TalentNode, TalentTreeNode } from './nodes';
+
 // Types
 import { TalentTree } from '@system/types/item';
 
 // Math
 import { Ray } from '@system/math';
+import { GRID_SIZE } from '../../constants';
 
 // Constants
 const HIT_AREA_SIZE = 5;
 
-export class Connection extends Drawable {
+export abstract class BaseConnection extends Drawable {
     // Re-declare canvas type
     public declare readonly canvas: PIXICanvasApplication<
         typeof TalentTreeWorld
@@ -22,13 +26,13 @@ export class Connection extends Drawable {
 
     public selected = false;
 
-    private fromPos: PIXI.IPointData;
-    private toPos: PIXI.IPointData;
+    protected fromPos: PIXI.IPointData;
+    protected toPos: PIXI.IPointData;
 
     public constructor(
         canvas: PIXICanvasApplication,
-        public readonly from: TalentTree.TalentNode,
-        public readonly to: TalentTree.TalentNode,
+        public readonly from: BaseNode,
+        public readonly to: BaseNode,
         public readonly path?: PIXI.Point[],
     ) {
         super(canvas);
@@ -41,9 +45,9 @@ export class Connection extends Drawable {
         // Set filters
         this.filters = [
             new GlowFilter({
-                distance: 11,
+                distance: 15,
                 outerStrength: 1,
-                alpha: 0.2,
+                alpha: 0,
             }),
             new PIXI.ColorMatrixFilter(),
         ];
@@ -61,41 +65,23 @@ export class Connection extends Drawable {
         return this.filters![1] as PIXI.ColorMatrixFilter;
     }
 
-    /**
-     * Whether the connection is obtained by the context actor.
-     * A connection is obtained if the context actor both the talents represented by the FROM and TO nodes.
-     */
-    public get isConnectionObtained() {
-        // Get context actor
-        const actor = this.canvas.world.contextActor;
-        if (!actor) return false;
-
-        // Check if the actor has the talents
-        return (
-            actor.hasTalent(this.from.talentId) &&
-            actor.hasTalent(this.to.talentId)
-        );
+    public get parentNode() {
+        const parent = this.parent?.parent;
+        return parent instanceof TalentTreeNode ? parent : null;
     }
 
-    /**
-     * Whether the connection is available to be unlocked.
-     * A connection is available if the TO talent is obtained and the FROM talent is not obtained,
-     * and the context actor has the required prerequisites for the FROM talent.
-     */
-    public get isConnectionAvailable() {
-        // Get context actor
-        const actor = this.canvas.world.contextActor;
-        if (!actor) return false;
+    public abstract get isObtained(): boolean;
+    public abstract get isAvailable(): boolean;
 
-        // Ensure the actor has the TO talent
-        if (!actor.hasTalent(this.to.talentId)) return false;
-
-        // Ensure the actor does NOT have the FROM talent
-        if (actor.hasTalent(this.from.talentId)) return false;
-
-        // Check prerequisites
-        return actor.hasTalentPreRequisites(this.to.prerequisites);
+    protected get fromOffset(): PIXI.IPointData {
+        return { x: 0, y: 0 };
     }
+
+    protected get toOffset(): PIXI.IPointData {
+        return { x: 0, y: 0 };
+    }
+
+    /* --- Public methods --- */
 
     public select() {
         this.selected = true;
@@ -108,14 +94,19 @@ export class Connection extends Drawable {
     }
 
     public refresh() {
-        if (this.canvas.world.editable) {
+        if (this.parentNode?.contentEditable) {
             this.interactive = true;
-            this.cursor = 'pointer'; // TODO: Depends on view
+            this.cursor = 'pointer';
 
             // Generate hit area
             this.generateHitArea();
+        } else {
+            this.interactive = false;
+            this.cursor = 'default';
         }
     }
+
+    /* --- Lifecycle --- */
 
     public override _update() {
         // Check if the from or to node has moved
@@ -133,6 +124,8 @@ export class Connection extends Drawable {
         }
     }
 
+    /* --- Drawing --- */
+
     public override _draw() {
         // Draw path
         this.drawPath();
@@ -145,40 +138,40 @@ export class Connection extends Drawable {
         if (
             !this.canvas.world.editable &&
             !!this.canvas.world.contextActor &&
-            !this.isConnectionObtained
+            !this.isObtained
         ) {
-            if (this.isConnectionAvailable) {
+            this.glowFilter.alpha = 0;
+
+            if (this.isAvailable) {
                 this.colorMatrixFilter.greyscale(0.1, false);
+                this.alpha = 1;
             } else {
-                this.colorMatrixFilter.greyscale(0.05, false);
+                this.colorMatrixFilter.greyscale(0.01, false);
+                this.alpha = 0.5;
             }
         } else {
             this.colorMatrixFilter.reset();
+            this.glowFilter.alpha = 0.4;
+            this.alpha = 1;
         }
     }
 
-    private drawPath() {
+    protected drawPath() {
         // Set line style
-        this.lineStyle({
-            width: 3,
-            color:
-                this.canvas.world.editable && !!this.canvas.world.contextActor
-                    ? !this.selected
-                        ? 'white'
-                        : 'gold'
-                    : this.isConnectionObtained
-                      ? '#7ba8fc'
-                      : 'white',
-        });
+        this.lineStyle(this.getLineStyle());
 
         if (!this.path || this.path.length === 0) {
             this.moveTo(
-                this.from.position.x + this.from.size.width / 2,
-                this.from.position.y + this.from.size.height / 2,
+                this.from.position.x +
+                    this.from.size.width / 2 +
+                    this.fromOffset.x,
+                this.from.position.y +
+                    this.from.size.height / 2 +
+                    this.fromOffset.y,
             );
             this.lineTo(
-                this.to.position.x + this.to.size.width / 2,
-                this.to.position.y + this.to.size.height / 2,
+                this.to.position.x + this.to.size.width / 2 + this.toOffset.x,
+                this.to.position.y + this.to.size.height / 2 + this.toOffset.y,
             );
         } else {
             for (let i = 0; i < this.path.length; i++) {
@@ -192,18 +185,36 @@ export class Connection extends Drawable {
         }
     }
 
+    protected getLineStyle() {
+        return {
+            width: 3,
+            color:
+                this.canvas.world.editable && !!this.canvas.world.contextActor
+                    ? !this.selected
+                        ? 'white'
+                        : 'gold'
+                    : this.isObtained
+                      ? '#7ba8fc'
+                      : 'white',
+        };
+    }
+
+    /* --- Helpers --- */
+
     /**
      * Helper function to generate a polygon hit area for the connection.
      * This is used to make the connection clickable.
      */
-    private generateHitArea() {
+    protected generateHitArea() {
         const from = new PIXI.Point(
-            this.from.position.x + this.from.size.width / 2,
-            this.from.position.y + this.from.size.height / 2,
+            this.from.position.x + this.from.size.width / 2 + this.fromOffset.x,
+            this.from.position.y +
+                this.from.size.height / 2 +
+                this.fromOffset.y,
         );
         const to = new PIXI.Point(
-            this.to.position.x + this.to.size.width / 2,
-            this.to.position.y + this.to.size.height / 2,
+            this.to.position.x + this.to.size.width / 2 + this.toOffset.x,
+            this.to.position.y + this.to.size.height / 2 + this.toOffset.y,
         );
 
         const path = [to, ...(this.path ?? []), from].map(
@@ -329,5 +340,106 @@ export class Connection extends Drawable {
         });
 
         this.hitArea = new PIXI.Polygon(polygonPoints);
+    }
+}
+
+export class TalentsConnection extends BaseConnection {
+    // Re-declare from & to
+    public declare readonly from: TalentNode;
+    public declare readonly to: TalentNode;
+
+    public constructor(
+        canvas: PIXICanvasApplication,
+        from: TalentNode,
+        to: TalentNode,
+        path?: PIXI.Point[],
+    ) {
+        super(canvas, from, to, path);
+    }
+
+    /* --- Accessors --- */
+
+    /**
+     * Whether the connection is obtained by the context actor.
+     * A connection is obtained if the context actor both the talents represented by the FROM and TO nodes.
+     */
+    public get isObtained() {
+        // Get context actor
+        const actor = this.canvas.world.contextActor;
+        if (!actor) return false;
+
+        // Check if the actor has the talents
+        return (
+            actor.hasTalent(this.from.data.talentId) &&
+            actor.hasTalent(this.to.data.talentId)
+        );
+    }
+
+    /**
+     * Whether the connection is available to be unlocked.
+     * A connection is available if the TO talent is obtained and the FROM talent is not obtained,
+     * and the context actor has the required prerequisites for the FROM talent.
+     */
+    public get isAvailable() {
+        // Get context actor
+        const actor = this.canvas.world.contextActor;
+        if (!actor) return false;
+
+        // Ensure the actor has the TO talent
+        if (!actor.hasTalent(this.to.data.talentId)) return false;
+
+        // Ensure the actor does NOT have the FROM talent
+        if (actor.hasTalent(this.from.data.talentId)) return false;
+
+        // Check prerequisites
+        return actor.hasTalentPreRequisites(this.from.data.prerequisites);
+    }
+}
+
+export class NestedTreeConnection extends BaseConnection {
+    // Re-declare from & to
+    public declare readonly from: TalentTreeNode;
+    public declare readonly to: TalentNode;
+
+    public constructor(
+        canvas: PIXICanvasApplication,
+        from: TalentTreeNode,
+        to: TalentNode,
+        path?: PIXI.Point[],
+    ) {
+        super(canvas, from, to, path);
+    }
+
+    /* --- Accessors --- */
+
+    public get isObtained() {
+        // Get context actor
+        const actor = this.canvas.world.contextActor;
+        if (!actor) return false;
+
+        // Check if the actor has the talent and tree
+        return actor.hasTalent(this.to.data.talentId) && this.from.isObtained;
+    }
+
+    public get isAvailable() {
+        // Get context actor
+        const actor = this.canvas.world.contextActor;
+        if (!actor) return false;
+
+        // Ensure the actor has the TO talent
+        if (!actor.hasTalent(this.to.data.talentId)) return false;
+
+        // Check if tree is available
+        return this.from.isAvailable;
+    }
+
+    protected get fromOffset() {
+        return {
+            x:
+                (this.from.contentBounds?.x ?? 0) -
+                GRID_SIZE / 2 +
+                (this.from.contentBounds?.width ?? 0) / 2,
+            y: (this.from.contentBounds?.y ?? 0) - GRID_SIZE,
+        };
     }
 }

--- a/src/system/applications/item/components/talent-tree/canvas/elements/index.ts
+++ b/src/system/applications/item/components/talent-tree/canvas/elements/index.ts
@@ -1,3 +1,3 @@
 export { TalentTreeCanvasElement as TalentTree } from './tree';
-export { Connection } from './connection';
+export { BaseConnection, TalentsConnection } from './connection';
 export * as Nodes from './nodes';

--- a/src/system/applications/item/components/talent-tree/canvas/elements/nodes/index.ts
+++ b/src/system/applications/item/components/talent-tree/canvas/elements/nodes/index.ts
@@ -1,2 +1,3 @@
 export { BaseNode } from './types';
 export { TalentNode } from './talent-node';
+export { TalentTreeNode } from './tree-node';

--- a/src/system/applications/item/components/talent-tree/canvas/elements/nodes/tree-node.ts
+++ b/src/system/applications/item/components/talent-tree/canvas/elements/nodes/tree-node.ts
@@ -1,0 +1,536 @@
+import { TalentTreeItem } from '@system/documents/item';
+import { TalentTree } from '@system/types/item';
+
+// Import base node
+import { BaseNode } from './types';
+
+// Canvas
+import { PIXICanvasApplication, Drawable } from '@system/applications/canvas';
+import { TalentTreeWorld, MouseOverNodeEvent } from '../../world';
+import { TalentNode } from './talent-node';
+import {
+    BaseConnection,
+    TalentsConnection,
+    NestedTreeConnection,
+} from '../connection';
+
+// Constants
+import { SUB_GRID_SIZE, GRID_SIZE } from '../../../constants';
+
+class Layer<
+    T extends PIXI.DisplayObject = PIXI.DisplayObject,
+> extends Drawable {
+    public declare children: T[];
+
+    public constructor(canvas: PIXICanvasApplication, zIndex: number) {
+        super(canvas);
+
+        this.zIndex = zIndex;
+
+        this.filters = [new PIXI.ColorMatrixFilter()];
+    }
+
+    public get colorMatrixFilter() {
+        return this.filters![0] as PIXI.ColorMatrixFilter;
+    }
+
+    /**
+     * Initializes any uninitialized children.
+     */
+    public async initializeChildren() {
+        await Promise.all(
+            this.children
+                .filter(
+                    (child) => child instanceof Drawable && !child.initialized,
+                )
+                .map((child) => (child as unknown as Drawable).initialize()),
+        );
+    }
+}
+
+class TreeHeader extends Drawable {
+    private text: PIXI.Text;
+
+    public constructor(private readonly node: TalentTreeNode) {
+        super(node.canvas);
+
+        // Add text
+        this.text = new PIXI.Text(this.node.item.name, {
+            fontSize: 16,
+            fill: 'white',
+            fontFamily: 'Penumbra Serif Std',
+            fontWeight: 'bold',
+        });
+
+        // Set text anchor
+        this.text.anchor.set(0.5, 0.5);
+
+        // Add text to the drag handle
+        this.addChild(this.text);
+
+        // Check interactivity
+        if (!this.node.editable) {
+            this.eventMode = 'none';
+            this.cursor = 'default';
+        }
+    }
+
+    protected override _draw() {
+        this.clear();
+
+        if (this.node.isRoot) return;
+
+        // Draw drag handle
+        this.beginFill('#010e2d');
+        this.drawRect(
+            this.node.contentBounds!.x - SUB_GRID_SIZE,
+            this.node.contentBounds!.y - SUB_GRID_SIZE * 5,
+            this.node.contentBounds!.width + SUB_GRID_SIZE * 2,
+            SUB_GRID_SIZE * 4,
+        );
+
+        // Update text position
+        this.text.position.set(
+            this.node.contentBounds!.x + this.node.contentBounds!.width / 2,
+            this.node.contentBounds!.y - SUB_GRID_SIZE * 3,
+        );
+    }
+}
+
+class TreeBackground extends Drawable {
+    public constructor(private readonly node: TalentTreeNode) {
+        super(node.canvas);
+
+        // Check interactivity
+        if (!this.node.editable) {
+            this.eventMode = 'none';
+            this.cursor = 'default';
+        }
+    }
+
+    protected override _draw() {
+        this.clear();
+
+        if (this.node.isRoot) return;
+
+        // Draw background
+        this.beginFill('#111', 0.7);
+        this.drawRect(
+            this.node.contentBounds!.x - SUB_GRID_SIZE,
+            this.node.contentBounds!.y - SUB_GRID_SIZE * 5,
+            this.node.contentBounds!.width + SUB_GRID_SIZE * 2,
+            this.node.contentBounds!.height + SUB_GRID_SIZE * 6,
+        );
+        this.endFill();
+    }
+}
+
+export class TalentTreeNode extends BaseNode {
+    // Redeclare data type
+    public declare readonly data: TalentTree.TreeNode & { isRoot?: boolean };
+    public declare readonly canvas: PIXICanvasApplication<
+        typeof TalentTreeWorld
+    >;
+
+    private nodesLayer;
+    private connectionsLayer;
+    private header?: TreeHeader;
+
+    private _contentBounds?: PIXI.Rectangle;
+
+    public constructor(
+        canvas: PIXICanvasApplication<typeof TalentTreeWorld>,
+        data: TalentTree.TreeNode & { isRoot?: boolean },
+        public readonly item: TalentTreeItem,
+    ) {
+        super(canvas, data);
+
+        if (!this.isRoot) {
+            this.addChild(new TreeBackground(this));
+        }
+
+        this.name = item.name;
+
+        // Create layers
+        this.nodesLayer = new Layer<BaseNode>(this.canvas, 2);
+        this.connectionsLayer = new Layer<BaseConnection>(this.canvas, 1);
+
+        // Add layers
+        this.addChild(this.connectionsLayer);
+        this.addChild(this.nodesLayer);
+
+        if (!this.isRoot) {
+            this.header = new TreeHeader(this);
+            this.addChild(this.header);
+        }
+    }
+
+    public override async _initialize() {
+        await this.refresh();
+    }
+
+    /* --- Accessors --- */
+
+    public get nodes() {
+        return this.nodesLayer?.children as BaseNode[] | undefined;
+    }
+
+    public get connections() {
+        return this.connectionsLayer?.children as BaseConnection[] | undefined;
+    }
+
+    public get isRoot(): boolean {
+        return !!this.data.isRoot;
+    }
+
+    public get editable() {
+        return this.canvas.world.editable;
+    }
+
+    public get contentEditable() {
+        return this.editable && this.isRoot;
+    }
+
+    public get contentBounds() {
+        return this._contentBounds;
+    }
+
+    public get rootTalents() {
+        return this.item.system.nodes.filter(
+            (node) =>
+                node.type === TalentTree.Node.Type.Talent &&
+                node.connections.size === 0,
+        ) as TalentTree.TalentNode[];
+    }
+
+    public get isObtained() {
+        // Get context actor
+        const actor = this.canvas.world.contextActor;
+        if (!actor) return false;
+
+        // Check if the actor has any of the root talents
+        return this.rootTalents.some((talent) =>
+            actor.hasTalent(talent.talentId),
+        );
+    }
+
+    public get isAvailable() {
+        // Get context actor
+        const actor = this.canvas.world.contextActor;
+        if (!actor) return false;
+
+        // Check if the actor meets the prerequisites for any of the root talents
+        return this.rootTalents.some(
+            (talent) =>
+                !actor.hasTalent(talent.id) &&
+                actor.hasTalentPreRequisites(talent.prerequisites),
+        );
+    }
+
+    /* --- Drawing --- */
+
+    protected override _draw() {
+        if (this.isRoot) return;
+
+        // Draw bounds
+        this.lineStyle({
+            width: 1,
+            color: '#d0a552',
+            alignment: 1,
+        });
+        this.drawRect(
+            this.contentBounds!.x - SUB_GRID_SIZE,
+            this.contentBounds!.y - SUB_GRID_SIZE * 5,
+            this.contentBounds!.width + SUB_GRID_SIZE * 2,
+            this.contentBounds!.height + SUB_GRID_SIZE * 6,
+        );
+    }
+
+    /* --- Public functions --- */
+
+    public async refresh() {
+        await super.refresh();
+        await this.refreshContents();
+    }
+
+    /* --- Helpers --- */
+
+    private async refreshContents() {
+        const dataNodes = Array.from(this.item.system.nodes);
+
+        // Check if any new nodes have been added
+        const addedNodes = dataNodes
+            .filter(
+                (node) =>
+                    !this.nodes!.some((child) => child.data.id === node.id),
+            )
+            .filter(
+                (node) => !('uuid' in node) || fromUuidSync(node.uuid) !== null,
+            );
+
+        // Add new nodes to the canvas
+        await Promise.all(
+            addedNodes.map(async (node) => {
+                if (node.type === TalentTree.Node.Type.Talent) {
+                    this.nodesLayer.addChild(new TalentNode(this.canvas, node));
+                } else if (node.type === TalentTree.Node.Type.Tree) {
+                    // Get the tree item
+                    const item = (await fromUuid(
+                        node.uuid,
+                    )) as unknown as TalentTreeItem;
+                    this.nodesLayer.addChild(
+                        new TalentTreeNode(this.canvas, node, item),
+                    );
+                }
+            }),
+        );
+
+        // Check if any nodes have been removed
+        const removedNodes = this.nodes!.filter(
+            (child) => !dataNodes.some((node) => node.id === child.data.id),
+        );
+
+        // Remove nodes from the canvas
+        removedNodes.forEach((child) => this.nodesLayer.removeChild(child));
+
+        // Get list of all node connections
+        const nodeConnections = dataNodes
+            .filter((node) => node.type === TalentTree.Node.Type.Talent)
+            .map((node) => {
+                return node.connections.map((connection) => ({
+                    fromId: node.id,
+                    toId: connection.id,
+                    path: connection.path,
+                }));
+            })
+            .flat()
+            .filter(({ fromId, toId }) => !!fromId && toId);
+
+        const treeConnections = dataNodes
+            .filter((node) => node.type === TalentTree.Node.Type.Tree)
+            .map((dataNode) => {
+                // Get the talent tree node
+                const talentTreeNode = this.nodesLayer.children.find(
+                    (child) => child.data.id === dataNode.id,
+                ) as TalentTreeNode;
+
+                return talentTreeNode.rootTalents
+                    .filter(
+                        (talentNode) =>
+                            talentNode.prerequisites.size > 0 &&
+                            talentNode.prerequisites.some(
+                                (prereq) =>
+                                    prereq.type ===
+                                        TalentTree.Node.Prerequisite.Type
+                                            .Talent &&
+                                    Array.from(prereq.talents).every((ref) =>
+                                        this.item.system.nodes.some(
+                                            (n) =>
+                                                n.type ===
+                                                    TalentTree.Node.Type
+                                                        .Talent &&
+                                                n.talentId === ref.id,
+                                        ),
+                                    ),
+                            ),
+                    )
+                    .map((talentNode) =>
+                        talentNode.prerequisites
+                            .filter(
+                                (prereq) =>
+                                    prereq.type ===
+                                    TalentTree.Node.Prerequisite.Type.Talent,
+                            )
+                            .map((prereq) =>
+                                prereq.talents
+                                    .map((ref) => ({
+                                        talentId: this.item.system.nodes.find(
+                                            (n) =>
+                                                n.type ===
+                                                    TalentTree.Node.Type
+                                                        .Talent &&
+                                                n.talentId === ref.id,
+                                        )?.id,
+                                        treeId: dataNode.id,
+                                    }))
+                                    .filter((v) => !!v.talentId),
+                            ),
+                    )
+                    .flat(2)
+                    .filter(
+                        (v, i, self) =>
+                            self.findIndex(
+                                (t) =>
+                                    t.talentId === v.talentId &&
+                                    t.treeId === v.treeId,
+                            ) === i,
+                    );
+            })
+            .flat(2);
+
+        const connections = [...nodeConnections, ...treeConnections];
+
+        // Check if any connections have been added
+        const addedConnections = connections.filter(
+            (connection) =>
+                !this.connections!.some(
+                    (child) =>
+                        ('fromId' in connection &&
+                            child.from.data.id === connection.fromId &&
+                            child.to.data.id === connection.toId) ||
+                        ('talentId' in connection &&
+                            child.from.data.id === connection.treeId &&
+                            child.to.data.id === connection.talentId),
+                ),
+        );
+
+        // Add new connections to the canvas
+        addedConnections.forEach((connection) => {
+            if ('fromId' in connection) {
+                // Find from and to nodes
+                const from = this.nodesLayer.children.find(
+                    (child) => child.data.id === connection.fromId,
+                ) as TalentNode;
+                const to = this.nodesLayer.children.find(
+                    (child) => child.data.id === connection.toId,
+                ) as TalentNode;
+
+                // Create the connection element
+                const connectionElement = new TalentsConnection(
+                    this.canvas,
+                    from,
+                    to,
+                    connection.path?.map(
+                        (point) => new PIXI.Point(point.x, point.y),
+                    ),
+                );
+                this.connectionsLayer.addChild(connectionElement);
+            } else {
+                console.log('added connection', connection, this.item.id);
+
+                // Find the talent node
+                const talentNode = this.nodesLayer.children.find(
+                    (child) => child.data.id === connection.talentId,
+                ) as TalentNode;
+
+                // Find the tree node
+                const treeNode = this.nodesLayer.children.find(
+                    (child) => child.data.id === connection.treeId,
+                ) as TalentTreeNode;
+
+                // Create the connection element
+                const connectionElement = new NestedTreeConnection(
+                    this.canvas,
+                    treeNode,
+                    talentNode,
+                );
+                this.connectionsLayer.addChild(connectionElement);
+            }
+        });
+
+        // Check if any connections have been removed
+        const removedConnections = this.connections!.filter((child) => {
+            const connection = child;
+
+            if (connection instanceof TalentsConnection) {
+                // Get the from node
+                const fromNode = dataNodes.find(
+                    (node) => node.id === connection.from.data.id,
+                );
+
+                // Check if the from node still exists and has the connection
+                return (
+                    !fromNode ||
+                    fromNode.type !== TalentTree.Node.Type.Talent ||
+                    !fromNode.connections.some(
+                        (c) => c.id === connection.to.data.id,
+                    )
+                );
+            } else {
+                // Get the from node
+                const fromTreeNode = dataNodes.find(
+                    (node) => node.id === connection.from.data.id,
+                );
+
+                const toTalentNode = dataNodes.find(
+                    (node) => node.id === connection.to.data.id,
+                );
+
+                // Check if the from and to nodes still exist
+                return (
+                    !fromTreeNode ||
+                    fromTreeNode.type !== TalentTree.Node.Type.Tree ||
+                    !toTalentNode
+                );
+            }
+        });
+
+        // Remove connections from the canvas
+        removedConnections.forEach((child) =>
+            this.connectionsLayer.removeChild(child),
+        );
+
+        const contentsChanged =
+            addedNodes.length > 0 ||
+            removedNodes.length > 0 ||
+            addedConnections.length > 0 ||
+            removedConnections.length > 0;
+
+        if (contentsChanged) {
+            // Initialize children
+            await this.nodesLayer.initializeChildren();
+        }
+
+        // Refresh nodes
+        await Promise.all(this.nodes!.map((node) => node.refresh()));
+
+        // Refresh connections
+        this.connections!.forEach((connection) => connection.refresh());
+
+        // Calculate content bounds
+        this.calculateContentBounds();
+    }
+
+    private calculateContentBounds() {
+        const leftMostPosition = Math.min(
+            ...this.nodesLayer.children.map((node) => node.data.position.x),
+        );
+        const rightMostPosition = Math.max(
+            ...this.nodesLayer.children.map((node) => {
+                if (node instanceof TalentNode) {
+                    return node.data.position.x + node.data.size.width;
+                } else if (node instanceof TalentTreeNode) {
+                    return node.data.position.x + node.contentBounds!.width;
+                } else {
+                    return 0;
+                }
+            }),
+        );
+
+        const topMostPosition = Math.min(
+            ...this.nodesLayer.children.map((node) => node.data.position.y),
+        );
+        const bottomMostPosition = Math.max(
+            ...this.nodesLayer.children.map((node) => {
+                if (node instanceof TalentNode) {
+                    return node.data.position.y + node.data.size.height;
+                } else if (node instanceof TalentTreeNode) {
+                    return node.data.position.y + node.contentBounds!.height;
+                } else {
+                    return 0;
+                }
+            }),
+        );
+
+        // Calculate width and height
+        const width = rightMostPosition - leftMostPosition;
+        const height = bottomMostPosition - topMostPosition;
+
+        this._contentBounds = new PIXI.Rectangle(
+            leftMostPosition,
+            topMostPosition,
+            width,
+            height,
+        );
+    }
+}

--- a/src/system/applications/item/components/talent-tree/canvas/elements/nodes/types.ts
+++ b/src/system/applications/item/components/talent-tree/canvas/elements/nodes/types.ts
@@ -1,7 +1,12 @@
+import { TalentTree } from '@system/types/item';
 import { PIXICanvasApplication, Drawable } from '@system/applications/canvas';
+
+// Constants
+import { GRID_SIZE } from '../../../constants';
 
 interface NodeData {
     id: string;
+    type: TalentTree.Node.Type;
     position: PIXI.IPointData;
 }
 
@@ -22,9 +27,22 @@ export abstract class BaseNode extends Drawable {
         this.cursor = 'pointer';
     }
 
-    public refresh() {
+    /* --- Accessors --- */
+
+    public get size() {
+        return {
+            width: GRID_SIZE,
+            height: GRID_SIZE,
+        };
+    }
+
+    /* --- Public functions --- */
+
+    public refresh(): Promise<void> {
         this.x = this.data.position.x;
         this.y = this.data.position.y;
+
+        return Promise.resolve();
     }
 
     public select() {

--- a/src/system/applications/item/components/talent-tree/canvas/elements/tree.ts
+++ b/src/system/applications/item/components/talent-tree/canvas/elements/tree.ts
@@ -1,38 +1,12 @@
 import { TalentTreeItem } from '@system/documents/item';
 import { TalentTree } from '@system/types/item';
-import { TalentTreeItemData } from '@system/data/item/talent-tree';
 
 // Canvas
 import { PIXICanvasApplication, Drawable } from '@system/applications/canvas';
 import { TalentTreeWorld } from '../world';
 
 // Canvas elements
-import { BaseNode, TalentNode } from './nodes';
-import { Connection } from './connection';
-
-// Constants
-import { SUB_GRID_SIZE } from '../../constants';
-
-class Layer extends Drawable {
-    public constructor(canvas: PIXICanvasApplication, zIndex: number) {
-        super(canvas);
-
-        this.zIndex = zIndex;
-    }
-
-    /**
-     * Initializes any uninitialized children.
-     */
-    public async initializeChildren() {
-        await Promise.all(
-            this.children
-                .filter(
-                    (child) => child instanceof Drawable && !child.initialized,
-                )
-                .map((child) => (child as Drawable).initialize()),
-        );
-    }
-}
+import { TalentTreeNode } from './nodes';
 
 export class TalentTreeCanvasElement extends Drawable {
     // Re-declare canvas type
@@ -40,10 +14,9 @@ export class TalentTreeCanvasElement extends Drawable {
         typeof TalentTreeWorld
     >;
 
-    public backgroundAlpha = 0.75;
+    public backgroundAlpha = 1;
 
-    private nodesLayer;
-    private connectionsLayer;
+    private rootNode: TalentTreeNode;
     private background = new PIXI.Sprite();
 
     private backgroundTexture?: PIXI.Texture;
@@ -54,21 +27,25 @@ export class TalentTreeCanvasElement extends Drawable {
     ) {
         super(canvas);
 
-        // Create layers
-        this.nodesLayer = new Layer(this.canvas, 2);
-        this.connectionsLayer = new Layer(this.canvas, 1);
-
         // Set background z-index
         this.background.zIndex = 0;
 
+        // Create root node
+        this.rootNode = new TalentTreeNode(
+            this.canvas,
+            {
+                id: this.item.id,
+                position: { x: 0, y: 0 },
+                type: TalentTree.Node.Type.Tree,
+                uuid: this.item.uuid,
+                isRoot: true,
+            },
+            this.item,
+        );
+
         // Add layers
         this.addChild(this.background);
-        this.addChild(this.connectionsLayer);
-        this.addChild(this.nodesLayer);
-    }
-
-    public override async _initialize() {
-        await this.refreshContents();
+        this.addChild(this.rootNode);
     }
 
     /* --- Accessors --- */
@@ -78,11 +55,11 @@ export class TalentTreeCanvasElement extends Drawable {
     }
 
     public get nodes() {
-        return this.nodesLayer.children as BaseNode[];
+        return this.rootNode.nodes;
     }
 
     public get connections() {
-        return this.connectionsLayer.children as Connection[];
+        return this.rootNode.connections;
     }
 
     public get editable() {
@@ -135,117 +112,6 @@ export class TalentTreeCanvasElement extends Drawable {
         }
 
         // Refresh contents
-        await this.refreshContents();
-    }
-
-    /* --- Helpers --- */
-
-    private async refreshContents() {
-        const dataNodes = Array.from(this.data.nodes);
-
-        // Check if any new nodes have been added
-        const addedNodes = dataNodes
-            .filter((node) => node.type === TalentTree.Node.Type.Talent)
-            .filter(
-                (node) =>
-                    !this.nodes.some(
-                        (child) =>
-                            child instanceof TalentNode &&
-                            child.data.id === node.id,
-                    ),
-            );
-
-        // Add new nodes to the canvas
-        addedNodes.forEach((node) => {
-            // Create the node element
-            const nodeElement = new TalentNode(this.canvas, node);
-            this.nodesLayer.addChild(nodeElement);
-        });
-
-        // Check if any nodes have been removed
-        const removedNodes = this.nodes
-            .filter((child) => child instanceof TalentNode)
-            .filter(
-                (child) => !dataNodes.some((node) => node.id === child.data.id),
-            );
-
-        // Remove nodes from the canvas
-        removedNodes.forEach((child) => this.nodesLayer.removeChild(child));
-
-        // Check if any connections have been added
-        const addedConnections = dataNodes
-            .filter((node) => node.type === TalentTree.Node.Type.Talent)
-            .map((node) => {
-                return node.connections.map((connection) => ({
-                    from: node,
-                    to: dataNodes.find(
-                        (n) => n.id === connection.id,
-                    ) as TalentTree.TalentNode,
-                    path: connection.path,
-                }));
-            })
-            .flat()
-            .filter(({ from, to }) => !!from && to)
-            .filter(
-                (connection) =>
-                    !this.connections.some(
-                        (child) =>
-                            child.from.id === connection.from.id &&
-                            child.to.id === connection.to.id,
-                    ),
-            );
-
-        // Add new connections to the canvas
-        addedConnections.forEach((connection) => {
-            // Create the connection element
-            const connectionElement = new Connection(
-                this.canvas,
-                connection.from,
-                connection.to,
-                connection.path?.map(
-                    (point) => new PIXI.Point(point.x, point.y),
-                ),
-            );
-            this.connectionsLayer.addChild(connectionElement);
-        });
-
-        // Check if any connections have been removed
-        const removedConnections = this.connections.filter((child) => {
-            const connection = child;
-
-            // Get the from node
-            const fromNode = dataNodes.find(
-                (node) => node.id === connection.from.id,
-            );
-
-            // Check if the from node still exists and has the connection
-            return (
-                !fromNode ||
-                fromNode.type !== TalentTree.Node.Type.Talent ||
-                !fromNode.connections.some((c) => c.id === connection.to.id)
-            );
-        });
-
-        // Remove connections from the canvas
-        removedConnections.forEach((child) =>
-            this.connectionsLayer.removeChild(child),
-        );
-
-        const contentsChanged =
-            addedNodes.length > 0 ||
-            removedNodes.length > 0 ||
-            addedConnections.length > 0 ||
-            removedConnections.length > 0;
-
-        if (contentsChanged) {
-            // Initialize children
-            await this.nodesLayer.initializeChildren();
-        }
-
-        // Refresh nodes
-        this.nodes.forEach((node) => node.refresh());
-
-        // Refresh connections
-        this.connections.forEach((connection) => connection.refresh());
+        await this.rootNode.refresh();
     }
 }

--- a/src/system/applications/item/components/talent-tree/canvas/world.ts
+++ b/src/system/applications/item/components/talent-tree/canvas/world.ts
@@ -35,13 +35,15 @@ export interface RightClickNodeEvent<
 > extends NodeEvent<Node> {}
 export interface MouseOverNodeEvent<
     Node extends CanvasElements.Nodes.BaseNode = CanvasElements.Nodes.BaseNode,
-> extends NodeEvent<Node> {}
+> extends NodeEvent<Node> {
+    position: PIXI.IPointData;
+}
 export interface MouseOutNodeEvent<
     Node extends CanvasElements.Nodes.BaseNode = CanvasElements.Nodes.BaseNode,
 > extends NodeEvent<Node> {}
 
 export interface ConnectionEvent {
-    connection: CanvasElements.Connection;
+    connection: CanvasElements.BaseConnection;
     from: CanvasElements.Nodes.TalentNode;
     to: CanvasElements.Nodes.TalentNode;
 }
@@ -86,7 +88,7 @@ export class TalentTreeWorld extends World {
         this.on('click', (event) => {
             if (event.target instanceof CanvasElements.Nodes.BaseNode) {
                 this.onClickNode(event);
-            } else if (event.target instanceof CanvasElements.Connection) {
+            } else if (event.target instanceof CanvasElements.BaseConnection) {
                 this.onClickConnection(event);
             }
         });
@@ -94,7 +96,7 @@ export class TalentTreeWorld extends World {
         this.on('rightclick', (event) => {
             if (event.target instanceof CanvasElements.Nodes.BaseNode) {
                 this.onRightClickNode(event);
-            } else if (event.target instanceof CanvasElements.Connection) {
+            } else if (event.target instanceof CanvasElements.BaseConnection) {
                 this.onRightClickConnection(event);
             }
         });
@@ -127,7 +129,7 @@ export class TalentTreeWorld extends World {
         if (this.interactionState !== 'none') return;
 
         // Find the node
-        const node = this.tree.nodes.find((n) => n.data === from)!;
+        const node = this.tree.nodes!.find((n) => n.data === from)!;
 
         this.interactionState = 'create-connection';
         this.contextElement = node;
@@ -231,14 +233,14 @@ export class TalentTreeWorld extends World {
         // Prevent the event from bubbling up
         event.stopPropagation();
 
-        const connection = event.target as CanvasElements.Connection;
-
-        // Get the node canvas elements
-        const from = this.tree.nodes.find((n) => n.data === connection.from)!;
-        const to = this.tree.nodes.find((n) => n.data === connection.to)!;
+        const connection = event.target as CanvasElements.BaseConnection;
 
         // Dispatch event
-        this.emit('click-connection', { connection, from, to });
+        this.emit('click-connection', {
+            connection,
+            from: connection.from,
+            to: connection.to,
+        });
     }
 
     private onRightClickNode(event: PIXI.FederatedMouseEvent) {
@@ -260,14 +262,15 @@ export class TalentTreeWorld extends World {
         // Prevent the event from bubbling up
         event.stopPropagation();
 
-        const connection = event.target as CanvasElements.Connection;
-
-        // Get the node canvas elements
-        const from = this.tree.nodes.find((n) => n.data === connection.from)!;
-        const to = this.tree.nodes.find((n) => n.data === connection.to)!;
+        const connection = event.target as CanvasElements.BaseConnection;
 
         // Dispatch event
-        this.emit('rightclick-connection', { ...event, connection, from, to });
+        this.emit('rightclick-connection', {
+            ...event,
+            connection,
+            from: connection.from,
+            to: connection.to,
+        });
     }
 
     private onMouseOverNode(event: PIXI.FederatedMouseEvent) {

--- a/src/system/applications/item/components/talent-tree/talent-tree-view.ts
+++ b/src/system/applications/item/components/talent-tree/talent-tree-view.ts
@@ -126,7 +126,7 @@ export class TalentTreeViewComponent<
         this._selectedType = 'node';
 
         // Select node
-        this.canvasTree!.nodes.find(
+        this.canvasTree!.nodes!.find(
             (n) =>
                 n instanceof CanvasElements.Nodes.TalentNode &&
                 n.data.id === node.id,
@@ -145,16 +145,16 @@ export class TalentTreeViewComponent<
         if (!this.selected) return;
 
         if (this.selectedType === 'node') {
-            this.canvasTree!.nodes.find(
+            this.canvasTree!.nodes!.find(
                 (n) =>
                     n instanceof CanvasElements.Nodes.TalentNode &&
                     n.data.id === (this.selected as TalentTree.Node).id,
             )?.deselect();
         } else {
-            this.canvasTree!.connections.find(
+            this.canvasTree!.connections!.find(
                 (c) =>
-                    c.from.id === (this.selected as NodeConnection).from &&
-                    c.to.id === (this.selected as NodeConnection).to,
+                    c.from.data.id === (this.selected as NodeConnection).from &&
+                    c.to.data.id === (this.selected as NodeConnection).to,
             )?.deselect();
         }
 
@@ -446,7 +446,7 @@ export class TalentTreeViewComponent<
         const node = event.node.data;
 
         // Get node view position
-        const viewPos = this.viewport!.worldToView(node.position);
+        const viewPos = event.node.getGlobalPosition();
 
         // Get node size
         const nodeSize = {
@@ -493,7 +493,9 @@ export class TalentTreeViewComponent<
                     };
                 }),
                 description: await TextEditor.enrichHTML(
-                    item.system.description?.value ?? '',
+                    item.system.description?.short ??
+                        item.system.description?.value ??
+                        '',
                 ),
                 hasContextActor: !!this.contextActor,
             },
@@ -526,10 +528,10 @@ export class TalentTreeViewComponent<
         game.tooltip!.deactivate();
 
         // Remove tooltip root
-        const tooltipRoot = this.element!.querySelector(
+        const tooltipRoot = this.element!.querySelectorAll(
             '.talent-tree-tooltip-root',
         );
-        if (tooltipRoot) tooltipRoot.remove();
+        tooltipRoot.forEach((el) => el.remove());
     }
 
     /* --- Context --- */

--- a/src/system/types/item/talent-tree.ts
+++ b/src/system/types/item/talent-tree.ts
@@ -176,12 +176,7 @@ export interface TreeNode extends BaseNode<Node.Type.Tree> {
     /**
      * The UUID of the TalentTreeItem the node refers to.
      */
-    uuid?: string;
-
-    /**
-     * Object containing the TalentTreeItem data
-     */
-    item: Pick<TalentTreeItem, 'name' | 'type' | 'img' | 'system'>;
+    uuid: string;
 }
 
 export interface TextNode extends BaseNode<Node.Type.Text> {


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR adds support for nesting talent trees. Talent trees can be dragged on the tree as talents and will render out their contents.

**Related Issue**  
Partially addresses #70 

**How Has This Been Tested?**  
Locally nesting talent trees

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/37d94894-e9e8-41b4-ba3e-5241391d6e5a)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331