### PR TITLE
fix: non-square ratio item portraits

### DIFF
--- a/src/style/sheets/item/module.scss
+++ b/src/style/sheets/item/module.scss
@@ -85,6 +85,8 @@
                 flex: none;
                 height: 72px;
                 margin-top: -0.375rem;
+                display: flex;
+                justify-content: center;
     
                 &::after {
                     box-shadow: inset 0 0 12px var(--cosmere-shadow-85);
@@ -99,12 +101,13 @@
                 }
     
                 img {
-                    width: 100%;
-                    height: 100%;
-                    object-fit: cover;
-                    object-position: center;
+                    max-width: 100%;
+                    max-height: 100%;
+                    height: auto;
+                    width: auto;
                     border: none;
                     margin: unset;
+                    flex: 0;
                 }
     
                 img:hover {

--- a/src/style/sheets/sheet.scss
+++ b/src/style/sheets/sheet.scss
@@ -112,6 +112,12 @@
                 align-items: center;
                 justify-content: center;
 
+                > img {
+                    max-width: 100%;
+                    max-height: 100%;
+                    border: 0;
+                }
+
                 .roll-icon {
                     display: none;
                     position: absolute;


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue where items with non-square ratios would escape the bounds of their portrait square in the item list. Also fixes how items with non-square ratios show in the item sheet, now appropriately adding padding and centring the images.

**Related Issue**  
Closes #334.

**How Has This Been Tested?**  
Tested with both types of non-square ratio images (horizontal and vertical preference) in both actor sheet item lists and in the item sheet itself.

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/6e8b6664-986b-40b5-8132-9252d6bb8efe)
![image](https://github.com/user-attachments/assets/6992a584-86fb-4ff5-a332-c69857bbe910)

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: [insert version here].
