### PR TITLE
fix(skill mods): Ensured Attribute mods were properly accounted for

### DIFF
--- a/src/system/data/actor/common.ts
+++ b/src/system/data/actor/common.ts
@@ -635,26 +635,26 @@ export class CommonActorDataModel<
             this.defenses[group].derived = 10 + attrsSum;
         });
 
-        // Derive skill modifiers
-        (Object.keys(this.skills) as Skill[]).forEach((skill) => {
-            // Get the skill config
-            const skillConfig = CONFIG.COSMERE.skills[skill];
+        // // Derive skill modifiers
+        // (Object.keys(this.skills) as Skill[]).forEach((skill) => {
+        //     // Get the skill config
+        //     const skillConfig = CONFIG.COSMERE.skills[skill];
 
-            // Get the attribute associated with this skill
-            const attributeId = skillConfig.attribute;
+        //     // Get the attribute associated with this skill
+        //     const attributeId = skillConfig.attribute;
 
-            // Get attribute
-            const attribute = this.attributes[attributeId];
+        //     // Get attribute
+        //     const attribute = this.attributes[attributeId];
 
-            // Get skill rank
-            const rank = this.skills[skill].rank;
+        //     // Get skill rank
+        //     const rank = this.skills[skill].rank;
 
-            // Get attribute value
-            const attrValue = attribute.value + attribute.bonus;
+        //     // Get attribute value
+        //     const attrValue = attribute.value + attribute.bonus;
 
-            // Calculate mod
-            this.skills[skill].mod.derived = attrValue + rank;
-        });
+        //     // Calculate mod
+        //     this.skills[skill].mod.derived = attrValue + rank;
+        // });
 
         // Derive non-core skill unlocks
         (Object.keys(this.skills) as Skill[]).forEach((skill) => {
@@ -765,7 +765,28 @@ export class CommonActorDataModel<
      * Apply secondary data derivations to this Data Model.
      * This is called after Active Effects are applied.
      */
-    public prepareSecondaryDerivedData(): void {}
+    public prepareSecondaryDerivedData(): void {
+        // Derive skill modifiers
+        (Object.keys(this.skills) as Skill[]).forEach((skill) => {
+            // Get the skill config
+            const skillConfig = CONFIG.COSMERE.skills[skill];
+
+            // Get the attribute associated with this skill
+            const attributeId = skillConfig.attribute;
+
+            // Get attribute
+            const attribute = this.attributes[attributeId];
+
+            // Get skill rank
+            const rank = this.skills[skill].rank;
+
+            // Get attribute value
+            const attrValue = attribute.value + attribute.bonus;
+
+            // Calculate mod
+            this.skills[skill].mod.derived = attrValue + rank;
+        });
+    }
 }
 
 const SENSES_RANGES = [5, 10, 20, 50, 100, Number.MAX_VALUE];

--- a/src/system/data/actor/common.ts
+++ b/src/system/data/actor/common.ts
@@ -635,27 +635,6 @@ export class CommonActorDataModel<
             this.defenses[group].derived = 10 + attrsSum;
         });
 
-        // // Derive skill modifiers
-        // (Object.keys(this.skills) as Skill[]).forEach((skill) => {
-        //     // Get the skill config
-        //     const skillConfig = CONFIG.COSMERE.skills[skill];
-
-        //     // Get the attribute associated with this skill
-        //     const attributeId = skillConfig.attribute;
-
-        //     // Get attribute
-        //     const attribute = this.attributes[attributeId];
-
-        //     // Get skill rank
-        //     const rank = this.skills[skill].rank;
-
-        //     // Get attribute value
-        //     const attrValue = attribute.value + attribute.bonus;
-
-        //     // Calculate mod
-        //     this.skills[skill].mod.derived = attrValue + rank;
-        // });
-
         // Derive non-core skill unlocks
         (Object.keys(this.skills) as Skill[]).forEach((skill) => {
             if (CONFIG.COSMERE.skills[skill].core) return;

--- a/src/system/dice/d20-roll.ts
+++ b/src/system/dice/d20-roll.ts
@@ -265,7 +265,7 @@ export class D20Roll extends foundry.dice.Roll<D20RollData> {
                 ? this.data.attributes[result.attribute]
                 : { value: 0, bonus: 0 };
             this.terms[2] = new foundry.dice.terms.NumericTerm({
-                number: skill.rank + attribute.value,
+                number: skill.rank + attribute.value + attribute.bonus,
             });
         }
 

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -854,7 +854,7 @@ export class CosmereActor<
 
         // Add attribute mod
         data.mod = options.attribute
-            ? attribute.value + skill.rank
+            ? attribute.value + attribute.bonus + skill.rank
             : skill.mod.value;
         data.skill = {
             id: skillId,


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This change ensures that the skill displays, roll dialogs and roll calculations all correctly account for any attribute bonuses applied through Active Effects.
This is achieved mainly through the moving of where the skill mod derived data field is calculated, but also required some updates to the roll configuration dialogs to ensure correct display there too.

**Related Issue**  
Closes #356

**How Has This Been Tested?**  
Following the reproduction steps in the linked issue (see images) and also by rolling skills from the sheet.

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/bfcce5ea-329f-4560-b2e2-51cdcfee6ecb)
![image](https://github.com/user-attachments/assets/870d31f6-5bef-41c7-b336-7ed6668a1d92)
![image](https://github.com/user-attachments/assets/3d84d99d-2647-43d9-a772-c17f17d3d3c2)
![image](https://github.com/user-attachments/assets/56e232ac-8610-4e2a-bd63-5c47e3021008)


**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331.
