### PR TITLE
Fix(localization): context dependent 'add' button #133

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -313,6 +313,7 @@
                 "Weapon": {
                     "label": "Weapon",
                     "label_plural": "Weapons",
+                    "label_action": "Weapon Action",
                     "desc_placeholder": "Edit this to describe what this weapon is & how it looks.",
                     "New": "New Weapon"
                 },
@@ -325,6 +326,7 @@
                 "Equipment": {
                     "label": "Equipment",
                     "label_plural": "Equipment",
+                    "label_action": "Equipment Action",
                     "desc_placeholder": "Edit this to describe what this piece of equipment is & how it looks.",
                     "New": "New Equipment"
                 },

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -172,7 +172,7 @@
                     "Strike": "Strike",
                     "BaseSectionName": "{type} Actions",
                     "MiscSectionName": "Miscellaneous Actions",
-                    "NewItem": "Add Action"
+                    "NewItem": "Add {type}"
                 },
                 "Equipment": {
                     "Quantity": "Quantity",

--- a/src/system/applications/actor/components/actions-list.ts
+++ b/src/system/applications/actor/components/actions-list.ts
@@ -76,6 +76,7 @@ const STATIC_SECTIONS = {
     Weapons: {
         id: 'weapons',
         label: 'COSMERE.Item.Type.Weapon.label_plural',
+        name: 'COSMERE.Item.Type.Weapon.label_action',
         default: false,
         filter: (item: CosmereItem) => item.isWeapon(),
         new: (parent: CosmereActor) =>
@@ -100,6 +101,7 @@ const STATIC_SECTIONS = {
     Equipment: {
         id: 'equipment',
         label: 'COSMERE.Item.Type.Equipment.label_plural',
+        name: 'COSMERE.Item.Type.Equipment.label_action',
         default: false,
         filter: (item: CosmereItem) => item.isEquipment(),
         new: (parent: CosmereActor) =>
@@ -125,6 +127,7 @@ const STATIC_SECTIONS = {
     BasicActions: {
         id: 'basic-actions',
         label: 'COSMERE.Item.Action.Type.Basic.label_plural',
+        name: 'COSMERE.Item.Action.Type.Basic.label',
         default: true,
         filter: (item: CosmereItem) =>
             item.isAction() && item.system.type === ActionType.Basic,
@@ -311,6 +314,7 @@ export class ActorActionsListComponent extends HandlebarsApplicationComponent<
                         type: path.name,
                     },
                 ),
+                name: `${path.name} ${game.i18n?.localize('COSMERE.Item.Type.Action.label')}`,
                 default: true,
                 filter: (item: CosmereItem) =>
                     item.isTalent() && item.system.path === path.system.id,
@@ -346,6 +350,7 @@ export class ActorActionsListComponent extends HandlebarsApplicationComponent<
                                   type: ancestry.name,
                               },
                           ),
+                          name: `${ancestry.name} ${game.i18n?.localize('COSMERE.Item.Type.Action.label')}`,
                           default: false,
                           filter: (item: CosmereItem) =>
                               (item.isTalent() || item.isAction()) &&
@@ -394,6 +399,7 @@ export class ActorActionsListComponent extends HandlebarsApplicationComponent<
             return {
                 id: type,
                 label: game.i18n!.localize(config.plural),
+                name: `${config.label} ${game.i18n?.localize('COSMERE.Item.Type.Action.label')}`,
                 default: false,
                 filter: (item: CosmereItem) =>
                     item.isPower() && item.system.type === type,

--- a/src/templates/actors/components/actions-list.hbs
+++ b/src/templates/actors/components/actions-list.hbs
@@ -16,7 +16,7 @@
                 {{#if @root.editable}}
                     {{#if section.canAddNewItems}}
                         <a data-action="new-item"
-                            data-tooltip="COSMERE.Actor.Sheet.Actions.NewItem"
+                            data-tooltip="{{localize "COSMERE.Actor.Sheet.Actions.NewItem" type=(localize section.label)}}"
                         >
                             <i class="fa-solid fa-plus"></i>
                         </a>
@@ -25,21 +25,21 @@
                     {{/if}}
                 {{/if}}
             </div>
-        </section>        
+        </section>
     </li>
 
     {{#each section.items as |item|}}
     {{#with (lookup @root.itemState item.id) as |state|}}
-    {{#with (itemContext item) as |ctx|}}    
+    {{#with (itemContext item) as |ctx|}}
     {{#with (lookup section.itemData item.id) as |data|}}
 
-    <li class="item usable collapsible {{#if state.expanded}}expanded{{/if}}" 
-        data-item-id="{{item.id}}" 
+    <li class="item usable collapsible {{#if state.expanded}}expanded{{/if}}"
+        data-item-id="{{item.id}}"
         {{#if @root.editable}}data-drag="true"{{/if}}
     >
         <section class="details">
             {{!-- Image --}}
-            <div class="img" 
+            <div class="img"
                 data-action="use-item"
                 data-tooltip="COSMERE.Actor.Sheet.Actions.Use"
             >
@@ -65,7 +65,7 @@
                     </i>
                     {{else}}
                     <i class="cosmere-icon passive"></i>
-                    {{/if}}                    
+                    {{/if}}
                 {{/if}}
             </div>
 
@@ -137,7 +137,7 @@
                 </a>
                 {{/if}}
             </div>
-        </section>        
+        </section>
 
         <section class="description collapsible-content">
             <div class="wrapper">

--- a/src/templates/actors/components/actions-list.hbs
+++ b/src/templates/actors/components/actions-list.hbs
@@ -16,7 +16,7 @@
                 {{#if @root.editable}}
                     {{#if section.canAddNewItems}}
                         <a data-action="new-item"
-                            data-tooltip="{{localize "COSMERE.Actor.Sheet.Actions.NewItem" type=(localize section.label)}}"
+                            data-tooltip="{{localize "COSMERE.Actor.Sheet.Actions.NewItem" type=(localize section.name)}}"
                         >
                             <i class="fa-solid fa-plus"></i>
                         </a>


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Simple issue with the "add action" tooltip not using a formatted string to insert action type.

**Related Issue**  
Closes #133 

**How Has This Been Tested?**  
1. Open an actor sheet in edit mode
2. Go to actions tab
3. Hover over the `+` by each action category
4. Observe the tooltip updating to include category type

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/83b24534-0576-4b7d-a8e3-2239637648cd)
![image](https://github.com/user-attachments/assets/426b02ab-e703-4c2d-a474-eb22b6ba2df0)

**Checklist:**  
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331.

**Additional context**  
N/A
