### PR TITLE
feat(combat): refactor combat and combatants to properly handle permissions

### DIFF
--- a/src/declarations/foundry/client/data/documents/combat.d.ts
+++ b/src/declarations/foundry/client/data/documents/combat.d.ts
@@ -1,3 +1,65 @@
-declare interface Combat {
-    turns: Combatant[];
+declare namespace Combat {
+    export type ConfiguredInstance = Combat;
+
+    interface CombatHistoryData {
+        round: number | null;
+        turn: number | null;
+        tokenId: string | null;
+        combatantId: string | null;
+    }
+}
+
+declare class Combat<
+    C extends Combatant = Combatant,
+    Schema extends foundry.abstract.DataSchema = foundry.abstract.DataSchema,
+    Parent extends Document | null = foundry.abstract.Document.Any,
+> extends _ClientDocumentMixin<D>(
+    foundry.documents.BaseCombat<Schema, Parent>,
+) {
+    system: Schema;
+    combatants: Collection<C>;
+
+    turn: number | null;
+
+    /**
+     * Track the sorted turn order of this combat encounter
+     */
+    turns: C[];
+
+    /**
+     * Record the current round, turn, and tokenId to understand changes in the encounter state
+     * @type {CombatHistoryData}
+     */
+    current: Combat.CombatHistoryData;
+
+    /**
+     * Track the previous round, turn, and tokenId to understand changes in the encounter state
+     */
+    previous?: Combat.CombatHistoryData;
+
+    /**
+     * Begin the combat encounter, advancing to round 1 and turn 1
+     */
+    async startCombat(): Promise<this>;
+
+    /**
+     * Advance the combat to the next round
+     */
+    async nextRound(): Promise<this>;
+
+    /**
+     * Display a dialog querying the GM whether they wish to end the combat encounter and empty the tracker
+     */
+    async endCombat(): Promise<this>;
+
+    /**
+     * Return the Array of combatants sorted into initiative order, breaking ties alphabetically by name.
+     */
+    setupTurns(): C[];
+
+    /**
+     * Get the current history state of the Combat encounter.
+     * @param combatant       The new active combatant
+     */
+    protected _getCurrentState(combatant: C): Combat.CombatHistoryData;
 }

--- a/src/declarations/foundry/client/data/documents/combatant.d.ts
+++ b/src/declarations/foundry/client/data/documents/combatant.d.ts
@@ -1,0 +1,61 @@
+declare class Combatant<
+    Schema extends foundry.abstract.DataSchema = foundry.abstract.DataSchema,
+    Parent extends Document | null = foundry.abstract.Document.Any,
+> extends _ClientDocumentMixin<D>(
+    foundry.documents.BaseCombatant<Schema, Parent>,
+) {
+    system: Schema;
+
+    /**
+     * A convenience alias of Combatant#parent which is more semantically intuitive
+     */
+    get combat(): Combat | null;
+
+    /**
+     * This is treated as a non-player combatant if it has no associated actor and no player users who can control it
+     */
+    get isNPC(): boolean;
+
+    /**
+     * A reference to the Actor document which this Combatant represents, if any
+     */
+    get actor(): Actor | null;
+
+    /**
+     * A reference to the Token document which this Combatant represents, if any
+     */
+    get token(): TokenDocument | null;
+
+    /**
+     * An array of non-Gamemaster Users who have ownership of this Combatant.
+     */
+    get players(): User[];
+
+    /**
+     * Has this combatant been marked as defeated?
+     */
+    get isDefeated(): boolean;
+
+    /* -------------------------------------------- */
+
+    /**
+     * Get a Roll object which represents the initiative roll for this Combatant.
+     * @param formula           An explicit Roll formula to use for the combatant.
+     * @returns                 The unevaluated Roll instance to use for the combatant.
+     */
+    public getInitiativeRoll(formula?: string): Roll;
+
+    /**
+     * Roll initiative for this particular combatant.
+     * @param formula           A dice formula which overrides the default for this Combatant.
+     * @returns                 The updated Combatant.
+     */
+    public async rollInitiative(formula?: string): Promise<this>;
+
+    /**
+     * Acquire the default dice formula which should be used to roll initiative for this combatant.
+     * Modules or systems could choose to override or extend this to accommodate special situations.
+     * @returns                 The initiative formula to use for this combatant.
+     */
+    protected _getInitiativeFormula(): string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,9 +52,13 @@ Hooks.once('init', async () => {
     CONFIG.Item.dataModels = dataModels.item.config;
     CONFIG.Item.documentClass = documents.CosmereItem;
 
-    CONFIG.Combat.documentClass = documents.CosmereCombat;
-    CONFIG.Combatant.documentClass = documents.CosmereCombatant;
+    CONFIG.Combat.documentClass = documents.CosmereCombat as typeof Combat;
     CONFIG.ui.combat = applications.combat.CosmereCombatTracker;
+
+    (CONFIG.Combatant as AnyMutableObject).dataModels =
+        dataModels.combatant.config;
+    CONFIG.Combatant.documentClass =
+        documents.CosmereCombatant as typeof Combatant;
 
     CONFIG.Token.documentClass = documents.CosmereTokenDocument;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,8 +55,9 @@ Hooks.once('init', async () => {
     CONFIG.Combat.documentClass = documents.CosmereCombat as typeof Combat;
     CONFIG.ui.combat = applications.combat.CosmereCombatTracker;
 
-    (CONFIG.Combatant as AnyMutableObject).dataModels =
-        dataModels.combatant.config;
+    // NOTE: Disabled for now as v12 doesn't permit users to update the system of combatants they own
+    // (CONFIG.Combatant as AnyMutableObject).dataModels =
+    //     dataModels.combatant.config;
     CONFIG.Combatant.documentClass =
         documents.CosmereCombatant as typeof Combatant;
 

--- a/src/system/applications/combat/combat-tracker.ts
+++ b/src/system/applications/combat/combat-tracker.ts
@@ -36,11 +36,11 @@ export class CosmereCombatTracker extends CombatTracker {
             // Prepare turn data
             const newTurn: CosmereTurn = {
                 ...turn,
-                turnSpeed: combatant.system.turnSpeed,
+                turnSpeed: combatant.turnSpeed,
                 type: combatant.actor.type,
-                activated: combatant.system.activated,
+                activated: combatant.activated,
                 isBoss: combatant.isBoss,
-                bossFastActivated: combatant.system.bossFastActivated,
+                bossFastActivated: combatant.bossFastActivated,
             };
 
             // Strip active player formatting

--- a/src/system/applications/combat/combat-tracker.ts
+++ b/src/system/applications/combat/combat-tracker.ts
@@ -1,7 +1,11 @@
-import { ActorType, AdversaryRole, TurnSpeed } from '@src/system/types/cosmere';
-import { CosmereCombatant } from '@src/system/documents/combatant';
-import { SYSTEM_ID } from '@src/system/constants';
-import { TEMPLATES } from '@src/system/utils/templates';
+import { ActorType, TurnSpeed } from '@system/types/cosmere';
+
+// Documents
+import { CosmereCombatant } from '@system/documents/combatant';
+
+// Constants
+import { SYSTEM_ID } from '@system/constants';
+import { TEMPLATES } from '@system/utils/templates';
 
 /**
  * Overrides default tracker template to implement slow/fast buckets and combatant activation button.
@@ -24,39 +28,24 @@ export class CosmereCombatTracker extends CombatTracker {
             fastNPC: CosmereTurn[];
             slowNPC: CosmereTurn[];
         };
-        //add combatant type, speed, and activation status to existing turn data.
-        data.turns = data.turns.flatMap((turn) => {
-            const combatant: CosmereCombatant =
-                this.viewed!.getEmbeddedDocument(
-                    'Combatant',
-                    turn.id,
-                    {},
-                ) as CosmereCombatant;
+
+        // Add combatant type, speed, and activation status to existing turn data
+        data.turns = data.turns.flatMap((turn, i) => {
+            const combatant = this.viewed!.turns[i] as CosmereCombatant;
+
+            // Prepare turn data
             const newTurn: CosmereTurn = {
                 ...turn,
-                turnSpeed: combatant.getFlag(
-                    SYSTEM_ID,
-                    'turnSpeed',
-                ) as TurnSpeed,
+                turnSpeed: combatant.system.turnSpeed,
                 type: combatant.actor.type,
-                activated: combatant.getFlag(SYSTEM_ID, 'activated') as boolean,
-                isBoss: combatant.getFlag(SYSTEM_ID, 'isBoss') as boolean,
-                bossFastActivated: combatant.getFlag(
-                    SYSTEM_ID,
-                    'bossFastActivated',
-                ) as boolean,
+                activated: combatant.system.activated,
+                isBoss: combatant.isBoss,
+                bossFastActivated: combatant.system.bossFastActivated,
             };
-            //strips active player formatting
+
+            // Strip active player formatting
             newTurn.css = '';
-            // ensure boss adversaries have both a fast and slow turn
-            if (newTurn.isBoss) {
-                newTurn.turnSpeed = TurnSpeed.Slow;
-                const bossFastTurn = {
-                    ...newTurn,
-                    turnSpeed: TurnSpeed.Fast,
-                };
-                return [newTurn, bossFastTurn];
-            }
+
             // provide current turn for non-boss combatants
             return newTurn;
         });
@@ -111,13 +100,17 @@ export class CosmereCombatTracker extends CombatTracker {
     protected _onClickToggleTurnSpeed(event: Event) {
         event.preventDefault();
         event.stopPropagation();
+
+        // Get the button and the closest combatant list item
         const btn = event.currentTarget as HTMLElement;
         const li = btn.closest<HTMLElement>('.combatant')!;
-        const combatant: CosmereCombatant = this.viewed!.getEmbeddedDocument(
-            'Combatant',
+
+        // Get the combatant
+        const combatant = this.viewed!.combatants.get(
             li.dataset.combatantId!,
-            {},
         ) as CosmereCombatant;
+
+        // Toggle the combatant's turn speed
         void combatant.toggleTurnSpeed();
     }
 
@@ -127,44 +120,46 @@ export class CosmereCombatTracker extends CombatTracker {
     protected _onActivateCombatant(event: Event) {
         event.preventDefault();
         event.stopPropagation();
+
+        // Get the button and the closest combatant list item
         const btn = event.currentTarget as HTMLElement;
         const li = btn.closest<HTMLElement>('.combatant')!;
-        const combatant: CosmereCombatant = this.viewed!.getEmbeddedDocument(
-            'Combatant',
+
+        // Get the combatant
+        const combatant = this.viewed!.combatants.get(
             li.dataset.combatantId!,
-            {},
         ) as CosmereCombatant;
-        // Toggle the correct activation flag for bosses and nonbosses
-        if (!combatant.isBoss() || li.classList.contains(TurnSpeed.Slow)) {
-            void combatant.setFlag(SYSTEM_ID, 'activated', true);
-        } else {
-            void combatant.setFlag(SYSTEM_ID, 'bossFastActivated', true);
-        }
+
+        // Mark the combatant as activated
+        void combatant.markActivated(
+            combatant.isBoss && li.dataset.phase === TurnSpeed.Fast,
+        );
     }
 
     /**
      * toggles combatant turn speed on clicking the "fast/slow" option in the turn tracker context menu
      */
     protected _onContextToggleTurnSpeed(li: JQuery<HTMLElement>) {
-        const combatant: CosmereCombatant = this.viewed!.getEmbeddedDocument(
-            'Combatant',
+        // Get the combatant from the list item
+        const combatant = this.viewed!.combatants.get(
             li.data('combatant-id') as string,
-            {},
         ) as CosmereCombatant;
-        combatant.toggleTurnSpeed();
+
+        // Toggle the combatant's turn speed
+        void combatant.toggleTurnSpeed();
     }
 
     /**
      * resets combatants activation status to hasn't activated
      */
     protected _onContextResetActivation(li: JQuery<HTMLElement>) {
-        const combatant: CosmereCombatant = this.viewed!.getEmbeddedDocument(
-            'Combatant',
+        // Get the combatant from the list item
+        const combatant = this.viewed!.combatants.get(
             li.data('combatant-id') as string,
-            {},
         ) as CosmereCombatant;
-        void combatant.setFlag(SYSTEM_ID, 'activated', false);
-        void combatant.setFlag(SYSTEM_ID, 'bossFastActivated', false);
+
+        // Reset the combatant's activation status
+        void combatant.resetActivation();
     }
 
     /**

--- a/src/system/data/combatant/combatant.ts
+++ b/src/system/data/combatant/combatant.ts
@@ -1,0 +1,43 @@
+import { ActorType, AdversaryRole, TurnSpeed } from '@system/types/cosmere';
+import { CosmereCombatant } from '@system/documents/combatant';
+
+export interface CombatantData {
+    /**
+     * The turn speed type of the combatant, either slow or fast.
+     */
+    turnSpeed: TurnSpeed;
+
+    /**
+     * Whether or not the combatant has acted this turn.
+     */
+    activated: boolean;
+
+    /**
+     * Whether or not the boss combatant has acted on its fast turn.
+     * This is only used for boss adversaries.
+     */
+    bossFastActivated?: boolean;
+}
+
+export class CombatantDataModel extends foundry.abstract.TypeDataModel<
+    CombatantData,
+    CosmereCombatant
+> {
+    static defineSchema() {
+        return {
+            turnSpeed: new foundry.data.fields.StringField({
+                required: true,
+                blank: false,
+                initial: TurnSpeed.Slow,
+                choices: [TurnSpeed.Slow, TurnSpeed.Fast],
+            }),
+            activated: new foundry.data.fields.BooleanField({
+                required: true,
+                initial: false,
+            }),
+            bossFastActivated: new foundry.data.fields.BooleanField({
+                required: false,
+            }),
+        };
+    }
+}

--- a/src/system/data/combatant/index.ts
+++ b/src/system/data/combatant/index.ts
@@ -1,0 +1,7 @@
+import { CombatantDataModel } from './combatant';
+
+export const config = {
+    base: CombatantDataModel,
+};
+
+export * from './combatant';

--- a/src/system/data/index.ts
+++ b/src/system/data/index.ts
@@ -1,3 +1,4 @@
 export * as actor from './actor';
 export * as item from './item';
 export * as activeEffect from './active-effect';
+export * as combatant from './combatant';

--- a/src/system/documents/combat.ts
+++ b/src/system/documents/combat.ts
@@ -2,6 +2,9 @@ import { TurnSpeed } from '@system/types/cosmere';
 
 import { CosmereCombatant } from './combatant';
 
+// Constants
+import { SYSTEM_ID } from '@system/constants';
+
 export class CosmereCombat extends Combat<CosmereCombatant> {
     /**
      * Sets all defeated combatants activation status to true (already activated),
@@ -34,7 +37,7 @@ export class CosmereCombat extends Combat<CosmereCombatant> {
                         options: unknown,
                     ) => CosmereCombatant)(
                         foundry.utils.mergeObject(c.toObject(), {
-                            'system.turnSpeed': TurnSpeed.Fast,
+                            [`flags.${SYSTEM_ID}.turnSpeed`]: TurnSpeed.Fast,
                         }),
                         { parent: c.parent },
                     );

--- a/src/system/documents/combat.ts
+++ b/src/system/documents/combat.ts
@@ -1,26 +1,14 @@
-import { SYSTEM_ID } from '../constants';
+import { TurnSpeed } from '@system/types/cosmere';
+
 import { CosmereCombatant } from './combatant';
 
-export class CosmereCombat extends Combat {
-    declare turns: CosmereCombatant[];
-
+export class CosmereCombat extends Combat<CosmereCombatant> {
     /**
      * Sets all defeated combatants activation status to true (already activated),
      * and all others to false (hasn't activated yet)
      */
     resetActivations() {
-        for (const combatant of this.turns) {
-            void combatant.setFlag(
-                SYSTEM_ID,
-                'activated',
-                combatant.isDefeated ? true : false,
-            );
-            void combatant.setFlag(
-                SYSTEM_ID,
-                'bossFastActivated',
-                combatant.isDefeated ? true : false,
-            );
-        }
+        this.turns.forEach((combatant) => void combatant.resetActivation());
     }
 
     override async startCombat(): Promise<this> {
@@ -31,5 +19,43 @@ export class CosmereCombat extends Combat {
     override async nextRound(): Promise<this> {
         this.resetActivations();
         return super.nextRound();
+    }
+
+    override setupTurns(): CosmereCombatant[] {
+        this.turns ??= [];
+
+        const turns = Array.from(this.combatants)
+            .flatMap((c) => {
+                if (c.isBoss) {
+                    // If the combatant is a boss, clone it to create a fast turn beside its slow turn
+                    const clone = new (CONFIG.Combatant
+                        .documentClass as unknown as new (
+                        data: unknown,
+                        options: unknown,
+                    ) => CosmereCombatant)(
+                        foundry.utils.mergeObject(c.toObject(), {
+                            'system.turnSpeed': TurnSpeed.Fast,
+                        }),
+                        { parent: c.parent },
+                    );
+                    return [clone, c];
+                } else {
+                    return c;
+                }
+            })
+            .sort(this._sortCombatants);
+
+        if (this.turn !== null)
+            this.turn = Math.clamp(this.turn, 0, turns.length - 1);
+
+        // Update state tracking
+        const c = turns[this.turn!];
+        this.current = this._getCurrentState(c);
+
+        // One-time initialization of the previous state
+        if (!this.previous) this.previous = this.current;
+
+        // Return the array of prepared turns
+        return (this.turns = turns);
     }
 }

--- a/src/system/documents/combatant.ts
+++ b/src/system/documents/combatant.ts
@@ -1,14 +1,14 @@
 import { ActorType, AdversaryRole, TurnSpeed } from '@system/types/cosmere';
 
-// Data
-import { CombatantDataModel } from '@system/data/combatant';
-
 // Documents
 import { AdversaryActor, CosmereActor } from './actor';
 
+// Constants
+import { SYSTEM_ID } from '@system/constants';
+
 let _schema: foundry.data.fields.SchemaField | undefined;
 
-export class CosmereCombatant extends Combatant<CombatantDataModel> {
+export class CosmereCombatant extends Combatant {
     public static defineSchema() {
         const schema = super.defineSchema();
         // Remove the initiative field from the schema as we handle it using a getter
@@ -40,8 +40,20 @@ export class CosmereCombatant extends Combatant<CombatantDataModel> {
         const spd = this.actor.system.attributes.spd;
         let initiative = spd.value + spd.bonus;
         if (this.actor.type === ActorType.Character) initiative += 500;
-        if (this.system.turnSpeed === TurnSpeed.Fast) initiative += 1000;
+        if (this.turnSpeed === TurnSpeed.Fast) initiative += 1000;
         return initiative;
+    }
+
+    public get turnSpeed(): TurnSpeed {
+        return this.getFlag(SYSTEM_ID, 'turnSpeed') || TurnSpeed.Slow;
+    }
+
+    public get activated(): boolean {
+        return this.getFlag(SYSTEM_ID, 'activated') || false;
+    }
+
+    public get bossFastActivated(): boolean {
+        return this.getFlag(SYSTEM_ID, 'bossFastActivated') || false;
     }
 
     /* --- Life cycle --- */
@@ -58,32 +70,26 @@ export class CosmereCombatant extends Combatant<CombatantDataModel> {
      */
     public async toggleTurnSpeed() {
         const newSpeed =
-            this.system.turnSpeed === TurnSpeed.Slow
-                ? TurnSpeed.Fast
-                : TurnSpeed.Slow;
+            this.turnSpeed === TurnSpeed.Slow ? TurnSpeed.Fast : TurnSpeed.Slow;
 
         // Update the turn speed
-        await this.update({
-            'system.turnSpeed': newSpeed,
-        });
+        await this.setFlag(SYSTEM_ID, 'turnSpeed', newSpeed);
     }
 
     public async markActivated(bossFastActivated = false) {
         if (bossFastActivated && this.isBoss) {
-            await this.update({
-                'system.bossFastActivated': true,
-            });
+            await this.setFlag(SYSTEM_ID, 'bossFastActivated', true);
         } else {
-            await this.update({
-                'system.activated': true,
-            });
+            await this.setFlag(SYSTEM_ID, 'activated', true);
         }
     }
 
     public async resetActivation() {
         await this.update({
-            'system.activated': false,
-            'system.bossFastActivated': false,
+            [`flags.${SYSTEM_ID}`]: {
+                activated: false,
+                bossFastActivated: false,
+            },
         });
     }
 }

--- a/src/templates/combat/combatant.hbs
+++ b/src/templates/combat/combatant.hbs
@@ -1,4 +1,4 @@
-<li class="combatant actor directory-item flexrow {{this.css}} {{this.turnSpeed}} {{#if this.defeated}}defeated{{/if}}" data-combatant-id="{{this.id}}">
+<li class="combatant actor directory-item flexrow {{this.css}} {{this.turnSpeed}} {{#if this.defeated}}defeated{{/if}}" data-phase="{{this.turnSpeed}}" data-combatant-id="{{this.id}}">
     <img class="token-image" data-src="{{this.img}}" alt="{{this.name}}" />
     <div class="token-name flexcol">
         <h4 class="combatant-name">{{this.name}}</h4>


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Other (please describe):

**Description**  
This PR fixes the permissions errors that players receive whenever the combat state of an actor they don't control gets toggled. The combatants have been cleaned up. The combat document has been changed to handle the double boss turns directly, instead of relying on the combat tracker. 

Initially I set the the combatants up to use an actual data model instead of flags, however V12 doesn't permit users to update system fields on combatants they own. It looks like this may be fixed for V13 so leaving the data model class in even though its unused.

**Related Issue**  
Closes #390 

**How Has This Been Tested?**  
1. Join instance as GM
2. Join instance as player in separate window
3. As GM: activate a scene with some number of actors that the player lacks permission for
4. As GM: create an encounter
5. As GM: toggle the combat state of an actor that the player lacks permission for
6. Ensure the player did not get any errors
7. As GM: add a boss to the encounter
8. As GM: toggle the turn speed of an adversary
9. As player: toggle the turn speed of your character
10. As GM: mark a regular adversary as having acted
11. As GM: mark the boss fast turn as having acted
12. As GM: mark the boss slow turn as having acted
13. As player: mark your character as having acted
14. As GM: advance to the next round

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343