### PR TITLE
fix: hide roll mode drop down in roll config

### DIFF
--- a/src/system/applications/dialogs/attack-configuration.ts
+++ b/src/system/applications/dialogs/attack-configuration.ts
@@ -295,7 +295,7 @@ export class AttackConfigurationDialog extends ComponentHandlebarsApplicationMix
             attribute: getNullableFromFormInput<Attribute>(
                 form.attribute.value,
             ),
-            rollMode: form.rollMode.value as RollMode,
+            rollMode: (form.rollMode?.value as RollMode) ?? 'roll',
             temporaryModifiers: form.temporaryMod.value,
             plotDie: form.raiseStakes.checked,
             advantageMode:

--- a/src/system/applications/dialogs/roll-configuration.ts
+++ b/src/system/applications/dialogs/roll-configuration.ts
@@ -221,7 +221,7 @@ export class RollConfigurationDialog extends ComponentHandlebarsApplicationMixin
             attribute: getNullableFromFormInput<Attribute>(
                 form.attribute.value,
             ),
-            rollMode: form.rollMode.value as RollMode,
+            rollMode: (form.rollMode?.value as RollMode) ?? 'roll',
             temporaryModifiers: form.temporaryMod.value,
             plotDie: form.raiseStakes.checked,
             advantageMode:

--- a/src/templates/roll/dialogs/roll-configuration.hbs
+++ b/src/templates/roll/dialogs/roll-configuration.hbs
@@ -1,12 +1,13 @@
 <form>
-    <div class="form-group">
+    {{!-- NOTE: Hiding this until roll workflow refactor since it does not work and is not an easy fix. --}}
+    {{!-- <div class="form-group">
         <label>{{ localize "DICE.RollMode" }}</label>
         <div class="form-fields">
             <select name="rollMode">
                 {{selectOptions rollModes selected=defaultRollMode localize=true}}
             </select>
         </div>        
-    </div>
+    </div> --}}
     <div class="form-group">
         <label>{{ localize 'COSMERE.Actor.Attribute.name' }}</label>
         <div class="form-fields">


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [X] Other (please describe): Temporarily Disabling of Feature

**Description**  
As discussed on Discord, we are temporarily hiding the roll config dropdown for roll mode until the roll workflow refactor as it does not presently work and is a tricky thing to fix due to how messages are being created for attacks.

**Related Issue**  
Closes #360.

**How Has This Been Tested?**  
Tested both types of roll config windows to ensure drop down is gone and rolls still execute, respecting the chat window roll mode.

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/f0ce9a29-de7a-41fa-9752-af611c3c6cf1)
![image](https://github.com/user-attachments/assets/df5143f3-919b-4320-a25d-98513c84d1fe)

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: 12.343.