### PR TITLE
feat(items): expand data model and usage workflow to support multiple consumption options

### DIFF
--- a/src/style/sheets/item/module.scss
+++ b/src/style/sheets/item/module.scss
@@ -316,7 +316,7 @@
             min-height: 32px;
 
             > app-id-input,
-            > .form-fields {
+            .form-fields {
                 display: flex;
                 flex-direction: row;
                 flex: 2;

--- a/src/system/applications/item/base.ts
+++ b/src/system/applications/item/base.ts
@@ -19,6 +19,7 @@ import { ComponentHandlebarsApplicationMixin } from '@system/applications/compon
 import { TabsApplicationMixin } from '@system/applications/mixins';
 import { DescriptionItemData } from '@src/system/data/item/mixins/description';
 import { ItemConsumeData } from '@src/system/data/item/mixins/activatable';
+import { SYSTEM_ID } from '@src/system/constants';
 
 const { ItemSheetV2 } = foundry.applications.sheets;
 
@@ -433,7 +434,7 @@ export class BaseItemSheet extends TabsApplicationMixin(
     }
 
     /**
-     * Helper to track activation consumption changes
+     * Helper to manage activation consumption changes
      */
     private getUpdatedConsumption(
         formData: FormDataExtended,
@@ -450,7 +451,7 @@ export class BaseItemSheet extends TabsApplicationMixin(
             const parts = /\[(\d*)\]\.(\w+)$/.exec(formKey);
 
             if (!parts || parts.length < 2) {
-                console.error('Bad form key:', formKey);
+                console.error(`[${SYSTEM_ID}] Bad form key: ${formKey}`);
                 return;
             }
 
@@ -467,6 +468,8 @@ export class BaseItemSheet extends TabsApplicationMixin(
 
             existingConsumeData[dataKey] = formData.get(formKey);
 
+            // Use "None" to remove entries,
+            // otherwise we have a (theoretically) valid type, so use it.
             if (existingConsumeData.type === NONE) {
                 consumeData.delete(i);
             } else {

--- a/src/system/applications/item/components/details-activation.ts
+++ b/src/system/applications/item/components/details-activation.ts
@@ -1,4 +1,8 @@
-import { ActivationType } from '@system/types/cosmere';
+import {
+    ActivationType,
+    ItemConsumeType,
+    Resource,
+} from '@system/types/cosmere';
 import { ConstructorOf, NONE } from '@system/types/utils';
 import { SYSTEM_ID } from '@src/system/constants';
 import { TEMPLATES } from '@src/system/utils/templates';
@@ -11,6 +15,34 @@ export class DetailsActivationComponent extends HandlebarsApplicationComponent<
     ConstructorOf<BaseItemSheet>
 > {
     static TEMPLATE = `systems/${SYSTEM_ID}/templates/${TEMPLATES.ITEM_DETAILS_ACTIVATION}`;
+
+    /**
+     * NOTE: Unbound methods is the standard for defining actions
+     * within ApplicationV2
+     */
+    /* eslint-disable @typescript-eslint/unbound-method */
+    static readonly ACTIONS = {
+        'add-consumption-option': this.addConsumptionOption,
+    };
+    /* eslint-enable @typescript-eslint/unbound-method */
+
+    /* --- Actions --- */
+    protected static addConsumptionOption(this: DetailsActivationComponent) {
+        if (!this.application.item.hasActivation()) return;
+
+        // Get the activation data
+        const { activation } = this.application.item.system;
+
+        activation.consume?.push({
+            type: ItemConsumeType.Resource,
+            value: 0,
+            resource: Resource.Focus,
+        });
+
+        void this.application.item.update({
+            ['system.activation.consume']: activation.consume,
+        });
+    }
 
     /* --- Context --- */
 
@@ -28,10 +60,12 @@ export class DetailsActivationComponent extends HandlebarsApplicationComponent<
         // Get the activation data
         const { activation } = this.application.item.system;
 
+        console.log(activation);
+
         return {
             hasActivationType: activation.type !== ActivationType.None,
             hasActivationCost: !!activation.cost.type,
-            hasConsume: !!activation.consume,
+            consume: activation.consume,
             hasUses: !!activation.uses,
             hasSkill: !!activation.skill,
 

--- a/src/system/data/item/mixins/activatable.ts
+++ b/src/system/data/item/mixins/activatable.ts
@@ -16,6 +16,12 @@ interface ItemResourceData {
     recharge?: ItemRechargeType;
 }
 
+export interface ItemConsumeData {
+    type: ItemConsumeType;
+    value: number;
+    resource?: Resource;
+}
+
 export interface ActivatableItemData {
     activation: {
         type: ActivationType;
@@ -23,11 +29,7 @@ export interface ActivatableItemData {
             value?: number;
             type?: ActionCostType;
         };
-        consume?: {
-            type: ItemConsumeType;
-            value: number;
-            resource?: Resource;
-        };
+        consume?: ItemConsumeData[];
         uses?: {
             type: ItemUseType;
             value: number;
@@ -90,40 +92,43 @@ export function ActivatableItemMixin<P extends CosmereItem>() {
                                 required: true,
                             },
                         ),
-                        consume: new foundry.data.fields.SchemaField(
-                            {
-                                type: new foundry.data.fields.StringField({
-                                    required: true,
-                                    nullable: false,
-                                    blank: false,
-                                    choices: Object.keys(
-                                        CONFIG.COSMERE.items.activation
-                                            .consumeTypes,
-                                    ),
-                                    initial: ItemConsumeType.Resource,
-                                }),
-                                value: new foundry.data.fields.NumberField({
-                                    required: true,
-                                    nullable: false,
-                                    min: 0,
-                                    integer: true,
-                                    initial: 0,
-                                }),
-                                resource: new foundry.data.fields.StringField({
-                                    blank: false,
-                                    choices: [
-                                        ...Object.keys(
-                                            CONFIG.COSMERE.resources,
+                        consume: new foundry.data.fields.ArrayField(
+                            new foundry.data.fields.SchemaField(
+                                {
+                                    type: new foundry.data.fields.StringField({
+                                        required: true,
+                                        nullable: false,
+                                        blank: false,
+                                        choices: Object.keys(
+                                            CONFIG.COSMERE.items.activation
+                                                .consumeTypes,
                                         ),
-                                    ],
-                                    initial: Resource.Focus,
-                                }),
-                            },
-                            {
-                                required: false,
-                                nullable: true,
-                                initial: null,
-                            },
+                                        initial: ItemConsumeType.Resource,
+                                    }),
+                                    value: new foundry.data.fields.NumberField({
+                                        required: true,
+                                        nullable: false,
+                                        min: 0,
+                                        integer: true,
+                                        initial: 0,
+                                    }),
+                                    resource:
+                                        new foundry.data.fields.StringField({
+                                            blank: false,
+                                            choices: [
+                                                ...Object.keys(
+                                                    CONFIG.COSMERE.resources,
+                                                ),
+                                            ],
+                                            initial: Resource.Focus,
+                                        }),
+                                },
+                                {
+                                    required: false,
+                                    nullable: true,
+                                    initial: null,
+                                },
+                            ),
                         ),
                         flavor: new foundry.data.fields.HTMLField(),
                         skill: new foundry.data.fields.StringField({

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -839,7 +839,6 @@ export class CosmereItem<
         const consumptionAvailable =
             options.shouldConsume !== false && !!this.system.activation.consume;
 
-        console.log('test');
         // Determine if we should handle resource consumption
         let consumeResponse: ItemConsumeData[] | null = null;
         if (consumptionAvailable && !options.shouldConsume) {
@@ -849,7 +848,6 @@ export class CosmereItem<
             if (consumeResponse === null) return null;
         }
 
-        console.log(consumeResponse);
         // Handle resource consumption
         if (!!consumeResponse && consumeResponse.length > 0) {
             // Process each included resource consumption
@@ -1091,7 +1089,9 @@ export class CosmereItem<
                           : game.i18n!.localize('GENERIC.Unknown');
 
                 return {
+                    type: consumeType,
                     resource: label,
+                    resourceId: consumptionData.resource ?? 'unknown',
                     amount,
                     shouldConsume,
                 };

--- a/src/system/utils/handlebars/index.ts
+++ b/src/system/utils/handlebars/index.ts
@@ -344,32 +344,34 @@ Handlebars.registerHelper(
 
                 // Check if the activation consumes some resource
                 if (item.system.activation.consume) {
-                    const consumesResource =
-                        item.system.activation.consume.type ===
-                        ItemConsumeType.Resource;
-                    const consumesItem =
-                        item.system.activation.consume.type ===
-                        ItemConsumeType.Item;
+                    context.consume = [];
 
-                    // Get resource
-                    const resource = item.system.activation.consume.resource;
+                    for (const consumable of item.system.activation.consume) {
+                        const consumesResource =
+                            consumable.type === ItemConsumeType.Resource;
+                        const consumesItem =
+                            consumable.type === ItemConsumeType.Item;
 
-                    context.hasConsume = true;
-                    context.consume = {
-                        type: item.system.activation.consume.type,
-                        value: item.system.activation.consume.value,
-                        consumesResource,
-                        consumesItem,
+                        // Get resource
+                        const resource = consumable.resource;
 
-                        ...(resource
-                            ? {
-                                  resource:
-                                      item.system.activation.consume.resource,
-                                  resourceLabel:
-                                      CONFIG.COSMERE.resources[resource].label,
-                              }
-                            : {}),
-                    };
+                        context.hasConsume = true;
+                        context.consume.push({
+                            type: consumable.type,
+                            value: consumable.value,
+                            consumesResource,
+                            consumesItem,
+
+                            ...(resource
+                                ? {
+                                      resource: consumable.resource,
+                                      resourceLabel:
+                                          CONFIG.COSMERE.resources[resource]
+                                              .label,
+                                  }
+                                : {}),
+                        });
+                    }
                 }
 
                 if (item.system.activation.uses) {

--- a/src/system/utils/handlebars/types.ts
+++ b/src/system/utils/handlebars/types.ts
@@ -66,7 +66,7 @@ export interface ItemContext {
         consumesResource: boolean;
         consumesItem: boolean;
         resource: string;
-    }>;
+    }>[];
 
     hasUses: boolean;
     uses: Partial<{

--- a/src/templates/item/components/details-activation.hbs
+++ b/src/templates/item/components/details-activation.hbs
@@ -49,38 +49,50 @@
     {{!-- Consume --}}
     <div class="form-group consume">
         <label>{{localize "COSMERE.Item.Sheet.Activation.Consume"}}</label>
-        <div class="form-fields">
-            {{#if hasConsume}}
-            <input name="system.activation.consume.value"
-                type="number"
-                min="0"
-                step="1"
-                value="{{item.system.activation.consume.value}}"
-                {{#if (not editable)}}
-                readonly
-                {{/if}}
-            >
-            {{/if}}
+        <div>
+            {{#each consume}}
+            <div class="form-fields">
+                <input name="system.activation.consume[{{@index}}].value"
+                    type="number"
+                    min="0"
+                    step="1"
+                    value="{{this.value}}"
+                    {{#if (not ../editable)}}
+                    readonly
+                    {{/if}}
+                >
 
-            {{#if (eq item.system.activation.consume.type "resource")}}
-            <select name="system.activation.consume.resource"
+                {{#if (eq this.type "resource")}}
+                <select name="system.activation.consume[{{@index}}].resource"
+                    {{#if (not ../editable)}}
+                    disabled
+                    {{/if}}
+                >
+                    {{selectOptions ../resourceSelectOptions selected=this.resource localize=true}}
+                </select>
+                {{/if}}
+
+                {{!-- TODO: Consume type = item --}}
+
+                <select name="system.activation.consume[{{@index}}].type"
+                    {{#if (not ../editable)}}
+                    disabled
+                    {{/if}}
+                >
+                    {{selectOptions ../consumeTypeSelectOptions selected=this.type localize=true}}
+                </select>
+            </div>
+            {{else}}
+            <select name="system.activation.consume[].type"
                 {{#if (not editable)}}
                 disabled
                 {{/if}}
             >
-                {{selectOptions resourceSelectOptions selected=item.system.activation.consume.resource localize=true}}
+                {{selectOptions consumeTypeSelectOptions selected="none" localize=true}}
             </select>
-            {{/if}}
+            {{/each}}
 
-            {{!-- TODO: Consume type = item --}}
-
-            <select name="system.activation.consume.type"
-                {{#if (not editable)}}
-                disabled
-                {{/if}}
-            >
-                {{selectOptions consumeTypeSelectOptions selected=item.system.activation.consume.type localize=true}}
-            </select>
+            <button data-action="add-consumption-option">+</button>
         </div>
     </div>
 

--- a/src/templates/item/dialog/item-consume.hbs
+++ b/src/templates/item/dialog/item-consume.hbs
@@ -1,8 +1,10 @@
 <form>
     <div class="form-group">
-        <label>
-            <span>{{label}}</span>
-        </label>
-        <input type="checkbox" name="shouldConsume" {{#if shouldConsume}}checked{{/if}}>
+        {{#each resources as |resource|}}
+            <label>
+                <span>{{resource.label}}</span>
+            </label>
+            <input type="checkbox" name="{{resource.label}}" {{#if resource.shouldConsume}}checked{{/if}}>
+        {{/each}}
     </div>
 </form>

--- a/src/templates/item/dialog/item-consume.hbs
+++ b/src/templates/item/dialog/item-consume.hbs
@@ -1,10 +1,10 @@
 <form>
-    <div class="form-group">
+    <div class="form-group" id="consumables">
         {{#each resources as |resource|}}
             <label>
                 <span>{{resource.label}}</span>
             </label>
-            <input type="checkbox" name="{{resource.label}}" {{#if resource.shouldConsume}}checked{{/if}}>
+            <input id="{{resource.id}}" type="checkbox" name="{{resource.label}}" {{#if resource.shouldConsume}}checked{{/if}}>
         {{/each}}
     </div>
 </form>


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Other (please describe):

**Description**  
Extends the existing data model to represent resource consumption as a list. Additionally reconfigures the item sheet to support the addition of further consumption options (and their removal, by setting the type to None). Also updates the resource consumption dialog to allow the user to deselect any number of resources.

Duplicate resource types are fully supported, and handled appropriately. This is largely so users can choose to add additional costs, like additional Focus they might want to spend conditionally, as they desire.

**Data Changes**
`CosmereItem.system.activation.consume` - **Breaking**
- Old type: `ItemConsumeData`
- New type: `ItemConsumeData[]`

**Data migration is necessary.** 

**To-Do**
- [ ] Migration
- [ ] Style pass on the item activation data component and item-consume dialog


**Related Issue**  
Closes #262 

**How Has This Been Tested?**  
1. Create an item
2. Set the initial consume type to focus, with any non-zero value
3. Click the `+` to add another consumption option
4. Set the new consumption option to investiture, with any non-zero value
5. Roll the item, testing all four permutations of the resource consumption selection
6. Change the investiture option to _also_ be focus
7. Repeat step 5
8. Change either option to None- confirming that it disappears from the sheet.

**Screenshots (if applicable)**  
To-do (style pass pending)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.311.

**Additional context**  
I built this off of the 0.3.1 branch, but it's best to leave it for 1.0.0 as a result of the breaking change. I'm only using 0.3.1 as the base branch to simplify the commit history. We should hold this PR, even if complete, until 0.3.1 is out and merged into the 1.0.0 working branch.
