### PR TITLE
fix(character sheets): properly display movement rates in config dialog

### DIFF
--- a/src/system/applications/actor/dialogs/configure-movement-rate.ts
+++ b/src/system/applications/actor/dialogs/configure-movement-rate.ts
@@ -140,7 +140,7 @@ export class ConfigureMovementRateDialog extends HandlebarsApplicationMixin(
         const movementRates = (
             Object.keys(CONFIG.COSMERE.movement.types) as MovementType[]
         ).map((type) => ({
-            ...this.movementData[type].rate,
+            rate: this.movementData[type].rate,
             mode: this.movementData[type].rate.mode,
             type,
             label: CONFIG.COSMERE.movement.types[type].label,

--- a/src/templates/actors/dialogs/configure-movement-rate.hbs
+++ b/src/templates/actors/dialogs/configure-movement-rate.hbs
@@ -1,28 +1,28 @@
 <form>
-    {{#each movementRates as |rate|}}
-        <div class="form-group {{#if (eq rate.type "walk")}}max{{/if}}">
-            {{#if (not (eq rate.type "walk"))}}
-            <label>{{localize rate.label}}</label>
+    {{#each movementRates as |movement|}}
+        <div class="form-group {{#if (eq movement.type "walk")}}max{{/if}}">
+            {{#if (not (eq movement.type "walk"))}}
+            <label>{{localize movement.label}}</label>
             {{/if}}
             <div class="form-fields">
-                <input name="{{concat rate.type ".value"}}"
+                <input name="{{concat movement.type ".value"}}"
                     type="number"
-                    value="{{derived rate}}"
+                    value="{{derived movement.rate}}"
                     min="0"
                     step="1"
-                    {{#if (eq rate.mode 'derived')}}
+                    {{#if (eq movement.mode 'derived')}}
                     readonly
                     {{/if}}
                 >
             </div>
         </div>
 
-        {{#if (eq rate.type "walk")}}
+        {{#if (eq movement.type "walk")}}
         <div class="form-group">
             <label>{{localize "GENERIC.Mode"}}</label>
             <div class="form-fields">
-                <select name="{{concat rate.type ".mode"}}">
-                    {{selectOptions @root.modes selected=rate.mode localize=true}}
+                <select name="{{concat movement.type ".mode"}}">
+                    {{selectOptions @root.modes selected=movement.mode localize=true}}
                 </select>
             </div>
         </div>


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue where movement rates weren't properly displaying in the configuration dialog. This change preserves _all_ derived members, notably including the `value` getter, so that the `derive` helper can actually make any use of the movement rates.

**Related Issue**  
Closes #322 

**How Has This Been Tested?**  
1. Create an actor
2. Open the movement config dialog
4. Observe the actual values
5. Set mode to custom
6. Change movement rates
7. Confirm that it updates correctly in the dialog

**Screenshots (if applicable)** 
_Before:_
![image](https://github.com/user-attachments/assets/a6bcb74a-732d-4128-aaff-e219de545cef)

_After:_
![image](https://github.com/user-attachments/assets/1b5333bc-f244-4723-a786-2ba801304e7f)


**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331.
