### PR TITLE
fix(component system): fix issue causing form associated components to lose track of their value

### DIFF
--- a/src/system/applications/component-system/system.ts
+++ b/src/system/applications/component-system/system.ts
@@ -150,8 +150,26 @@ export function registerComponent(
             class extends HTMLElement {
                 static formAssociated = true;
 
-                public value: unknown;
                 public name: string | undefined;
+                private _value: unknown;
+                private internals: ElementInternals;
+
+                constructor() {
+                    super();
+
+                    this.internals = this.attachInternals();
+                }
+
+                public set value(value: unknown) {
+                    this._value = value;
+                    this.internals.setFormValue(
+                        value as string | File | FormData | null,
+                    );
+                }
+
+                public get value() {
+                    return this._value;
+                }
             },
         );
     }
@@ -462,6 +480,20 @@ export function replaceComponent(
     const element = (root ?? $(app.element)).find(
         `${instance.selector}[data-component-id="${instance.id}"]`,
     );
+
+    // Retain value if the element is form associated
+    if (
+        !!componentRegistry[componentRef].element &&
+        element.get(0) !== componentRegistry[componentRef].element &&
+        componentClsRegistry[instance.selector].FORM_ASSOCIATED
+    ) {
+        // Assign value to the new element
+        (element.get(0) as unknown as { value: unknown }).value = (
+            componentRegistry[componentRef].element as unknown as {
+                value: unknown;
+            }
+        ).value;
+    }
 
     // Assign element
     componentRegistry[componentRef].element = element.get(0);

--- a/src/system/applications/components/document-drop-list.ts
+++ b/src/system/applications/components/document-drop-list.ts
@@ -228,6 +228,9 @@ export class DocumentDropListComponent extends DragDropComponentMixin(
     protected override _onRender(params: Params) {
         super._onRender(params);
 
+        // Set value
+        this.element!.value = this.value ?? [];
+
         // Set name
         if (this.params!.name) {
             this.name = this.params!.name;

--- a/src/system/applications/components/document-reference-input.ts
+++ b/src/system/applications/components/document-reference-input.ts
@@ -206,6 +206,9 @@ export class DocumentReferenceInputComponent extends DragDropComponentMixin(
     protected override _onRender(params: Params) {
         super._onRender(params);
 
+        // Set value
+        this.element!.value = this.value ?? '';
+
         // Set name
         if (this.params!.name) {
             this.name = this.params!.name;

--- a/src/system/applications/components/multi-value-select.ts
+++ b/src/system/applications/components/multi-value-select.ts
@@ -145,6 +145,9 @@ export class MultiValueSelectComponent extends HandlebarsApplicationComponent<
     protected override _onRender(params: Params) {
         super._onRender(params);
 
+        // Set value
+        this.element!.value = this.value ?? '';
+
         // Set name
         if (this.params!.name) {
             this.name = this.params!.name;


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR fixes an issue causing our form associated components to "forget" their value when the form is submitted as result of anything but a change event from that component. 

**Related Issue**  
Closes #306 

**How Has This Been Tested?**  
1. Create path
2. Ad linked skills
3. Update the identifier
4. Close and open item
5. Linked skills remain as they were

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331