### PR TITLE
feat(item events): add goal completed and goal progressed event types

### DIFF
--- a/src/declarations/foundry/common/abstract/data.d.ts
+++ b/src/declarations/foundry/common/abstract/data.d.ts
@@ -507,7 +507,7 @@ namespace foundry {
              * @param scope The flag scope which namespaces the key
              * @param key The flag key
              */
-            getFlag<T extends any>(scope: string, key: string): T;
+            getFlag<T extends any>(scope: string, key: string): T | undefined;
 
             /**
              * Assign a "flag" to this document.

--- a/src/declarations/foundry/common/abstract/fields.d.ts
+++ b/src/declarations/foundry/common/abstract/fields.d.ts
@@ -286,6 +286,8 @@ declare namespace foundry {
             }
 
             class NumberField extends DataField {
+                options: NumberFieldOptions;
+
                 constructor(
                     options?: NumberFieldOptions,
                     context?: DataFieldContext,

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -764,6 +764,14 @@
                             "Label": "Deactivated Modality",
                             "Description": "Triggered when this item's mode becomes inactive for its modality."
                         },
+                        "goal-complete": {
+                            "Label": "Goal Completed",
+                            "Description": "Triggered when this Goal item is completed."
+                        },
+                        "goal-progress": {
+                            "Label": "Goal Progressed",
+                            "Description": "Triggered when this Goal item's progress is updated towards completion."
+                        },
                         "update-actor": {
                             "Label": "Actor Updated",
                             "Description": "Triggered when this item's parent actor is updated."

--- a/src/system/api/item.ts
+++ b/src/system/api/item.ts
@@ -289,6 +289,7 @@ export function registerItemEventType(
         description: data.description,
         hook: data.hook,
         host: data.host ?? ItemEventSystem.Event.ExecutionHost.Owner,
+        filter: data.filter,
         condition: data.condition,
         transform: data.transform,
     };

--- a/src/system/applications/item/dialogs/edit-event-rule.ts
+++ b/src/system/applications/item/dialogs/edit-event-rule.ts
@@ -166,11 +166,30 @@ export class ItemEditEventRuleDialog extends ComponentHandlebarsApplicationMixin
     /* --- Context --- */
 
     public _prepareContext() {
+        const allEventSelectOptions = (
+            (this.rule.schema.fields.event as foundry.data.fields.StringField)
+                .choices as () => AnyMutableObject
+        )();
+
         // Prepare the context
         return Promise.resolve({
             editable: true,
             item: this.item,
             rule: this.rule,
+            eventSelectOptions: Object.entries(allEventSelectOptions)
+                .filter(
+                    ([event]) =>
+                        CONFIG.COSMERE.items.events.types[event]?.filter?.(
+                            this.item,
+                        ) !== false,
+                )
+                .reduce(
+                    (acc, [event, label]) => ({
+                        ...acc,
+                        [event]: label,
+                    }),
+                    {},
+                ),
         });
     }
 }

