### PR TITLE
feat: armor charge tracking

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -321,6 +321,7 @@
                 "Armor": {
                     "label": "Armor",
                     "label_plural": "Armor",
+                    "label_action": "Armor Action",
                     "desc_placeholder": "Edit this to describe what this armor is & how it looks.",
                     "New": "New Armor"
                 },

--- a/src/system/applications/actor/components/actions-list.ts
+++ b/src/system/applications/actor/components/actions-list.ts
@@ -98,6 +98,30 @@ const STATIC_SECTIONS = {
                 { parent },
             ) as Promise<CosmereItem>,
     },
+    Armor: {
+        id: 'armor',
+        label: 'COSMERE.Item.Type.Armor.label_plural',
+        name: 'COSMERE.Item.Type.Armor.label_action',
+        default: false,
+        filter: (item: CosmereItem) => item.isArmor(),
+        new: (parent: CosmereActor) =>
+            CosmereItem.create(
+                {
+                    type: ItemType.Equipment,
+                    name: game.i18n!.localize('COSMERE.Item.Type.Armor.New'),
+                    system: {
+                        activation: {
+                            type: ActivationType.Utility,
+                            cost: {
+                                type: ActionCostType.Action,
+                                value: 1,
+                            },
+                        },
+                    },
+                },
+                { parent },
+            ) as Promise<CosmereItem>,
+    },
     Equipment: {
         id: 'equipment',
         label: 'COSMERE.Item.Type.Equipment.label_plural',
@@ -378,7 +402,7 @@ export class ActorActionsListComponent extends HandlebarsApplicationComponent<
                       },
                   ]
                 : []),
-
+            STATIC_SECTIONS.Armor,
             STATIC_SECTIONS.Equipment,
             STATIC_SECTIONS.BasicActions,
             STATIC_SECTIONS.MiscActions,

--- a/src/system/data/item/armor.ts
+++ b/src/system/data/item/armor.ts
@@ -9,6 +9,10 @@ import {
     DescriptionItemData,
 } from './mixins/description';
 import { EquippableItemMixin, EquippableItemData } from './mixins/equippable';
+import {
+    ActivatableItemMixin,
+    ActivatableItemData,
+} from './mixins/activatable';
 import { TraitsItemMixin, TraitsItemData } from './mixins/traits';
 import { PhysicalItemMixin, PhysicalItemData } from './mixins/physical';
 import { ExpertiseItemMixin, ExpertiseItemData } from './mixins/expertise';
@@ -17,6 +21,7 @@ export interface ArmorItemData
     extends IdItemData,
         DescriptionItemData,
         EquippableItemData,
+        ActivatableItemData,
         ExpertiseItemData,
         TraitsItemData<ArmorTraitId>,
         PhysicalItemData {
@@ -39,6 +44,7 @@ export class ArmorItemDataModel extends DataModelMixin<
             choices: [EquipType.Wear],
         },
     }),
+    ActivatableItemMixin(),
     ExpertiseItemMixin(),
     TraitsItemMixin(),
     PhysicalItemMixin(),

--- a/src/templates/item/armor/partials/armor-details-tab.hbs
+++ b/src/templates/item/armor/partials/armor-details-tab.hbs
@@ -6,6 +6,7 @@
         {{app-item-details-id}}
     </fieldset>
     {{app-item-details-equip}}
+    {{app-item-details-activation}}
     <fieldset>
         <legend>{{localize "COSMERE.Item.Armor.Deflect"}}</legend>
         <div class="item-details-form">


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Makes armour items activatable so that the can contain charge tracking. This is in lieu of a later refactor to separate actions from items more distinctly, as the current approach is clunky.

**Related Issue**  
Closes #338.

**How Has This Been Tested?**  
Tested with existing and new armor items to make sure they have the Usage section and that, when equipped, they show in the actions tab under a new armor section.

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/6e7ae950-f687-4775-a853-0b51436eb6d1)
![image](https://github.com/user-attachments/assets/a62dc784-ad90-44f2-bfa3-160bea95f501)

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: [insert version here].
