### PR TITLE
fix(path sheet): fix issue causing talent trees to not be rerendered when opening to talents tab directly

### DIFF
--- a/src/system/applications/item/components/talent-tree/canvas/elements/nodes/tree-node.ts
+++ b/src/system/applications/item/components/talent-tree/canvas/elements/nodes/tree-node.ts
@@ -406,8 +406,6 @@ export class TalentTreeNode extends BaseNode {
                 );
                 this.connectionsLayer.addChild(connectionElement);
             } else {
-                console.log('added connection', connection, this.item.id);
-
                 // Find the talent node
                 const talentNode = this.nodesLayer.children.find(
                     (child) => child.data.id === connection.talentId,

--- a/src/system/applications/item/path-sheet.ts
+++ b/src/system/applications/item/path-sheet.ts
@@ -62,8 +62,15 @@ export class PathItemSheet extends BaseItemSheet {
 
     /* --- Lifecycle --- */
 
-    protected override async onTabChange(tab: string, group: string) {
-        if (tab === 'talents') {
+    protected _onFirstRender(context: unknown, options: unknown): void {
+        super._onFirstRender(context, options);
+
+        // Invoke on tab change
+        void this.onTabChange();
+    }
+
+    protected override async onTabChange() {
+        if (this.tab === 'talents') {
             // Look up talent tree
             const talentTree = this.item.system.talentTree
                 ? ((await fromUuid(this.item.system.talentTree)) as unknown as

--- a/src/system/applications/mixins/tabs.ts
+++ b/src/system/applications/mixins/tabs.ts
@@ -48,6 +48,10 @@ export function TabsApplicationMixin<
 
         public tabGroups: Record<string, string> = {};
 
+        public get tab(): string {
+            return this.tabGroups[PRIMARY_TAB_GROUP] ?? '';
+        }
+
         public override changeTab(
             tab: string,
             group: string,


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR fixes a bug causing the talent tree on the "talents" tab of the path sheet to not be rendered when opening the sheet directly to the "talents" tab. 

**Related Issue**  
Closes #295 

**How Has This Been Tested?**  
1. Open path with talents configured
2. Navigate to talents tab
3. Close path
4. Open path again

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331