### PR TITLE
fix(configure resources config): fix issue causing bonus value to double each time the dialog is saved

### DIFF
--- a/src/system/applications/actor/dialogs/configure-resource.ts
+++ b/src/system/applications/actor/dialogs/configure-resource.ts
@@ -88,7 +88,12 @@ export class ConfigureResourceDialog extends HandlebarsApplicationMixin(
 
     private static onUpdateResource(this: ConfigureResourceDialog) {
         void this.actor.update({
-            [`system.resources.${this.resourceId}`]: this.resourceData,
+            [`system.resources.${this.resourceId}`]: {
+                max: {
+                    mode: this.mode,
+                    override: this.resourceData.max.override,
+                },
+            },
         });
         void this.close();
     }

--- a/src/system/applications/actor/dialogs/configure-resource.ts
+++ b/src/system/applications/actor/dialogs/configure-resource.ts
@@ -90,7 +90,7 @@ export class ConfigureResourceDialog extends HandlebarsApplicationMixin(
         void this.actor.update({
             [`system.resources.${this.resourceId}`]: {
                 max: {
-                    mode: this.mode,
+                    useOverride: this.resourceData.max.useOverride,
                     override: this.resourceData.max.override,
                 },
             },

--- a/src/templates/actors/dialogs/configure-resource.hbs
+++ b/src/templates/actors/dialogs/configure-resource.hbs
@@ -10,7 +10,7 @@
                 type="number"
                 min="0"
                 step="1"
-                value="{{derived max}}"
+                value="{{default max.override (derived max)}}"
                 {{/if}}
             >
         </div>        


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR fixes an issue with the configure resource dialog that causes the bonus value to be doubled each time the dialog is saved. Also resolves an issue causing the override (custom) input to re-apply the bonus after any change.

**Related Issue**  
Closes #346 

**How Has This Been Tested?**  
1. Create an active effect with: key system.resources.foc.max.bonus, mode: Add, value: 2
2. Toggle effect on
3. Open the resource config dialog for focus
4. Set it to mode custom
5. Adjust the value twice
6. Click update (value should be whatever you set custom to)
7. Open the config again
8. Click update (value should not change)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331