### PR TITLE
fix(talent trees): fix issue causing talent hover description fallback to fail

### DIFF
--- a/src/system/applications/item/components/talent-tree/talent-tree-view.ts
+++ b/src/system/applications/item/components/talent-tree/talent-tree-view.ts
@@ -12,6 +12,7 @@ import { NodeConnection } from './types';
 import * as TalentTreeUtils from '@system/utils/talent-tree';
 import { AppContextMenu } from '@system/applications/utils/context-menu';
 import { renderSystemTemplate, TEMPLATES } from '@system/utils/templates';
+import { htmlStringHasContent } from '@system/utils/generic';
 
 // Component imports
 import { HandlebarsApplicationComponent } from '@system/applications/component-system';
@@ -509,9 +510,11 @@ export class TalentTreeViewComponent<
                     };
                 }),
                 description: await TextEditor.enrichHTML(
-                    item.system.description?.short ??
-                        item.system.description?.value ??
-                        '',
+                    htmlStringHasContent(item.system.description?.short)
+                        ? item.system.description!.short!
+                        : htmlStringHasContent(item.system.description?.value)
+                          ? item.system.description!.value!
+                          : '',
                 ),
                 hasContextActor: !!this.contextActor,
             },

--- a/src/system/utils/generic.ts
+++ b/src/system/utils/generic.ts
@@ -9,6 +9,23 @@ import {
 import { AdvantageMode } from '../types/roll';
 import { NONE } from '../types/utils';
 
+const HTML_TAG_REGEX = /<[^>]+>/g;
+
+/**
+ * Checks if a given HTML string has any content or is just whitespace.
+ * @param htmlString The HTML string to check.
+ * @returns True if the HTML string has content, false otherwise.
+ */
+export function htmlStringHasContent(htmlString: string | undefined): boolean {
+    // If the string is undefined or null, return false
+    if (!htmlString) return false;
+
+    // Remove HTML tags and trim whitespace
+    const content = htmlString.replace(HTML_TAG_REGEX, '').trim();
+    // Check if the content is not empty
+    return content.length > 0;
+}
+
 /**
  * Determine if the keys of a requested keybinding are pressed.
  * @param {string} action Keybinding action within the system namespace. Can have multiple keybindings associated.


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR fixes an issue where the talent tooltip on talent trees uses the short description even if it is empty. Caused by the use of the nullish coalescing operator (short description was an empty string). Also needed to add a check if the html contained actual content as a description with just whitespace was causing the same issue.

**Related Issue**  
Closes #366 

**How Has This Been Tested?**  
1. Create talent tree item
2. Create talent item
3. Add description (not short desc)
4. Add talent to talent tree
5. Leave edit mode on talent tree
6. Hover over talent -> Ensure you see the proper description
7. Add short description to talent
8. Hover over talent -> Ensure you see the short description
9. Replace short description with several spaces (only whitespace)
10. Hover over talent -> Ensure you see the proper description again

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343