### PR TITLE
feat: sense vision mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,31 @@ Hooks.once('init', async () => {
     // @ts-expect-error see note
     CONFIG.Dice.rolls.push(dice.DamageRoll);
 
+    CONFIG.Canvas.visionModes.sense = new VisionMode({
+        id: 'sense',
+        label: 'COSMERE.Actor.Statistics.SensesRange',
+        canvas: {
+            shader: ColorAdjustmentsSamplerShader,
+            uniforms: { contrast: 0, saturation: -1.0, brightness: 0 },
+        },
+        lighting: {
+            levels: {
+                [VisionMode.LIGHTING_LEVELS.DIM]:
+                    VisionMode.LIGHTING_LEVELS.BRIGHT,
+            },
+            background: { visibility: VisionMode.LIGHTING_VISIBILITY.REQUIRED },
+        },
+        vision: {
+            darkness: { adaptive: false },
+            defaults: {
+                attenuation: 0,
+                contrast: 0,
+                saturation: -1.0,
+                brightness: 0,
+            },
+        },
+    });
+
     // Register status effects
     registerStatusEffects();
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Adds a new vision mode "Sense" that is system appropriate (instead of "Darkvision").

**Related Issue**  
Closes #320.

**How Has This Been Tested?**  
Tested that the new Sense mode appears on tokens and that it correctly displays vision the same way as Darkvision (for now).

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/76b98bb0-06a5-4904-9ac0-c0fdc2baa0dd)

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: [insert version here].
