### PR TITLE
fix(actor): fix issue causing resource value clamping to ignore any bonus applied through active effects

### DIFF
--- a/src/declarations/foundry/common/abstract/data.d.ts
+++ b/src/declarations/foundry/common/abstract/data.d.ts
@@ -881,8 +881,7 @@ namespace foundry {
             public prepareData();
 
             /**
-             * Apply transformations of derivations to the values of the source data object.
-             * Compute data fields whose values are not stored to the database.
+             * Prepare data related to this Document itself, before any embedded Documents or derived data is computed.
              *
              * Called before {@link ClientDocument#prepareDerivedData} in {@link ClientDocument#prepareData}.
              */

--- a/src/system/data/actor/character.ts
+++ b/src/system/data/actor/character.ts
@@ -163,6 +163,16 @@ export class CharacterActorDataModel extends CommonActorDataModel<CharacterActor
                 // Assign max
                 resource.max.derived = 2 + willpower;
             }
+        });
+    }
+
+    public override prepareSecondaryDerivedData(): void {
+        super.prepareSecondaryDerivedData();
+
+        // Clamp resource values to their max values
+        (Object.keys(this.resources) as Resource[]).forEach((key) => {
+            // Get the resource
+            const resource = this.resources[key];
 
             // Get max
             const max = resource.max.value;

--- a/src/system/data/actor/common.ts
+++ b/src/system/data/actor/common.ts
@@ -707,6 +707,12 @@ export class CommonActorDataModel<
             this.attributes.str,
         );
     }
+
+    /**
+     * Apply secondary data derivations to this Data Model.
+     * This is called after Active Effects are applied.
+     */
+    public prepareSecondaryDerivedData(): void {}
 }
 
 const SENSES_RANGES = [5, 10, 20, 50, 100, Number.MAX_VALUE];

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -229,6 +229,7 @@ export class CosmereActor<
     public prepareDerivedData() {
         super.prepareDerivedData();
         this.applyActiveEffects();
+        this.system.prepareSecondaryDerivedData();
     }
 
     protected override _initialize(options?: object) {


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR resolves the issue where resources value clamping would ignore any bonus applied through Active Effects. This is fixed by introducing a secondary derivation step after AEs are applied for Actor data, and moving resource value clamping to that step.

**Related Issue**  
Closes #347 

**How Has This Been Tested?**  
1. Create an active effect with: key `system.resources.foc.max.bonus`, mode: `Add`, value: `2`
2. Toggle effect on
3. Increase focus by 2 above previous max

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331