### PR TITLE
fix(talent trees): fix issue causing the context menu to appear in the wrong spot for nested talent tree nodes

### DIFF
--- a/src/system/applications/item/components/talent-tree/canvas/elements/connection.ts
+++ b/src/system/applications/item/components/talent-tree/canvas/elements/connection.ts
@@ -162,16 +162,16 @@ export abstract class BaseConnection extends Drawable {
 
         if (!this.path || this.path.length === 0) {
             this.moveTo(
-                this.from.position.x +
+                this.from.origin.x +
                     this.from.size.width / 2 +
                     this.fromOffset.x,
-                this.from.position.y +
+                this.from.origin.y +
                     this.from.size.height / 2 +
                     this.fromOffset.y,
             );
             this.lineTo(
-                this.to.position.x + this.to.size.width / 2 + this.toOffset.x,
-                this.to.position.y + this.to.size.height / 2 + this.toOffset.y,
+                this.to.origin.x + this.to.size.width / 2 + this.toOffset.x,
+                this.to.origin.y + this.to.size.height / 2 + this.toOffset.y,
             );
         } else {
             for (let i = 0; i < this.path.length; i++) {
@@ -435,11 +435,11 @@ export class NestedTreeConnection extends BaseConnection {
 
     protected get fromOffset() {
         return {
-            x:
-                (this.from.contentBounds?.x ?? 0) -
-                GRID_SIZE / 2 +
-                (this.from.contentBounds?.width ?? 0) / 2,
-            y: (this.from.contentBounds?.y ?? 0) - GRID_SIZE,
+            x: 0,
+            y: -(
+                this.from.size.height / 2 -
+                (this.from.header?.size.height ?? 0) / 2
+            ),
         };
     }
 }

--- a/src/system/applications/item/components/talent-tree/canvas/elements/nodes/talent-node.ts
+++ b/src/system/applications/item/components/talent-tree/canvas/elements/nodes/talent-node.ts
@@ -74,6 +74,13 @@ export class TalentNode extends BaseNode {
 
     /* --- Accessors --- */
 
+    public override get size() {
+        return {
+            width: this.data.size.width,
+            height: this.data.size.height,
+        };
+    }
+
     public get glowFilter() {
         return this.filters![0] as GlowFilter;
     }

--- a/src/system/applications/item/components/talent-tree/canvas/elements/nodes/types.ts
+++ b/src/system/applications/item/components/talent-tree/canvas/elements/nodes/types.ts
@@ -15,7 +15,7 @@ export abstract class BaseNode extends Drawable {
 
     public constructor(
         canvas: PIXICanvasApplication,
-        public readonly data: NodeData,
+        public readonly data: TalentTree.Node,
     ) {
         super(canvas);
 
@@ -34,6 +34,10 @@ export abstract class BaseNode extends Drawable {
             width: GRID_SIZE,
             height: GRID_SIZE,
         };
+    }
+
+    public get origin(): PIXI.IPointData {
+        return this.position;
     }
 
     /* --- Public functions --- */

--- a/src/system/applications/item/components/talent-tree/talent-tree-view.ts
+++ b/src/system/applications/item/components/talent-tree/talent-tree-view.ts
@@ -199,22 +199,28 @@ export class TalentTreeViewComponent<
 
         this.app.world.on(
             'rightclick-node',
-            (event: RightClickNodeEvent<CanvasElements.Nodes.TalentNode>) => {
+            (event: RightClickNodeEvent<CanvasElements.Nodes.BaseNode>) => {
                 // Convert node position to view space
-                const viewPos = this.viewport!.worldToView(event.node.position);
+                const viewPos = this.viewport!.worldToView(event.node.origin);
 
                 // Get options
                 const options = [
-                    ...this.getTalentContextMenuOptions(event.node.data),
+                    ...(event.node.data.type === TalentTree.Node.Type.Talent
+                        ? this.getTalentContextMenuOptions(event.node.data)
+                        : []),
                     ...this.getNodeContextMenuOptions(event.node.data),
                 ];
                 if (options.length === 0) return;
 
+                // Adjust size for zoom
+                const size = {
+                    width: event.node.size.width * this.viewport!.view.zoom,
+                    height: event.node.size.height * this.viewport!.view.zoom,
+                };
+
                 // Show context menu
                 void this.contextMenu!.show(options, {
-                    left:
-                        viewPos.x +
-                        event.node.data.size.width / this.viewport!.view.zoom,
+                    left: viewPos.x + size.width,
                     top: viewPos.y,
                 });
             },

--- a/src/system/types/item/talent-tree.ts
+++ b/src/system/types/item/talent-tree.ts
@@ -106,7 +106,7 @@ export namespace Node {
         | LevelPrerequisite;
 }
 
-interface BaseNode<Type extends Node.Type = Node.Type> {
+export interface BaseNode<Type extends Node.Type = Node.Type> {
     /**
      * Unique identifier for the node
      */


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR resolves an issue where the context menu for nested talent tree nodes was being put in the wrong location. This was caused due to a nested talent tree node's actual position being the origin of the tree, however the content within that tree can be positioned arbitrarily. I've resolved it by adding an "origin" getter, which resolves to the top left of the tree.

Also added some additional de-saturation and reduced the brightness of talents in nested talent trees so it doesn't appear as though they can be edited/right clicked.

**Related Issue**  
Closes #368 

**How Has This Been Tested?**  
1. Open any talent tree that contains nested tree nodes
2. Right click a nested tree node -> confirm the context menu is in the right spot now
3. Right click a regular talent node -> confirm the context menu is still in the right spot

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/948df8df-e5fb-497a-a531-89e64d3ab36c)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343