### PR TITLE
fix(component system): fix issue causing nested loop indexes to have duplicate values

### DIFF
--- a/src/system/applications/component-system/system.ts
+++ b/src/system/applications/component-system/system.ts
@@ -165,8 +165,13 @@ function getFullIndexRecursive(
     data?: Handlebars.HelperOptions['data'],
 ): string | undefined {
     if (!data) return;
-    return [data.index ?? '0', getFullIndexRecursive(data._parent)]
-        .filter((v) => !!v)
+    return [
+        data.index ?? '0',
+        '_parent' in data && 'index' in data._parent
+            ? getFullIndexRecursive(data._parent)
+            : null,
+    ]
+        .filter((v) => v !== null)
         .join('.');
 }
 /* eslint-enable @typescript-eslint/no-unsafe-member-access */


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR fixes an issue with the way the component system assigns ids to components in nested loops (multiple levels of `#each`). The way the system got the nested index was incorrect and could cause duplicate values, causing duplicate component ids. This was only noticed/relevant for path linked skills, though could come up anywhere.

**Related Issue**  
Closes #297 

**How Has This Been Tested?**  
1. Open character sheet
2. Add Windrunner (and its surges) and Lighweaver (and its surges) to character
3. Linked skills are displayed under the correct path.

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/48b141f8-b2f4-410e-b3e4-219976ecd28e)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331