### PR TITLE
feat: add rules compendium with conditions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,14 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+### Exceptions
+This project is primarily licensed under the MIT License. However, the following directories contain content that is **excluded from the MIT License**:
+
+- `src/packs/rules/`
+- `src/packs/tables/`
+
+Content within these directories is included with permission from Brotherwise Games, LLC and is subject to separate restrictions.  
+See the respective `LICENSE` files in each directory for specific terms.

--- a/README.md
+++ b/README.md
@@ -14,3 +14,17 @@ For guidelines on how to create Issues, please see [CONTRIBUTING.md](./CONTRIBUT
 
 ## Contributing
 Wish to contribute? Check out [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## License
+The code and original assets in this project are licensed under the [MIT License](./LICENSE).
+
+However, some content in this repository is included with permission from Brotherwise Games and is **not** covered by the MIT License.
+
+This includes (but may not be limited to) the following directories:
+- `src/packs/rules/`
+- `src/packs/tables/`
+
+These directories contain official material from the *Cosmere Roleplaying Game* and are subject to separate terms.  
+Each includes a `LICENSE` file with the relevant details.
+
+Do not copy, redistribute, or reuse this content outside of this project.

--- a/src/declarations/foundry/client/data/documents/active-effect.d.ts
+++ b/src/declarations/foundry/client/data/documents/active-effect.d.ts
@@ -1,8 +1,3 @@
-// declare interface ActiveEffect {
-//     get id(): string;
-//     get parent(): foundry.abstract.Document | null;
-// }
-
 declare namespace ActiveEffect {
     interface EffectChangeData {
         /**

--- a/src/declarations/foundry/client/data/documents/journal-entry-page.d.ts
+++ b/src/declarations/foundry/client/data/documents/journal-entry-page.d.ts
@@ -1,0 +1,37 @@
+declare namespace JournalEntryPage {
+    interface BuildTOCOptions {
+        /**
+         * Include references to the heading DOM elements in the returned ToC.
+         * @default true
+         */
+        includeElement?: boolean;
+    }
+}
+
+declare interface JournalEntryPageHeading {
+    text: string;
+    level: number;
+    slug: string;
+    children: JournalEntryPageHeading[];
+    element?: HTMLElement;
+}
+
+declare class JournalEntryPage extends _ClientDocumentMixin(
+    foundry.documents.BaseJournalEntryPage,
+) {
+    /**
+     * Build a table of contents for the given HTML content.
+     * @param html                     The HTML content to generate a ToC outline for.
+     * @param options                  Additional options to configure ToC generation.
+     */
+    static buildTOC(
+        html: HTMLElement[],
+        options?: JournalEntryPage.BuildTOCOptions,
+    ): Record<string, JournalEntryPageHeading>;
+
+    text: {
+        content: string;
+        format: number;
+        type: string;
+    };
+}

--- a/src/declarations/foundry/client/data/documents/journal-entry.d.ts
+++ b/src/declarations/foundry/client/data/documents/journal-entry.d.ts
@@ -1,0 +1,5 @@
+declare class JournalEntry extends _ClientDocumentMixin(
+    foundry.documents.BaseJournalEntry,
+) {
+    pages: Collection<JournalEntryPage>;
+}

--- a/src/declarations/foundry/common/documents/journal-entry-page.d.ts
+++ b/src/declarations/foundry/common/documents/journal-entry-page.d.ts
@@ -1,0 +1,5 @@
+namespace foundry {
+    namespace documents {
+        declare class BaseJournalEntryPage extends foundry.abstract.Document {}
+    }
+}

--- a/src/declarations/foundry/common/documents/journal-entry.d.ts
+++ b/src/declarations/foundry/common/documents/journal-entry.d.ts
@@ -1,0 +1,5 @@
+namespace foundry {
+    namespace documents {
+        declare class BaseJournalEntry extends foundry.abstract.Document {}
+    }
+}

--- a/src/packs/rules/LICENSE
+++ b/src/packs/rules/LICENSE
@@ -1,0 +1,7 @@
+The contents of this directory are © Brotherwise Games, LLC. Used with permission.
+
+This content is **not licensed under the MIT License** and is excluded from the open source licensing of the rest of this project.
+
+It may not be redistributed, reproduced, or reused except when used within this project, and only under the terms granted by Brotherwise Games, LLC.
+
+All rights reserved.

--- a/src/packs/rules/conditions.json
+++ b/src/packs/rules/conditions.json
@@ -1,0 +1,39 @@
+{
+    "name": "Conditions",
+    "_id": "A3Ac4yL1J0tdYcjP",
+    "pages": [
+        {
+            "sort": 700000,
+            "name": "Conditions",
+            "type": "text",
+            "_id": "OMT0NRT0IcBuHczN",
+            "system": {},
+            "title": {
+                "show": true,
+                "level": 1
+            },
+            "image": {},
+            "text": {
+                "format": 1,
+                "content": "<div class=\"sl-journal\"><p>Many effects can apply a temporary condition to you (for example, “you become @UUID[.OMT0NRT0IcBuHczN#slowed]{Slowed}”). These alter your abilities for the duration of that effect.</p><p>If an effect doesn’t state its duration (or how you can remove the condition early), all the rules you need for determining that are in the condition itself.</p><p>Conditions generally only apply to characters, not objects. For example, if a rule tells you to apply a condition to targets in a certain area, objects in that area ignore that condition. However, when it fits the story, the GM might decide that objects are affected by a condition (or by a similar narrative effect).</p><p>This game includes the following conditions, listed in alphabetical order.</p><p></p><h2>Afflicted</h2><p>While Afflicted, you slowly take damage over time. In combat, at the end of each of your turns, you take the amount and type of damage specified by the effect that gave you the condition; this information is typically stated in brackets. For example, if you’re Afflicted [[/r 1d4]] Vital, you take 1d4 damage at the end of each of your turns.</p><p>Out of combat, you instead take that damage every 10 seconds and after each time someone attempts to remove the condition.</p><p>Unlike most conditions, you can be Afflicted by multiple effects simultaneously. When this happens, resolve each effect separately.</p><p></p><h2>Determined</h2><p>While Determined, when you fail a test, you can add an Opportunity to the result. After you choose to do so, remove the Determined condition.</p><p></p><h2>Disoriented</h2><p>While Disoriented, your senses are disrupted, making most tasks difficult. You can’t use reactions, your senses always count as obscured, and Perception tests (and similar tests to use your senses) gain a disadvantage.</p><p></p><h2>Empowered</h2><p>When a Knight Radiant swears an Ideal, they become Empowered, granting a burst of unrestrained power. While Empowered, you gain an advantage on all tests and your Investiture refills to your maximum at the start of each of your turns. Remove this condition at the end of the current scene.</p><p></p><h2>Enhanced</h2><p>While Enhanced, one of your attributes temporarily increases, as specified in brackets when you gain that condition. The specified attribute gains a bonus equal to the specified number; however, this bonus doesn’t change your defenses, maximum health, maximum focus, or maximum Investiture.</p><p>For example, if you have a Speed of 3 and become Enhanced [+2 Speed], you temporarily gain the following benefits:</p><ul><li><p>Gain a +2 bonus to Agility, Light Weaponry, Stealth, and Thievery tests.</p></li><li><p>Gain a +2 bonus to any talents that directly use your Speed.</p></li><li><p>Increase your movement rate from 30 feet to 40 feet.</p></li></ul><p>Unlike most conditions, Enhanced has a cumulative effect, and more than one of your attributes can be Enhanced at a time.</p><p></p><h2>Exhausted</h2><p>While Exhausted, you feel fatigued and your skill tests become more difficult.</p><p>When you gain this condition, it states a negative number in brackets. After you calculate a test result but before you resolve its effects, apply a penalty equal to this number.</p><p>After each long rest, reduce your Exhausted penalty by 1. The condition is removed when your penalty equals 0.</p><p>Unlike most conditions, Exhausted has a cumulative effect. When you gain a second instance of this condition, add its listed penalty to your current Exhausted penalty. For example, if an effect makes you Exhausted [-2], you subtract 2 from the result of all tests; if a different effect then makes you Exhausted [-1], that increases your Exhausted penalty, so you now subtract 3 from the result of all tests. As usual, your final test result can’t be less than 0, regardless of your penalty.</p><p></p><h2>Focused</h2><p>While Focused, you are engaged and intent on your task. When you use an ability that costs focus, its cost is reduced by 1.</p><p></p><h2>Immobilized</h2><p>While Immobilized, your movement rate becomes 0, and you can’t move or be moved by other effects.</p><p></p><h2>Prone</h2><p>While Prone, you are lying flat on the ground. While Prone, you are Slowed and melee attacks against you gain an advantage. You can use the Brace action without cover.</p><p>You can stand up and end this condition as 0. After you do, your movement rate is reduced by 5 until the start of your next turn.</p><p>If you become Prone while climbing or flying, you fall and take damage as usual.</p><p></p><h2>Restrained</h2><p>While Restrained, your movement rate becomes 0. You gain a disadvantage on all tests other than those to escape your bonds. If the effect that applies this condition doesn’t state an escape DC, it’s up to the GM whether and how the condition can be removed early.</p><p></p></p><p></p><h2>Slowed</h2><p>While Slowed, your movement rate is halved. If you become Slowed in the middle of movement, halve your remaining movement (rounded up).</p><p></p><h2>Stunned</h2><p>While Stunned in combat, you lose any reactions, and on your turn, you gain two fewer<span class=\"fontstyle0\" style=\"color:rgb(36,32,33);font-size:10pt\"> </span><span class=\"cosmere-icon\">1</span><span class=\"fontstyle0\" style=\"color:rgb(36,32,33);font-size:10pt\"> </span>and don’t gain a reaction. While Stunned out of combat, you are overwhelmed, making you move and react slower to your situation at the GM’s discretion.</p><p></p><h2>Surprised</h2><p>While Surprised, you lose any reactions, you don’t gain a reaction at the start of combat or on your turn, you can’t take a fast turn, and you gain one fewer <span class=\"cosmere-icon\">1</span>. Remove this condition after your next turn.</p><p></p><h2>Unconscious</h2><p>While Unconscious, your movement rate becomes 0, you can’t move or communicate, and you’re unaware of your surroundings. When you gain this condition, you fall @UUID[.OMT0NRT0IcBuHczN#prone]{Prone} and drop anything you’re carrying. You can’t interact with your surroundings or use any actions or reactions other than the Breathe Stormlight action and Regenerate free action (if you’re Radiant). In combat, you always go slow, but you can’t do anything on your turn (other than the above Radiant actions).</p><p>Enemies typically ignore Unconscious characters unless they have a strong reason to do otherwise.</p><p>If you are a PC, you can choose to regain consciousness at the end of any of your turns (no action required) or when an effect heals you to at least 1 health. When you do so, other characters can sense you’re conscious, you remove the Unconscious condition, and if you’re at 0 health, you recover 1 health. But be careful: with such low health, you could easily suffer another injury, this one potentially more dangerous or deadly.</p><p>If you are an NPC, you automatically regain consciousness when you recover 1 health.</p></div>"
+            },
+            "video": {
+                "controls": true,
+                "volume": 0.5
+            },
+            "src": null,
+            "ownership": {
+                "default": 2
+            },
+            "flags": {},
+            "_key": "!journal.pages!A3Ac4yL1J0tdYcjP.OMT0NRT0IcBuHczN"
+        }
+    ],
+    "folder": null,
+    "flags": {},
+    "sort": 99659,
+    "ownership": {
+        "default": 2
+    },
+    "_key": "!journal!A3Ac4yL1J0tdYcjP"
+}

--- a/src/packs/tables/LICENSE
+++ b/src/packs/tables/LICENSE
@@ -1,0 +1,7 @@
+The contents of this directory are © Brotherwise Games, LLC. Used with permission.
+
+This content is **not licensed under the MIT License** and is excluded from the open source licensing of the rest of this project.
+
+It may not be redistributed, reproduced, or reused except when used within this project, and only under the terms granted by Brotherwise Games, LLC.
+
+All rights reserved.

--- a/src/style/tooltip.scss
+++ b/src/style/tooltip.scss
@@ -61,7 +61,13 @@
         }
     }
 
