### PR TITLE
fix(items): allow power items to roll damage

### DIFF
--- a/src/system/data/item/power.ts
+++ b/src/system/data/item/power.ts
@@ -13,10 +13,12 @@ import {
     DescriptionItemMixin,
     DescriptionItemData,
 } from './mixins/description';
+import { DamagingItemData, DamagingItemMixin } from './mixins/damaging';
 
 export interface PowerItemData
     extends IdItemData,
         TypedItemData<PowerType>,
+        DamagingItemData,
         DescriptionItemData {
     /**
      * Wether to a custom skill is used, or
@@ -52,6 +54,7 @@ export class PowerItemDataModel extends DataModelMixin<
             ),
     }),
     ActivatableItemMixin(),
+    DamagingItemMixin(),
     DescriptionItemMixin({
         value: 'COSMERE.Item.Type.Power.desc_placeholder',
     }),

--- a/src/templates/item/power/partials/power-details-tab.hbs
+++ b/src/templates/item/power/partials/power-details-tab.hbs
@@ -18,10 +18,11 @@
                     blank="GENERIC.None"
                 }}
             {{/if}}
-        </div>        
+        </div>
     </fieldset>
     
     {{app-item-details-activation}}
+    {{app-item-details-damage}}
 </div>
 
 {{/with}}


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Modifies the Power item data model and sheet template to allow for damage rolls/configuration.

**Related Issue**  
Closes #333 

**How Has This Been Tested?**  
1. Create a new power item.
2. Go to details, change the formula/damage type
3. Roll the item from an actor
4. Confirm that a damage roll is produced

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.311
