### PR TITLE
fix(vector utils): replace @pixi/math-extras dependency with own implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
                 "@pixi-essentials/svg": "^3.0.0",
                 "@pixi/filter-drop-shadow": "^5.2.0",
                 "@pixi/filter-glow": "^5.2.1",
-                "@pixi/math-extras": "^7.4.2",
                 "spark-md5": "^3.0.2"
             },
             "devDependencies": {
@@ -667,15 +666,6 @@
             "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.4.2.tgz",
             "integrity": "sha512-7jHmCQoYk6e0rfSKjdNFOPl0wCcdgoraxgteXJTTHv3r0bMNx2pHD9FJ0VvocEUG7XHfj55O3+u7yItOAx0JaQ==",
             "license": "MIT"
-        },
-        "node_modules/@pixi/math-extras": {
-            "version": "7.4.2",
-            "resolved": "https://registry.npmjs.org/@pixi/math-extras/-/math-extras-7.4.2.tgz",
-            "integrity": "sha512-Ufim8EJ4k6tgB8VYnJopSDMTIMEMZTwobEyNCWVbeYmoDFdkdQeRHnHrco6YKdU8THN9ankJ9sCbhKBbe7j5BA==",
-            "license": "MIT",
-            "peerDependencies": {
-                "@pixi/core": "7.4.2"
-            }
         },
         "node_modules/@pixi/mesh": {
             "version": "7.4.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
         "@pixi-essentials/svg": "^3.0.0",
         "@pixi/filter-drop-shadow": "^5.2.0",
         "@pixi/filter-glow": "^5.2.1",
-        "@pixi/math-extras": "^7.4.2",
         "spark-md5": "^3.0.2"
     }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -129,11 +129,8 @@ function pixiImportFix() {
         name: 'pixi-import-fix',
         renderChunk: (code, chunk, options, meta) => {
             return code.replace(
-                "import { Point, ObservablePoint, Rectangle, Filter, utils } from '@pixi/core';",
+                "import { Filter, utils } from '@pixi/core';",
                 [
-                    'const Point = PIXI.Point;',
-                    'const ObservablePoint = PIXI.ObservablePoint;',
-                    'const Rectangle = PIXI.Rectangle;',
                     'const Filter = PIXI.Filter;',
                     'const utils = PIXI.utils;',
                 ].join('\n')

--- a/src/system/mixins/vector.d.ts
+++ b/src/system/mixins/vector.d.ts
@@ -1,20 +1,72 @@
-interface PointLike {
-    x: number;
-    y: number;
-}
-
 declare namespace GlobalMixins {
     export interface Point {
         /**
+         * Adds other to this point
+         * @param other
+         */
+        add(other: PIXI.IPointData): Point;
+
+        /**
+         * Subtracts other from this point
+         */
+        subtract(other: PIXI.IPointData): Point;
+
+        /**
+         * Multiplies this point by another point
+         */
+        multiply(other: PIXI.IPointData): Point;
+
+        /**
+         * Multiplies this point by a scalar value
+         */
+        multiplyScalar(scalar: number): Point;
+
+        /**
+         * Computes the dot product of other with this point.
+         * The dot product is the sum of the products of the corresponding components of two vectors
+         */
+        dot(other: PIXI.IPointData): number;
+
+        /**
+         * Computes the cross product of other with this point.
+         * Given two linearly independent R3 vectors a and b, the cross product, a × b (read "a cross b"),
+         * is a vector that is perpendicular to both a and b, and thus normal to the plane containing them.
+         * While cross product only exists on 3D space, we can assume the z component of 2D to be zero and
+         * the result becomes a vector that will only have magnitude on the z axis.
+         *
+         * This function returns the z component of the cross product of the two points.
+         */
+        cross(other: PIXI.IPointData): number;
+
+        /**
+         * Computes a normalized version of this point.
+         * A normalized vector is a vector of magnitude (length) 1.
+         */
+        normalize(): PIXI.Point;
+
+        /**
+         * Computes the magnitude of this point (Euclidean distance from 0, 0).
+         * Defined as the square root of the sum of the squares of each component.
+         */
+        magnitude(): number;
+
+        /**
+         * Computes the projection of this point onto another point.
+         * The projection of a vector a onto a vector b is the orthogonal projection of a onto b.
+         * It is the vector in the direction of b that is closest to a.
+         */
+        project(other: PIXI.IPointData): PIXI.Point;
+
+        /**
          * Finds the distance between two points
          */
-        distance(other: PointLike): number;
+        distance(other: PIXI.IPointData): number;
 
         /**
          * Finds the shortest angle between two points
          * @param b
          */
-        angle(b: PointLike): number;
+        angle(b: PIXI.IPointData): number;
 
         /**
          * Finds the tanget of the vector

--- a/src/system/mixins/vector.d.ts
+++ b/src/system/mixins/vector.d.ts
@@ -4,22 +4,22 @@ declare namespace GlobalMixins {
          * Adds other to this point
          * @param other
          */
-        add(other: PIXI.IPointData): Point;
+        add(other: PIXI.IPointData): PIXI.Point;
 
         /**
          * Subtracts other from this point
          */
-        subtract(other: PIXI.IPointData): Point;
+        subtract(other: PIXI.IPointData): PIXI.Point;
 
         /**
          * Multiplies this point by another point
          */
-        multiply(other: PIXI.IPointData): Point;
+        multiply(other: PIXI.IPointData): PIXI.Point;
 
         /**
          * Multiplies this point by a scalar value
          */
-        multiplyScalar(scalar: number): Point;
+        multiplyScalar(scalar: number): PIXI.Point;
 
         /**
          * Computes the dot product of other with this point.

--- a/src/system/mixins/vector.ts
+++ b/src/system/mixins/vector.ts
@@ -1,7 +1,84 @@
 /// <reference path="./vector.d.ts" />
 
-// Pixi math
-import '@pixi/math-extras';
+/**
+ * Adds other to this point
+ */
+export function add(this: PIXI.Point, b: Point): Point {
+    return new PIXI.Point(this.x + b.x, this.y + b.y);
+}
+
+/**
+ * Subtracts other from this point
+ */
+export function subtract(this: PIXI.Point, b: Point): Point {
+    return new PIXI.Point(this.x - b.x, this.y - b.y);
+}
+
+/**
+ * Multiplies this point by another point
+ */
+export function multiply(this: PIXI.Point, b: Point): Point {
+    return new PIXI.Point(this.x * b.x, this.y * b.y);
+}
+
+/**
+ * Multiplies this point by a scalar value
+ */
+export function multiplyScalar(this: PIXI.Point, scalar: number): Point {
+    return new PIXI.Point(this.x * scalar, this.y * scalar);
+}
+
+/**
+ * Computes the dot product of other with this point.
+ * The dot product is the sum of the products of the corresponding components of two vectors
+ */
+export function dot(this: PIXI.Point, b: Point): number {
+    return this.x * b.x + this.y * b.y;
+}
+
+/**
+ * Computes the cross product of other with this point.
+ * Given two linearly independent R3 vectors a and b, the cross product, a × b (read "a cross b"),
+ * is a vector that is perpendicular to both a and b, and thus normal to the plane containing them.
+ * While cross product only exists on 3D space, we can assume the z component of 2D to be zero and
+ * the result becomes a vector that will only have magnitude on the z axis.
+ *
+ * This function returns the z component of the cross product of the two points.
+ */
+export function cross(this: PIXI.Point, b: Point): number {
+    return this.x * b.y - this.y * b.x;
+}
+
+/**
+ * Computes a normalized version of this point.
+ * A normalized vector is a vector of magnitude (length) 1.
+ */
+export function normalize(this: PIXI.Point): PIXI.Point {
+    const magnitude = Math.sqrt(this.x * this.x + this.y * this.y);
+    return new PIXI.Point(this.x / magnitude, this.y / magnitude);
+}
+
+/**
+ * Computes the magnitude of this point (Euclidean distance from 0, 0).
+ * Defined as the square root of the sum of the squares of each component.
+ */
+export function magnitude(this: PIXI.Point): number {
+    return Math.sqrt(this.x * this.x + this.y * this.y);
+}
+
+/**
+ * Computes the projection of this point onto another point.
+ * The projection of a vector a onto a vector b is the orthogonal projection of a onto b.
+ * It is the vector in the direction of b that is closest to a.
+ */
+export function project(this: PIXI.Point, b: Point): PIXI.Point {
+    const normalizedScalarProjection =
+        (this.x * b.x + this.y * b.y) / (b.x * b.x + b.y * b.y);
+    return new PIXI.Point(
+        normalizedScalarProjection * b.x,
+        normalizedScalarProjection * b.y,
+    );
+}
 
 /**
  * Finds the distance between two points
@@ -52,6 +129,15 @@ export function rotate(this: PIXI.Point, angle: number): PIXI.Point {
 /* --- Define mixins --- */
 
 const mixins = {
+    add,
+    subtract,
+    multiply,
+    multiplyScalar,
+    dot,
+    cross,
+    normalize,
+    magnitude,
+    project,
     distance,
     angle,
     tanget,


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR fixes the bug that allows tokens to move through walls (cardinally). This bug was caused by the inclusion of the `@pixi/math-extras` library for vector math utils. These have been replaced with our own implementation.

**Related Issue**  
Closes #300 

**How Has This Been Tested?**  
1. Place a wall in a scene
2. Place a token beside the wall
3. Move (cardinally) into the wall -> Token gets blocked by the wall

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331