### PR TITLE
fix(action list component): fix issue causing ancestry actions to not be included in ancestry section

### DIFF
--- a/src/system/applications/actor/components/actions-list.ts
+++ b/src/system/applications/actor/components/actions-list.ts
@@ -348,14 +348,14 @@ export class ActorActionsListComponent extends HandlebarsApplicationComponent<
                           ),
                           default: false,
                           filter: (item: CosmereItem) =>
-                              item.isTalent() &&
+                              (item.isTalent() || item.isAction()) &&
                               item.system.ancestry === ancestry.system.id,
                           new: (parent: CosmereActor) =>
                               CosmereItem.create(
                                   {
-                                      type: ItemType.Talent,
+                                      type: ItemType.Action,
                                       name: game.i18n!.localize(
-                                          'COSMERE.Item.Type.Talent.New',
+                                          'COSMERE.Item.Type.Action.New',
                                       ),
                                       system: {
                                           ancestry: ancestry.system.id,


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR fixes a bug causing ancestry actions to show up in the misc section instead of the ancestry actions section.

**Related Issue**  
Closes #296 

**How Has This Been Tested?**  
1. Create new character
2. Add singer ancestry
3. Add forms of finesse
4. Check that Art form and Nimble form are both included in ancestry actions section

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/9e9aae94-8c47-4c23-b569-d2e09de12954)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331