### PR TITLE
fix(0.2-0.3 migration): fix issue causing talent tree migrations to fail and improve migration robustness

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1011,6 +1011,9 @@
         },
         "Damage": {
             "IgnoreDeflect": "Ignore Deflect"
+        },
+        "Migration": {
+            "DocumentMigrationFailed": "Failed to migrate {type} \"{name}\". {error}"
         }
     },
     "DICE": {

--- a/src/system/types/utils.ts
+++ b/src/system/types/utils.ts
@@ -6,6 +6,7 @@ export {
     EmptyObject,
     AnyMutableObject,
 } from '@league-of-foundry-developers/foundry-vtt-types/src/types/utils.mjs';
+import { AnyObject } from '@league-of-foundry-developers/foundry-vtt-types/src/types/utils.mjs';
 
 // Constant to improve UI consistency
 export const NONE = 'none';
@@ -72,3 +73,17 @@ export const COSMERE_DOCUMENT_CLASSES: Record<string, CosmereDocumentClass> = {
     Actor: CosmereActor,
     Item: CosmereItem,
 };
+
+export interface RawDocumentData<T = AnyObject> {
+    _id: string;
+    type: string;
+    name: string;
+    flags: Record<string, unknown>;
+    folder: string | null;
+    sort: number;
+    permission: {
+        default: number;
+        [key: string]: number;
+    };
+    system: T;
+}

--- a/src/system/utils/data.ts
+++ b/src/system/utils/data.ts
@@ -1,10 +1,9 @@
-import { DocumentConstructor } from '@league-of-foundry-developers/foundry-vtt-types/src/types/helperTypes.mjs';
-
 import {
     AnyObject,
     COSMERE_DOCUMENT_CLASSES,
     CosmereDocument,
     InvalidCollection,
+    RawDocumentData,
 } from '../types/utils';
 
 /**
@@ -12,7 +11,7 @@ import {
  */
 function getCollectionForDocumentType(
     documentType: string,
-): WorldCollection<DocumentConstructor, string> {
+): WorldCollection<foundry.abstract.Document.AnyConstructor, string> {
     const collection = game.collections?.get(documentType);
     if (!collection) {
         throw new Error(`Failed to retrieve "${documentType}" collection`);
@@ -21,9 +20,9 @@ function getCollectionForDocumentType(
     return collection;
 }
 
-export async function getRawDocumentSources<T = AnyObject>(
-    documentType: string,
-): Promise<AnyObject[]> {
+export async function getRawDocumentSources<
+    T extends RawDocumentData = RawDocumentData,
+>(documentType: string): Promise<T[]> {
     // NOTE: Use any type here as it keeps resolving to ManageCompendiumRequest instead of DocumentSocketRequest
     const { result } = await SocketInterface.dispatch('modifyDocument', {
         type: documentType,
@@ -34,7 +33,7 @@ export async function getRawDocumentSources<T = AnyObject>(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
 
-    return (result as AnyObject[] | undefined) ?? [];
+    return (result as T[] | undefined) ?? [];
 }
 
 /**

--- a/src/system/utils/migration/migrations/0.2-0.3.ts
+++ b/src/system/utils/migration/migrations/0.2-0.3.ts
@@ -209,6 +209,7 @@ async function migrateActors(actors: any[]) {
                 if (actor.type === ActorType.Character) {
                     /* --- Advancement ---*/
                     if (
+                        !(actor.system as CharacterActorDataModel).level ||
                         isNaN((actor.system as CharacterActorDataModel).level)
                     ) {
                         foundry.utils.mergeObject(changes, {

--- a/src/system/utils/migration/utils.ts
+++ b/src/system/utils/migration/utils.ts
@@ -1,0 +1,24 @@
+import { RawDocumentData } from '@system/types/utils';
+import { SYSTEM_ID } from '@system/constants';
+
+export function handleDocumentMigrationError(
+    error: unknown,
+    documentType: string,
+    document: RawDocumentData<unknown>,
+): void {
+    console.log(document);
+
+    ui.notifications.warn(
+        game.i18n!.format('COSMERE.Migration.DocumentMigrationFailed', {
+            name: document.name,
+            sort: game.i18n!.localize(`DOCUMENT.${documentType}`),
+            type: game.i18n!.localize(`TYPES.${documentType}.${document.type}`),
+            error:
+                error instanceof Error
+                    ? `${error.name}: ${error.message}`
+                    : 'Unknown error',
+        }),
+    );
+
+    console.warn(`[${SYSTEM_ID}] Failed to migrate document`, error, document);
+}


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR solves the issue causing 0.2-0.3 migrations to fail if custom talent trees are present in the world. The previous implementation failed since in the type we were using a collection, however when we grab the raw data from Foundry we get back a plain object. This PR also generally makes the migration more robust by wrapping each individual document migration in its own try/catch.

**Related Issue**  
Closes #302 

**How Has This Been Tested?**  
1. Install the test world and backups shared in test data
2. Revert to the oldest back up
3. Open the world with 0.3
4. Migration now succeeds

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331