### PR TITLE
fix: currency fallback icon

### DIFF
--- a/src/style/sheets/actor/module.scss
+++ b/src/style/sheets/actor/module.scss
@@ -833,6 +833,15 @@
                     top: 2px;
                     border: none;
                 }
+
+                .fallback {
+                    width: 16px;
+                    height: 16px;
+                    position: absolute;
+                    left: -8px;
+                    top: 2px;
+                    color: var(--cosmere-color-accent);
+                }
             }
         }
     }

--- a/src/system/applications/actor/components/currency-list.ts
+++ b/src/system/applications/actor/components/currency-list.ts
@@ -22,21 +22,31 @@ export class ActorCurrencyListComponent extends HandlebarsApplicationComponent<
 
     /* --- Context --- */
 
-    public _prepareContext(
+    public async _prepareContext(
         params: object,
         context: BaseActorSheetRenderContext,
     ) {
         return Promise.resolve({
             ...context,
 
-            currencies: Object.keys(CONFIG.COSMERE.currencies).map(
-                this.prepareCurrency.bind(this),
+            currencies: await Promise.all(
+                Object.keys(CONFIG.COSMERE.currencies).map(
+                    this.prepareCurrency.bind(this),
+                ),
             ),
         });
     }
 
-    private prepareCurrency(currencyId: string) {
-        const currencyConfig = CONFIG.COSMERE.currencies[currencyId];
+    private async prepareCurrency(currencyId: string) {
+        const currencyConfig = foundry.utils.duplicate(
+            CONFIG.COSMERE.currencies[currencyId],
+        );
+
+        try {
+            await FilePicker.browse('data', currencyConfig.icon ?? '');
+        } catch (ex) {
+            currencyConfig.icon = undefined;
+        }
 
         return {
             id: currencyId,

--- a/src/system/types/config.ts
+++ b/src/system/types/config.ts
@@ -116,7 +116,7 @@ export interface PathTypeConfig {
 
 export interface CurrencyConfig {
     label: string;
-    icon: string;
+    icon: string | undefined;
     denominations: {
         primary: CurrencyDenominationConfig[];
         secondary?: CurrencyDenominationConfig[];

--- a/src/templates/actors/components/currency-list.hbs
+++ b/src/templates/actors/components/currency-list.hbs
@@ -1,7 +1,11 @@
 <div class="currency-list">
     {{#each currencies as |currency|}}
     <div class="currency" data-tooltip="{{currency.config.label}}">
-        <img src="{{currency.config.icon}}">
+        {{#if currency.config.icon}}
+            <img src="{{currency.config.icon}}">
+        {{else}}
+            <div class="fallback"><i class="fa-solid fa-coins"></i></div>
+        {{/if}}
         <input name="currency"
             type="number"
             min="0"


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue where if  a currency icon is missing, there is a blank error icon. This introduces a fallback system that will show a generic icon in place of any missing icons, which is a neater solution.

**How Has This Been Tested?**  
Tested with the playtest materials (which have no currency icons for the registered icons) and ensured that the fallback takes effect. Tested with the handbook module to ensure icons still show up if available.

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/c8dd5ebe-5692-4968-976b-86b491dbb1ed)

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: [insert version here].
