### PR TITLE
Fix a size issue with the code editor for item prose mirror

### DIFF
--- a/src/style/sheets/sheet.scss
+++ b/src/style/sheets/sheet.scss
@@ -428,5 +428,11 @@
                 padding: 0.25rem 0.5rem;
             }
         }
+
+        > textarea {
+            min-height: 300px;
+            padding: 0.25rem 0.5rem;
+            scrollbar-color: var(--cosmere-color-base-6) var(--color-scrollbar-track);
+        }
     }
 }


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue where the code editor of an item prose mirror object would have too small a height size for practical use. Base size now matches base size of the description editor.

**Related Issue**  
Fixes #317.

**How Has This Been Tested?**  
Tested swapping back and forth between code editor and prose mirror to make sure size remains the same. Also tested to make sure scroll bar still shows appropriately for the code editor.

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/3acebb50-2117-456c-885c-3c1f8f6e08af)

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: 12.331.