--- a/src/system/constants/hooks.ts
+++ b/src/system/constants/hooks.ts
@@ -23,6 +23,34 @@ export const HOOKS = {
     MODE_DEACTIVATE_ITEM: `${SYSTEM_ID}.modeDeactivateItem`,
     PRE_MODE_DEACTIVATE_ITEM: `${SYSTEM_ID}.preModeDeactivateItem`,
 
+    /**
+     * Executed when a Goal Item's progresses gets updated towards completion.
+     * This only counts forward progress, not executed when the goal's progress is reduced.
+     */
+    PROGRESS_GOAL: `${SYSTEM_ID}.progressGoal`,
+    /**
+     * Executed before a Goal Item's progress is updated towards completion.
+     */
+    PRE_PROGRESS_GOAL: `${SYSTEM_ID}.preProgressGoal`,
+
+    /**
+     * Executed when a Goal Item's progress is updated.
+     */
+    UPDATE_PROGRESS_GOAL: `${SYSTEM_ID}.updateProgressGoal`,
+    /**
+     * Executed before a Goal Item's progress is updated.
+     */
+    PRE_UPDATE_PROGRESS_GOAL: `${SYSTEM_ID}.preUpdateProgressGoal`,
+
+    /**
+     * Executed when a Goal Item's progress gets filled and the goal is completed.
+     */
+    COMPLETE_GOAL: `${SYSTEM_ID}.completeGoal`,
+    /**
+     * Executed before a Goal Item's progress is filled and the goal is completed.
+     */
+    PRE_COMPLETE_GOAL: `${SYSTEM_ID}.preCompleteGoal`,
+
     /* ----- Chat message hooks ----- */
     /* -- Message interaction hooks -- */
     MESSAGE_INTERACTED: `${SYSTEM_ID}.chatMessageInteract`,

--- a/src/system/hooks/index.ts
+++ b/src/system/hooks/index.ts
@@ -1,6 +1,7 @@
 import './modules/dice-so-nice';
 import './welcome';
 import './actor';
+import './item';
 import './enrichers';
 
 export { register as registerItemEventSystem } from './item-event-system';

--- a/src/system/hooks/item-event-system/events.ts
+++ b/src/system/hooks/item-event-system/events.ts
@@ -68,6 +68,16 @@ const EVENTS: EventDefinition[] = [
         hook: HOOKS.MODE_DEACTIVATE_ITEM,
         filter: (item: CosmereItem) => item.hasModality(),
     },
+    {
+        type: 'goal-complete',
+        hook: HOOKS.COMPLETE_GOAL,
+        filter: (item: CosmereItem) => item.isGoal(),
+    },
+    {
+        type: 'goal-progress',
+        hook: HOOKS.PROGRESS_GOAL,
+        filter: (item: CosmereItem) => item.isGoal(),
+    },
 
     // General Actor events
     { type: 'update-actor', hook: 'updateActor' },

--- a/src/system/hooks/item-event-system/events.ts
+++ b/src/system/hooks/item-event-system/events.ts
@@ -36,6 +36,7 @@ const EVENTS: EventDefinition[] = [
     {
         type: 'equip',
         hook: 'updateItem',
+        filter: (item: CosmereItem) => item.isEquippable(),
         condition: (_: CosmereItem, change: DeepPartial<CosmereItem>) => {
             return (
                 foundry.utils.getProperty(change, 'system.equipped') === true
@@ -45,15 +46,28 @@ const EVENTS: EventDefinition[] = [
     {
         type: 'unequip',
         hook: 'updateItem',
+        filter: (item: CosmereItem) => item.isEquippable(),
         condition: (_: CosmereItem, change: DeepPartial<CosmereItem>) => {
             return (
                 foundry.utils.getProperty(change, 'system.equipped') === false
             );
         },
     },
-    { type: 'use', hook: HOOKS.USE_ITEM },
-    { type: 'mode-activate', hook: HOOKS.MODE_ACTIVATE_ITEM },
-    { type: 'mode-deactivate', hook: HOOKS.MODE_DEACTIVATE_ITEM },
+    {
+        type: 'use',
+        hook: HOOKS.USE_ITEM,
+        filter: (item: CosmereItem) => item.hasActivation(),
+    },
+    {
+        type: 'mode-activate',
+        hook: HOOKS.MODE_ACTIVATE_ITEM,
+        filter: (item: CosmereItem) => item.hasModality(),
+    },
+    {
+        type: 'mode-deactivate',
+        hook: HOOKS.MODE_DEACTIVATE_ITEM,
+        filter: (item: CosmereItem) => item.hasModality(),
+    },
 
     // General Actor events
     { type: 'update-actor', hook: 'updateActor' },
@@ -84,11 +98,12 @@ const EVENTS: EventDefinition[] = [
 ];
 
 export function registerEventTypes() {
-    EVENTS.forEach(({ type, hook, host, condition, transform }) => {
+    EVENTS.forEach(({ type, hook, host, filter, condition, transform }) => {
         cosmereRPG.api.registerItemEventType({
             type,
             hook,
-            host: host,
+            host,
+            filter,
             condition,
             transform,
             label: `COSMERE.Item.EventSystem.Event.Types.${type}.Label`,

--- a/src/system/hooks/item-event-system/index.ts
+++ b/src/system/hooks/item-event-system/index.ts
@@ -27,7 +27,7 @@ const VALID_DOCUMENT_TYPES = [
  * This is to prevent users getting themselves
  * stuck in an infinite loop of events.
  */
-const MAX_RECENT_EVENTS = 20;
+const MAX_RECENT_EVENTS = 50;
 
 /**
  * The time in milliseconds that an event is considered

--- a/src/system/hooks/item.ts
+++ b/src/system/hooks/item.ts
@@ -1,0 +1,133 @@
+import { CosmereItem } from '@system/documents/item';
+import { CosmereHooks } from '@system/types/hooks';
+import { DeepPartial, DeepMutable } from '@system/types/utils';
+
+// Data
+import { GoalItemDataModel } from '@system/data/item/goal';
+
+// Constants
+import { SYSTEM_ID } from '@system/constants';
+import { HOOKS } from '@system/constants/hooks';
+
+Hooks.on(
+    'preUpdateItem',
+    (item: CosmereItem, update: DeepMutable<DeepPartial<CosmereItem>>) => {
+        if (item.isGoal()) {
+            if (foundry.utils.hasProperty(update, 'system.level')) {
+                const currentLevel = item.system.level;
+                const newLevel = foundry.utils.getProperty(
+                    update,
+                    'system.level',
+                ) as number;
+
+                if (newLevel !== currentLevel) {
+                    /**
+                     * Hook: preUpdateProgressGoal
+                     */
+                    if (
+                        Hooks.call<CosmereHooks.PreUpdateProgressGoal>(
+                            HOOKS.PRE_UPDATE_PROGRESS_GOAL,
+                            item,
+                            newLevel,
+                        ) === false
+                    ) {
+                        return false;
+                    }
+
+                    if (newLevel > currentLevel) {
+                        /**
+                         * Hook: preProgressGoal
+                         */
+                        if (
+                            Hooks.call<CosmereHooks.PreProgressGoal>(
+                                HOOKS.PRE_PROGRESS_GOAL,
+                                item,
+                                newLevel,
+                            ) === false
+                        ) {
+                            return false;
+                        }
+                    }
+
+                    if (
+                        newLevel ===
+                        (
+                            GoalItemDataModel.schema.fields
+                                .level as foundry.data.fields.NumberField
+                        ).options.max!
+                    ) {
+                        /**
+                         * Hook: preCompleteGoal
+                         */
+                        if (
+                            Hooks.call<CosmereHooks.PreCompleteGoal>(
+                                HOOKS.PRE_COMPLETE_GOAL,
+                                item,
+                            ) === false
+                        ) {
+                            return false;
+                        }
+                    }
+
+                    // Add the previous level to the update
+                    foundry.utils.mergeObject(
+                        update,
+                        {
+                            [`flags.${SYSTEM_ID}.previousLevel`]: currentLevel,
+                        },
+                        {
+                            inplace: true,
+                        },
+                    );
+                }
+            }
+        }
+    },
+);
+
+Hooks.on(
+    'updateItem',
+    (item: CosmereItem, update: DeepPartial<CosmereItem>) => {
+        if (item.isGoal()) {
+            const previousLevel =
+                item.getFlag<number>(SYSTEM_ID, 'previousLevel') ?? 0;
+            const newLevel = item.system.level;
+
+            if (newLevel !== previousLevel) {
+                /**
+                 * Hook: updateProgressGoal
+                 */
+                Hooks.callAll<CosmereHooks.UpdateProgressGoal>(
+                    HOOKS.UPDATE_PROGRESS_GOAL,
+                    item,
+                );
+
+                if (newLevel > previousLevel) {
+                    /**
+                     * Hook: progressGoal
+                     */
+                    Hooks.callAll<CosmereHooks.ProgressGoal>(
+                        HOOKS.PROGRESS_GOAL,
+                        item,
+                    );
+                }
+
+                if (
+                    newLevel ===
+                    (
+                        GoalItemDataModel.schema.fields
+                            .level as foundry.data.fields.NumberField
+                    ).options.max!
+                ) {
+                    /**
+                     * Hook: completeGoal
+                     */
+                    Hooks.callAll<CosmereHooks.CompleteGoal>(
+                        HOOKS.COMPLETE_GOAL,
+                        item,
+                    );
+                }
+            }
+        }
+    },
+);

--- a/src/system/types/config.ts
+++ b/src/system/types/config.ts
@@ -48,6 +48,8 @@ import {
     DynamicItemListSectionGenerator,
 } from './application/actor/components/item-list';
 
+import { CosmereItem } from '@system/documents/item';
+
 export interface SizeConfig {
     label: string;
     size?: number;
@@ -341,6 +343,12 @@ export interface ItemEventTypeConfig {
     description?: string;
     hook: string;
     host: ItemEventSystem.Event.ExecutionHost;
+
+    /**
+     * A filter function to determine if this event should be available for a given item.
+     */
+    filter?: (item: CosmereItem) => boolean | Promise<boolean>;
+
     // NOTE: Allow any type as conditions should be able to freely match hook signatures
     /* eslint-disable @typescript-eslint/no-explicit-any */
     /**

--- a/src/system/types/hooks/item.ts
+++ b/src/system/types/hooks/item.ts
@@ -9,6 +9,14 @@ import { CosmereItem } from '@system/documents/item';
  * - modeActivateItem
  * - preModeDeactivateItem
  * - modeDeactivateItem
+ *
+ * --- Goal hooks ---
+ * - progressGoal — Triggered when a goal progresses towards completion (only forward progress).
+ * - preProgressGoal
+ * - updateProgressGoal — Triggered when a goal's progress is updated (can be forward or backward).
+ * - preUpdateProgressGoal
+ * - completeGoal — Triggered when a goal is completed.
+ * - preCompleteGoal
  */
 
 export type UseItem = (item: CosmereItem) => void;
@@ -20,3 +28,40 @@ export type ModeActivateItem = ModeChangeItem;
 export type PreModeActivateItem = PreModeChangeItem;
 export type ModeDeactivateItem = ModeChangeItem;
 export type PreModeDeactivateItem = PreModeChangeItem;
+
+/**
+ * Executed when a Goal Item's progresses gets updated towards completion.
+ * This only counts forward progress, not executed when the goal's progress is reduced.
+ */
+export type ProgressGoal = (item: CosmereItem) => void;
+
+/**
+ * Executed before a Goal Item's progress is updated towards completion.
+ */
+export type PreProgressGoal = (
+    item: CosmereItem,
+    newProgress: number,
+) => boolean;
+
+/**
+ * Executed when a Goal Item's progress is updated.
+ */
+export type UpdateProgressGoal = (item: CosmereItem) => void;
+
+/**
+ * Executed before a Goal Item's progress is updated.
+ */
+export type PreUpdateProgressGoal = (
+    item: CosmereItem,
+    newProgress: number,
+) => boolean;
+
+/**
+ * Executed when a Goal Item's progress gets filled and the goal is completed.
+ */
+export type CompleteGoal = (item: CosmereItem) => void;
+
+/**
+ * Executed before a Goal Item's progress is filled and the goal is completed.
+ */
+export type PreCompleteGoal = (item: CosmereItem) => boolean;

--- a/src/system/types/utils.ts
+++ b/src/system/types/utils.ts
@@ -16,6 +16,9 @@ export type Nullable<T> = T | null;
 
 export type SharedKeys<T, U> = keyof T & keyof U;
 
+export type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+export type DeepMutable<T> = { -readonly [P in keyof T]: DeepMutable<T[P]> };
+
 // NOTE: Using `any` in the below types as the resulting types don't rely on the `any`s
 // However they cannot be replaced with other types (e.g. `unknown`) without breaking dependent typings
 

--- a/src/templates/item/dialog/edit-event-rule.hbs
+++ b/src/templates/item/dialog/edit-event-rule.hbs
@@ -11,6 +11,7 @@
         value=rule.event
         name="event"
         localize=true
+        choices=eventSelectOptions
     }}
 
     <div class="form-group trigger-hint">


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR adds the following:
- 2 new events that are available to item event rules: Goal completed & Goal progressed. 
- Hooks for goal progression: `progressGoal` `preProgressGoal` `updateProgressGoal` `preUpdateProgressGoal` `completeGoal` `preCompleteGoal`
- The ability to filter which event types are available to be selected for event rules on certain items — The goal completed & goal progressed events are only available for Goal items, etc. (All existing event types that were only valid for certain items have been assigned their respective filters)

**Related Issue**  
Closes #382 

**How Has This Been Tested?**  
1. Open an Actor
2. Add a goal
3. Edit the goal
4. Add an event rule: set trigger to "Goal completed" and handler to "Grant items" and add an item to grant
5. Complete the goal -> Ensure the item was added to the actor
6. Remove the item from the actor
7. Reset the goal's progress
8. Edit the event rule: set trigger to "Goal progressed"
9. Progress the goal (but don't complete it) -> Ensure the item was added again
10. Edit the event rule, open the trigger dropdown and check that there's no events that are invalid for Goal items
11. Create a new Weapon item
12. Add an event rule to the weapon
13. Open the trigger dropdown and check that the "Goal completed" and "Goal progressed" events aren't present, and the "Equipped" and "Unequipped" events are
14. Create a new Talent item
15. Add an event rule to the talent
16. Open the trigger dropdown and check that the goal and equipment events aren't present, and the "Activated Modality" and "Deactivated Modality" events are

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/81bb4f14-a9ca-473d-a1ef-1c7ba76c09bd)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343