-    a.content-link {
-        background: #dddddd15;
+    .conditiontip {
+        text-align: left;
+    }
+
+    a {
+        &.content-link, &.roll {
+            background: #dddddd15;
+        }
     }
 }

--- a/src/system.json
+++ b/src/system.json
@@ -13,8 +13,12 @@
             "url": "https://github.com/the-metalworks"
         }
     ],
-    "esmodules": ["index.js"],
-    "styles": ["output.css"],
+    "esmodules": [
+        "index.js"
+    ],
+    "styles": [
+        "output.css"
+    ],
     "documentTypes": {
         "Actor": {
             "character": {},
@@ -25,33 +29,53 @@
             "armor": {},
             "equipment": {},
             "loot": {},
-
             "ancestry": {},
             "culture": {},
             "path": {},
             "specialty": {},
             "talent": {},
             "trait": {},
-
             "action": {},
-
             "injury": {},
             "connection": {},
             "goal": {},
-
             "power": {},
-
             "talent_tree": {}
         }
     },
     "packs": [
+        {
+            "name": "rules",
+            "label": "Rules",
+            "system": "cosmere-rpg",
+            "path": "packs/rules",
+            "type": "JournalEntry",
+            "ownership": {
+                "PLAYER": "OBSERVER",
+                "ASSISTANT": "OWNER"
+            }
+        },
         {
             "name": "tables",
             "label": "Roll Tables",
             "system": "cosmere-rpg",
             "path": "packs/tables",
             "type": "RollTable",
-            "private": false
+            "ownership": {
+                "PLAYER": "OBSERVER",
+                "ASSISTANT": "OWNER"
+            }
+        }
+    ],
+    "packFolders": [
+        {
+            "name": "Cosmere RPG",
+            "sorting": "m",
+            "color": "#141f3c",
+            "packs": [
+                "rules",
+                "tables"
+            ]
         }
     ],
     "languages": [

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -100,6 +100,8 @@ const COSMERE: CosmereRPGConfig = {
         [Status.Afflicted]: {
             label: 'COSMERE.Status.Afflicted',
             icon: 'systems/cosmere-rpg/assets/icons/svg/conditions/afflicted.svg',
+            reference:
+                'Compendium.cosmere-rpg.rules.JournalEntry.A3Ac4yL1J0tdYcjP.JournalEntryPage.OMT0NRT0IcBuHczN#afflicted',
             condition: true,
         },
         [Status.Blind]: {
@@ -115,26 +117,36 @@ const COSMERE: CosmereRPGConfig = {
         [Status.Determined]: {
             label: 'COSMERE.Status.Determined',
             icon: 'systems/cosmere-rpg/assets/icons/svg/conditions/determined.svg',
+            reference:
+                'Compendium.cosmere-rpg.rules.JournalEntry.A3Ac4yL1J0tdYcjP.JournalEntryPage.OMT0NRT0IcBuHczN#determined',
             condition: true,
         },
         [Status.Disoriented]: {
             label: 'COSMERE.Status.Disoriented',
             icon: 'systems/cosmere-rpg/assets/icons/svg/conditions/disoriented.svg',
+            reference:
+                'Compendium.cosmere-rpg.rules.JournalEntry.A3Ac4yL1J0tdYcjP.JournalEntryPage.OMT0NRT0IcBuHczN#disoriented',
             condition: true,
         },
         [Status.Empowered]: {
             label: 'COSMERE.Status.Empowered',
             icon: 'systems/cosmere-rpg/assets/icons/svg/conditions/empowered.svg',
+            reference:
+                'Compendium.cosmere-rpg.rules.JournalEntry.A3Ac4yL1J0tdYcjP.JournalEntryPage.OMT0NRT0IcBuHczN#empowered',
             condition: true,
         },
         [Status.Enhanced]: {
             label: 'COSMERE.Status.Enhanced',
             icon: 'systems/cosmere-rpg/assets/icons/svg/conditions/enhanced.svg',
+            reference:
+                'Compendium.cosmere-rpg.rules.JournalEntry.A3Ac4yL1J0tdYcjP.JournalEntryPage.OMT0NRT0IcBuHczN#enhanced',
             condition: true,
         },
         [Status.Exhausted]: {
             label: 'COSMERE.Status.Exhausted',
             icon: 'systems/cosmere-rpg/assets/icons/svg/conditions/exhausted.svg',
+            reference:
+                'Compendium.cosmere-rpg.rules.JournalEntry.A3Ac4yL1J0tdYcjP.JournalEntryPage.OMT0NRT0IcBuHczN#exhausted',
             condition: true,
             stackable: true,
             stacksDisplayTransform: (stacks) => (-stacks).toFixed(),
@@ -147,6 +159,8 @@ const COSMERE: CosmereRPGConfig = {
         [Status.Focused]: {
             label: 'COSMERE.Status.Focused',
             icon: 'systems/cosmere-rpg/assets/icons/svg/conditions/focused.svg',
+            reference:
+                'Compendium.cosmere-rpg.rules.JournalEntry.A3Ac4yL1J0tdYcjP.JournalEntryPage.OMT0NRT0IcBuHczN#focused',
             condition: true,
         },
         [Status.Hidden]: {
@@ -157,6 +171,8 @@ const COSMERE: CosmereRPGConfig = {
         [Status.Immobilized]: {
             label: 'COSMERE.Status.Immobilized',
             icon: 'systems/cosmere-rpg/assets/icons/svg/conditions/immobilized.svg',
+            reference:
+                'Compendium.cosmere-rpg.rules.JournalEntry.A3Ac4yL1J0tdYcjP.JournalEntryPage.OMT0NRT0IcBuHczN#immobilized',
             condition: true,
         },
         [Status.Invisible]: {
@@ -167,31 +183,43 @@ const COSMERE: CosmereRPGConfig = {
         [Status.Prone]: {
             label: 'COSMERE.Status.Prone',
             icon: 'systems/cosmere-rpg/assets/icons/svg/conditions/prone.svg',
+            reference:
+                'Compendium.cosmere-rpg.rules.JournalEntry.A3Ac4yL1J0tdYcjP.JournalEntryPage.OMT0NRT0IcBuHczN#prone',
             condition: true,
         },
         [Status.Restrained]: {
             label: 'COSMERE.Status.Restrained',
             icon: 'systems/cosmere-rpg/assets/icons/svg/conditions/restrained.svg',
+            reference:
+                'Compendium.cosmere-rpg.rules.JournalEntry.A3Ac4yL1J0tdYcjP.JournalEntryPage.OMT0NRT0IcBuHczN#restrained',
             condition: true,
         },
         [Status.Slowed]: {
             label: 'COSMERE.Status.Slowed',
             icon: 'systems/cosmere-rpg/assets/icons/svg/conditions/slowed.svg',
+            reference:
+                'Compendium.cosmere-rpg.rules.JournalEntry.A3Ac4yL1J0tdYcjP.JournalEntryPage.OMT0NRT0IcBuHczN#slowed',
             condition: true,
         },
         [Status.Stunned]: {
             label: 'COSMERE.Status.Stunned',
             icon: 'systems/cosmere-rpg/assets/icons/svg/conditions/stunned.svg',
+            reference:
+                'Compendium.cosmere-rpg.rules.JournalEntry.A3Ac4yL1J0tdYcjP.JournalEntryPage.OMT0NRT0IcBuHczN#stunned',
             condition: true,
         },
         [Status.Surprised]: {
             label: 'COSMERE.Status.Surprised',
             icon: 'systems/cosmere-rpg/assets/icons/svg/conditions/surprised.svg',
+            reference:
+                'Compendium.cosmere-rpg.rules.JournalEntry.A3Ac4yL1J0tdYcjP.JournalEntryPage.OMT0NRT0IcBuHczN#surprised',
             condition: true,
         },
         [Status.Unconscious]: {
             label: 'COSMERE.Status.Unconscious',
             icon: 'systems/cosmere-rpg/assets/icons/svg/conditions/unconscious.svg',
+            reference:
+                'Compendium.cosmere-rpg.rules.JournalEntry.A3Ac4yL1J0tdYcjP.JournalEntryPage.OMT0NRT0IcBuHczN#unconscious',
             condition: true,
         },
         [Status.Dead]: {

--- a/src/system/utils/uuid.ts
+++ b/src/system/utils/uuid.ts
@@ -1,0 +1,89 @@
+interface JournalEntryPageTextFromUuidOptions {
+    /**
+     * Whether or not to enrich the html content.
+     * @default false
+     */
+    enrich?: boolean;
+
+    /**
+     * Whether or not to include the heading in the returned text.
+     * @default true
+     */
+    includeHeading?: boolean;
+}
+
+export async function journalEntryPageTextFromUuid(
+    uuid: string,
+    options: JournalEntryPageTextFromUuidOptions = {},
+): Promise<string | null> {
+    // Default options
+    options.includeHeading = options.includeHeading ?? true;
+
+    // Parse the UUID
+    const { collection, documentId, id, type } = foundry.utils.parseUuid(uuid);
+    if (type !== 'JournalEntryPage') return null;
+
+    // Load the journal entry
+    const journal =
+        collection instanceof CompendiumCollection
+            ? ((await collection.getDocument(documentId!)) as JournalEntry)
+            : (collection!.get(documentId!) as JournalEntry);
+    if (!journal) return null;
+
+    const [pageId, target] = id.split('#') as [string, string | undefined];
+
+    // Get the page
+    const page = journal.pages.get(pageId);
+    if (!page) return null;
+
+    // Get the text content of the page
+    const text = getPageTextContent(page, target, options.includeHeading);
+    if (!text) return null;
+
+    // Enrich the text if requested
+    return options.enrich
+        ? await TextEditor.enrichHTML(text, {
+              relativeTo: page as unknown as foundry.abstract.Document.Any,
+          })
+        : text;
+}
+
+function getPageTextContent(
+    page: JournalEntryPage,
+    target: string | undefined,
+    includeHeading = true,
+): string | null {
+    if (!target) return page.text.content;
+
+    const renderTarget = document.createElement('template');
+    renderTarget.innerHTML = page.text.content;
+    const toc = JournalEntryPage.buildTOC(
+        Array.from(renderTarget.content.children) as HTMLElement[],
+    );
+
+    const validTargets = Object.keys(toc);
+
+    // Check if the target exists in the ToC
+    if (!validTargets.includes(target)) return null;
+
+    // Get the target heading
+    const heading = toc[target].element;
+    if (!heading) return null;
+
+    const headingIndex = validTargets.indexOf(target);
+    const nextHeading =
+        headingIndex + 1 < validTargets.length
+            ? toc[validTargets[headingIndex + 1]].element
+            : null;
+
+    // Get the text between the heading and the next heading
+    const els = $(heading)
+        .nextUntil(nextHeading ?? '')
+        .filter((_, el) => $(el).text().trim() !== '');
+
+    // Return the text content of the elements and the heading
+    return [
+        includeHeading ? heading.outerHTML : '',
+        ...els.toArray().map((el) => el.outerHTML),
+    ].join('');
+}

--- a/src/templates/actors/components/conditions.hbs
+++ b/src/templates/actors/components/conditions.hbs
@@ -8,31 +8,33 @@
         {{#each conditions as |condition|}}
             <div class="condition {{#if condition.active}}active{{/if}} {{#if condition.stackable}}stackable{{/if}} {{#if condition.immune}}immune{{/if}}" 
                 data-id="{{condition.id}}"
-                {{#if condition.immune}}
-                    data-tooltip="{{localize "COSMERE.Actor.Sheet.ImmuneTo" condition=(localize condition.name)}}"
+                {{#if condition.description}}
+                    data-tooltip="{{condition.description}}"
                 {{/if}}
             >
-            <a data-action="cycle-condition" 
-                {{#if condition.stackable}}
-                    data-tooltip="COSMERE.Actor.Sheet.Conditions.StackableConditionTooltip"
-                {{/if}}
-            >
-                <div class="condition-icon" style="mask:url('{{condition.icon}}') no-repeat center;mask-size:contain;"></div>
+                <a data-action="cycle-condition">
+                    <div class="condition-icon" style="mask:url('{{condition.icon}}') no-repeat center;mask-size:contain;"></div>
 
-                <span class="name">
-                    {{localize condition.name}}
-                    {{#if (and condition.stackable condition.active)}}
-                        <span class="stacks">[{{condition.stacks}}]</span>
-                    {{/if}}
-                </span>
+                    <span class="name">
+                        {{localize condition.name}}
+                        {{#if (and condition.stackable condition.active)}}
+                            <span class="stacks">[{{condition.stacks}}]</span>
+                        {{/if}}
+                    </span>
 
-                {{#if condition.active}}
-                    <i class="fa-solid fa-toggle-on"></i>
-                {{else}}
-                    <i class="fa-solid fa-toggle-off"></i>
-                {{/if}}
-            </a>
-        </div>
+                    <i {{#if condition.immune}}
+                            data-tooltip="{{localize "COSMERE.Actor.Sheet.ImmuneTo" condition=(localize condition.name)}}"
+                        {{else if condition.stackable}}
+                            data-tooltip="COSMERE.Actor.Sheet.Conditions.StackableConditionTooltip"
+                        {{/if}}
+                        {{#if condition.active}}
+                            class="fa-solid fa-toggle-on"
+                        {{else}}
+                            class="fa-solid fa-toggle-off"
+                        {{/if}}
+                    ></i>
+                </a>
+            </div>
         {{/each}}
 
         {{#times (mod (sub 3 (mod conditions.length 3)) 3)}}


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR changes the following:
- Adds a Rules compendium with Conditions journal
- Configures condition references to point to the relevant section of the page
- Adds a tooltip to the conditions component on the actor sheet with the condition effect, based on the configured reference.

Also updates the LICENSE to clarify that not all content falls under the MIT license and adds LICENSE files with separate terms where needed.

**Related Issue**  
Closes #357

**How Has This Been Tested?**  
1. Go to compendiums -> Cosmere RPG -> Rules
2. Open the Conditions journal
3. Open an actor
4. Go to Effects & Conditions tab
5. Hover over each Condition (except dead)

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/c7d28fa2-406e-415d-b0a0-3effdb7e4f4e)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343