### PR TITLE
Fix incorrect context popup positioning

### DIFF
--- a/src/system/applications/actor/components/character/connections-list.ts
+++ b/src/system/applications/actor/components/character/connections-list.ts
@@ -57,12 +57,18 @@ export class CharacterConnectionsListComponent extends HandlebarsApplicationComp
             const target = (event.currentTarget as HTMLElement).closest(
                 '.item',
             )!;
+
+            const tabBody = (event.currentTarget as HTMLElement).closest(
+                '.tab-body',
+            )!;
+
             const targetRect = target.getBoundingClientRect();
+            const tabRect = tabBody.getBoundingClientRect();
             const rootRect = this.element!.getBoundingClientRect();
 
             this.controlsDropdownPosition = {
                 top: targetRect.bottom - rootRect.top,
-                right: rootRect.right - targetRect.right,
+                right: tabRect.right - targetRect.right,
             };
         } else {
             this.contextConnectionId = null;

--- a/src/system/applications/actor/components/character/goals-list.ts
+++ b/src/system/applications/actor/components/character/goals-list.ts
@@ -58,13 +58,20 @@ export class CharacterGoalsListComponent extends HandlebarsApplicationComponent<
             const target = (event.currentTarget as HTMLElement).closest(
                 '.item',
             )!;
+
+            const tabBody = (event.currentTarget as HTMLElement).closest(
+                '.tab-body',
+            )!;
+
             const targetRect = target.getBoundingClientRect();
+            const tabRect = tabBody.getBoundingClientRect();
             const rootRect = this.element!.getBoundingClientRect();
 
             this.controlsDropdownPosition = {
                 top: targetRect.bottom - rootRect.top,
-                right: rootRect.right - targetRect.right,
+                right: tabRect.right - targetRect.right,
             };
+            console.log(this.controlsDropdownPosition);
         } else {
             this.contextGoalId = null;
         }

--- a/src/system/applications/utils/context-menu.ts
+++ b/src/system/applications/utils/context-menu.ts
@@ -232,7 +232,9 @@ export class AppContextMenu {
         if (firstArgIsElement) {
             // Get element bounds
             const elementBounds = element!.getBoundingClientRect();
-            const rootBounds = this.parent.element.getBoundingClientRect();
+            const rootBounds = (
+                this.parent.element.closest('.tab-body') ?? this.parent.element
+            ).getBoundingClientRect();
 
             // Figure out positioning with anchor
             positioning = {


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
The PR addresses the issue where context popups are appearing at the wrong position. The fix seems to be setting the position relative to the tab body, rather than the root element, because the `<menu/>` element's position is relative to the actual tab content.

**Related Issue**  
Partially addresses #282 

**How Has This Been Tested?**  
Just go on a character sheet, click the triple-dot, and confirm that the popup is placed much more closely/accurately than before.

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/e66ea05e-34ca-4ecc-ba6a-7e65fd82822d)
![image](https://github.com/user-attachments/assets/5733ed26-484c-4567-b150-dce4c764376a)


**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331.
