### PR TITLE
fix: natural deflect types

### DIFF
--- a/src/system/data/actor/common.ts
+++ b/src/system/data/actor/common.ts
@@ -687,6 +687,14 @@ export class CommonActorDataModel<
                         (this.deflect.types![type as DamageType] =
                             armor.system.deflects[type as DamageType].active),
                 );
+            } else {
+                Object.keys(CONFIG.COSMERE.damageTypes).forEach(
+                    (type) =>
+                        (this.deflect.types![type as DamageType] = !(
+                            CONFIG.COSMERE.damageTypes[type as DamageType]
+                                .ignoreDeflect ?? false
+                        )),
+                );
             }
 
             // Derive deflect


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue where when no armour is equipped by an actor, all damage ignores deflect. Now, if no armour is equipped, the default deflect config is used (plus whatever effects may be active on the actor).

**How Has This Been Tested?**  
Tested that default deflect types are now properly deflected if no armour is equipped. If armour is equipped, the deflect types from the armour itself are used instead (even if there are fewer of them than the default configs).

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/6fb1f2ab-8e0d-437a-96d5-a3a5cba4f709)
![image](https://github.com/user-attachments/assets/b968311e-089a-4e28-89ce-abcd3b827d13)

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: 12.331.
