### PR TITLE
feat(item event system): add use item handler

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -904,19 +904,6 @@
                                 "UUID": {
                                     "Label": "Item"
                                 },
-                                "MatchMode": {
-                                    "Label": "Match Mode",
-                                    "Hint": "How to match the item to update.\nIdentifier matches by the identifier set under Details.\nName matches by exact name, case sensitive.\nUUID matches only the exact item.",
-                                    "Choices": {
-                                        "identifier": "Identifier",
-                                        "name": "Name",
-                                        "uuid": "UUID"
-                                    }
-                                },
-                                "MatchAll": {
-                                    "Label": "Match All",
-                                    "Hint": "Whether to match all items or just the first one encountered."
-                                },
                                 "FastForward": {
                                     "Label": "Fast Forward",
                                     "Hint": "Whether to skip the roll dialog for the roll."
@@ -991,6 +978,31 @@
                                     "Label": "Macro"
                                 }
                             }
+                        },
+                        "General": {
+                            "Target": {
+                                "Label": "Target",
+                                "Choices": {
+                                    "self": "Self",
+                                    "sibling": "Other on same Actor",
+                                    "equipped-weapon": "Equipped Weapon",
+                                    "equipped-armor": "Equipped Armor",
+                                    "global": "Global"
+                                }
+                            },
+                            "MatchMode": {
+                                "Label": "Match Mode",
+                                "Hint": "How to match the item.\nIdentifier matches by the identifier set under Details.\nName matches by exact name, case sensitive.\nUUID matches only the exact item.",
+                                "Choices": {
+                                    "identifier": "Identifier",
+                                    "name": "Name",
+                                    "uuid": "UUID"
+                                }
+                            },
+                            "MatchAll": {
+                                "Label": "Match All",
+                                "Hint": "Whether to match all items or just the first one encountered."
+                            }
                         }
                     }
                 },
@@ -1061,7 +1073,7 @@
                     "ModifyTraitValueFull": "[trait] [[value]] > [[newValue]]",
                     "ViewTraits": "View Traits"
                 },
-                "Armor": {                    
+                "Armor": {
                     "DeflectedTypes": "Deflected Damage Types",
                     "ViewDeflected": "View Deflected Types"
                 },
@@ -1087,7 +1099,7 @@
                     "Formula": "Damage Formula",
                     "GrazeOverride": "Override Graze Damage Calculation",
                     "GrazeFormula": "New Formula",
-                    "GrazeHint": "Formula entered here will be the entirety of the calculation for graze damage. Any die rolls will be rolled separately from the main damage roll. You can pull in all or part of the main roll using @damage.total/@damage.unmodded/@damage.dice (the latter being the system default) or the selected attribute mod with @mod",                    
+                    "GrazeHint": "Formula entered here will be the entirety of the calculation for graze damage. Any die rolls will be rolled separately from the main damage roll. You can pull in all or part of the main roll using @damage.total/@damage.unmodded/@damage.dice (the latter being the system default) or the selected attribute mod with @mod",
                     "ViewGraze": "View Graze Override"
                 },
                 "Modality": {
@@ -1209,11 +1221,11 @@
         },
         "Sheet": {
             "Descriptions": {
-              "DescriptionHeader": "Description",
-              "ShortHeader": "Short Description",
-              "ChatHeader": "Chat Description",
-              "Collapsible": "Toggle Collapsible",
-              "Edit": "Edit Description"
+                "DescriptionHeader": "Description",
+                "ShortHeader": "Short Description",
+                "ChatHeader": "Chat Description",
+                "Collapsible": "Toggle Collapsible",
+                "Edit": "Edit Description"
             },
             "Effects": {
                 "Label": "Effects",
@@ -1418,9 +1430,7 @@
             "Warning": {
                 "OutOfBounds": "The selected bounds would place at least one talent outside the tree."
             },
-            "Notification": {
-
-            }
+            "Notification": {}
         },
         "PickDiceResult": {
             "Title": "Pick Result",
@@ -1508,7 +1518,7 @@
             "Cancel": "Cancel",
             "Update": "Update",
             "RemoveFavorite": "Remove Favorite",
-            "Favorite":  "Favorite",
+            "Favorite": "Favorite",
             "Confirm": "Confirm"
         },
         "Notification": {
@@ -1618,14 +1628,14 @@
                 "PrioritiseTargeted": "Prioritise Targeted Tokens"
             }
         },
-		"expandDescriptionByDefault": {
-			"name": "Expand Item Description By Default",
-			"hint": "Determines whether the description section of an item should be expanded by default when opening the item sheet."
-		},
-		"skillIncrementDecrementToggle": {
-			"name": "Enable Skill Pip Increment Behavior",
-			"hint": "Determines whether the skill pips increment/decrement on left click or right click, rather than setting to the clicked rank."
-		},
+        "expandDescriptionByDefault": {
+            "name": "Expand Item Description By Default",
+            "hint": "Determines whether the description section of an item should be expanded by default when opening the item sheet."
+        },
+        "skillIncrementDecrementToggle": {
+            "name": "Enable Skill Pip Increment Behavior",
+            "hint": "Determines whether the skill pips increment/decrement on left click or right click, rather than setting to the clicked rank."
+        },
         "systemTheme": {
             "name": "Preferred System Theme",
             "hint": "Specify the themed set of colours to use for system documents and interface elements. The selected theme will respect the preferred Dark/Light mode selected in the core settings."

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -890,6 +890,45 @@
                                     "Hint": "The value to set the skill rank to."
                                 }
                             },
+                            "use-item": {
+                                "Title": "Use item",
+                                "Description": "Uses an item by rolling it.",
+                                "Target": {
+                                    "Label": "Target",
+                                    "Choices": {
+                                        "self": "Self",
+                                        "sibling": "Other on same Actor",
+                                        "global": "Global"
+                                    }
+                                },
+                                "UUID": {
+                                    "Label": "Item"
+                                },
+                                "MatchMode": {
+                                    "Label": "Match Mode",
+                                    "Hint": "How to match the item to update.\nIdentifier matches by the identifier set under Details.\nName matches by exact name, case sensitive.\nUUID matches only the exact item.",
+                                    "Choices": {
+                                        "identifier": "Identifier",
+                                        "name": "Name",
+                                        "uuid": "UUID"
+                                    }
+                                },
+                                "MatchAll": {
+                                    "Label": "Match All",
+                                    "Hint": "Whether to match all items or just the first one encountered."
+                                },
+                                "FastForward": {
+                                    "Label": "Fast Forward",
+                                    "Hint": "Whether to skip the roll dialog for the roll."
+                                },
+                                "AdvantageMode": {
+                                    "Label": "Advantage Mode"
+                                },
+                                "TemporaryDamageModifiers": {
+                                    "Label": "Damage Bonus",
+                                    "Hint": "Damage bonus formula to apply to the roll. Only items that can roll damage."
+                                }
+                            },
                             "update-actor": {
                                 "Title": "Update Actor",
                                 "Description": "Updates an actor by applying a set of changes.",

--- a/src/system/applications/item/dialogs/edit-event-rule.ts
+++ b/src/system/applications/item/dialogs/edit-event-rule.ts
@@ -152,6 +152,7 @@ export class ItemEditEventRuleDialog extends ComponentHandlebarsApplicationMixin
         // Handle handler config rendering
         const handlerConfigHtml = await this.rule.handler.configRenderer?.({
             ...context,
+            event: this.rule.event,
             handler: this.rule.handler,
 
             // Emulate component system

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -900,7 +900,7 @@ export class CosmereItem<
                 this, // Source
                 {
                     ...options,
-                    configurable: fastForward,
+                    configurable: !fastForward,
                     advantageMode,
                     plotDie,
                 },
@@ -1055,7 +1055,7 @@ export class CosmereItem<
                 this, // Source
                 {
                     ...options,
-                    configurable: fastForward,
+                    configurable: !fastForward,
                     advantageMode,
                     plotDie,
                 },

--- a/src/system/hooks/item-event-system/handlers/index.ts
+++ b/src/system/hooks/item-event-system/handlers/index.ts
@@ -6,6 +6,7 @@ import { register as registerModifySkillRankHandler } from './modify-skill-rank'
 import { register as registerSetSkillRankHandler } from './set-skill-rank';
 import { register as registerGrantExpertisesHandler } from './grant-expertises';
 import { register as registerRemoveExpertisesHandler } from './remove-expertises';
+import { register as registerUseItemHandler } from './use-item';
 import { register as registerUpdateItemHandler } from './update-item';
 import { register as registerUpdateActorHandler } from './update-actor';
 import { register as registerExecuteMacroHandler } from './execute-macro';
@@ -19,6 +20,7 @@ export function registerHandlers() {
     registerSetSkillRankHandler();
     registerGrantExpertisesHandler();
     registerRemoveExpertisesHandler();
+    registerUseItemHandler();
     registerUpdateItemHandler();
     registerUpdateActorHandler();
     registerExecuteMacroHandler();

--- a/src/system/hooks/item-event-system/handlers/use-item.ts
+++ b/src/system/hooks/item-event-system/handlers/use-item.ts
@@ -106,7 +106,12 @@ export function register() {
                     this.target === ItemTarget.EquippedArmor)
             )
                 return;
-            if (this.target !== ItemTarget.Self && !this.uuid) return;
+            if (
+                !this.uuid &&
+                (this.target === ItemTarget.Sibling ||
+                    this.target === ItemTarget.Global)
+            )
+                return;
             if (this.target === ItemTarget.Self && event.type === 'use') return;
 
             // Get the item(s) to use

--- a/src/system/hooks/item-event-system/handlers/use-item.ts
+++ b/src/system/hooks/item-event-system/handlers/use-item.ts
@@ -1,0 +1,211 @@
+import { CosmereItem } from '@system/documents/item';
+import { HandlerType, Event } from '@system/types/item/event-system';
+import { AdvantageMode } from '@system/types/roll';
+
+// Constants
+import { SYSTEM_ID } from '@system/constants';
+import { TEMPLATES } from '@system/utils/templates';
+
+const enum UseItemTarget {
+    Self = 'self',
+    Sibling = 'sibling',
+    Global = 'global',
+}
+
+const enum MatchMode {
+    Identifier = 'identifier',
+    Name = 'name',
+    UUID = 'uuid',
+}
+
+interface UseItemHandlerConfigData {
+    target: UseItemTarget;
+    uuid?: string | null;
+    matchMode?: MatchMode | null;
+    matchAll?: boolean | null;
+    fastForward: boolean;
+    advantageMode: AdvantageMode;
+    temporaryModifiers?: string;
+    temporaryDamageModifiers?: string;
+}
+
+export function register() {
+    cosmereRPG.api.registerItemEventHandlerType({
+        type: HandlerType.UseItem,
+        label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.Title`,
+        description: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.Description`,
+        config: {
+            schema: {
+                target: new foundry.data.fields.StringField({
+                    choices: {
+                        [UseItemTarget.Self]: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.Target.Choices.${UseItemTarget.Self}`,
+                        [UseItemTarget.Sibling]: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.Target.Choices.${UseItemTarget.Sibling}`,
+                        [UseItemTarget.Global]: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.Target.Choices.${UseItemTarget.Global}`,
+                    },
+                    initial: UseItemTarget.Sibling,
+                    required: true,
+                    blank: false,
+                    label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.Target.Label`,
+                }),
+                uuid: new foundry.data.fields.DocumentUUIDField({
+                    type: 'Item',
+                    initial: null,
+                    nullable: true,
+                    label: 'Item',
+                }),
+                matchMode: new foundry.data.fields.StringField({
+                    nullable: true,
+                    initial: MatchMode.Identifier,
+                    choices: {
+                        [MatchMode.Identifier]: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.MatchMode.Choices.${MatchMode.Identifier}`,
+                        [MatchMode.Name]: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.MatchMode.Choices.${MatchMode.Name}`,
+                        [MatchMode.UUID]: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.MatchMode.Choices.${MatchMode.UUID}`,
+                    },
+                    label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.MatchMode.Label`,
+                    hint: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.MatchMode.Hint`,
+                }),
+                matchAll: new foundry.data.fields.BooleanField({
+                    initial: false,
+                    nullable: true,
+                    label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.MatchAll.Label`,
+                    hint: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.MatchAll.Hint`,
+                }),
+                fastForward: new foundry.data.fields.BooleanField({
+                    initial: true,
+                    label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.FastForward.Label`,
+                    hint: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.FastForward.Hint`,
+                }),
+                advantageMode: new foundry.data.fields.StringField({
+                    initial: AdvantageMode.None,
+                    choices: {
+                        [AdvantageMode.None]: `DICE.AdvantageMode.None`,
+                        [AdvantageMode.Advantage]: `DICE.AdvantageMode.Advantage`,
+                        [AdvantageMode.Disadvantage]: `DICE.AdvantageMode.Disadvantage`,
+                    },
+                    label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.AdvantageMode.Label`,
+                }),
+                temporaryModifiers: new foundry.data.fields.StringField({
+                    initial: '',
+                    label: `DICE.TemporaryBonus.Label`,
+                    hint: `DICE.TemporaryBonus.Hint`,
+                }),
+                temporaryDamageModifiers: new foundry.data.fields.StringField({
+                    initial: '',
+                    label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.TemporaryDamageModifiers.Label`,
+                    hint: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.TemporaryDamageModifiers.Hint`,
+                }),
+            },
+            template: `systems/${SYSTEM_ID}/templates/${TEMPLATES.IES_HANDLER_USE_ITEM}`,
+        },
+        executor: async function (
+            this: UseItemHandlerConfigData,
+            event: Event.UseItem,
+        ) {
+            if (this.target === UseItemTarget.Sibling && !event.item.actor)
+                return;
+            if (this.target !== UseItemTarget.Self && !this.uuid) return;
+            if (this.target === UseItemTarget.Self && event.type === 'use')
+                return;
+
+            // Get the item(s) to use
+            const itemsToUse = await getItemsToUse(
+                event.item,
+                this.target,
+                this.uuid ?? null,
+                this.matchMode ?? MatchMode.Identifier,
+                this.matchAll ?? false,
+            );
+
+            const configurable = !(
+                this.fastForward || event.options?.configurable
+            );
+
+            const advantageMode =
+                this.advantageMode && this.advantageMode !== AdvantageMode.None
+                    ? this.advantageMode
+                    : (event.options?.advantageMode ?? AdvantageMode.None);
+
+            await Promise.all(
+                itemsToUse.map((item) =>
+                    item.use({
+                        configurable,
+                        advantageMode,
+                        temporaryModifiers: this.temporaryModifiers,
+
+                        ...(item.hasDamage()
+                            ? {
+                                  damage: {
+                                      overrideFormula: [
+                                          item.system.damage.formula ?? '',
+                                          this.temporaryDamageModifiers,
+                                      ]
+                                          .filter((v) => !!v)
+                                          .join(' + '),
+                                  },
+                              }
+                            : {}),
+                    }),
+                ),
+            );
+        },
+    });
+}
+
+/* --- Helpers --- */
+
+async function getItemsToUse(
+    item: CosmereItem,
+    target: UseItemTarget,
+    uuid: string | null,
+    matchMode: MatchMode | null,
+    matchAll: boolean | null,
+): Promise<CosmereItem[]> {
+    if (target === UseItemTarget.Self) {
+        return [item];
+    } else if (target === UseItemTarget.Sibling && item.actor && uuid) {
+        // Look up the reference item from uuid
+        const referenceItem = (await fromUuid(uuid)) as CosmereItem | null;
+        if (!referenceItem) return [];
+
+        const siblings = item.actor.items;
+
+        // Determine the match mode
+        matchMode =
+            matchMode === MatchMode.Identifier && !referenceItem.hasId()
+                ? MatchMode.Name
+                : matchMode;
+
+        // Get the matcher function
+        const matcher =
+            matchMode === MatchMode.Identifier
+                ? getIdentifierMatcher(referenceItem)
+                : matchMode === MatchMode.Name
+                  ? getNameMatcher(referenceItem)
+                  : getUUIDMatcher(referenceItem);
+
+        // Get the items to update
+        return matchAll
+            ? siblings.filter(matcher)
+            : [siblings.find(matcher)].filter((item) => !!item);
+    } else if (target === UseItemTarget.Global && uuid) {
+        // Look up the target item from uuid
+        return [(await fromUuid(uuid)) as CosmereItem | null].filter(
+            (item) => !!item,
+        );
+    } else {
+        throw new Error('Invalid target');
+    }
+}
+
+function getIdentifierMatcher(referenceItem: CosmereItem) {
+    return (item: CosmereItem) =>
+        item.hasId() && item.system.id === referenceItem.system.id;
+}
+
+function getNameMatcher(referenceItem: CosmereItem) {
+    return (item: CosmereItem) => item.name === referenceItem.name;
+}
+
+function getUUIDMatcher(referenceItem: CosmereItem) {
+    return (item: CosmereItem) => item.uuid === referenceItem.uuid;
+}

--- a/src/system/hooks/item-event-system/handlers/use-item.ts
+++ b/src/system/hooks/item-event-system/handlers/use-item.ts
@@ -118,9 +118,8 @@ export function register() {
                 this.matchAll ?? false,
             );
 
-            const configurable = !(
-                this.fastForward || event.options?.configurable
-            );
+            const configurable =
+                !this.fastForward || (event.options?.configurable ?? true);
 
             const advantageMode =
                 this.advantageMode && this.advantageMode !== AdvantageMode.None

--- a/src/system/hooks/item-event-system/handlers/use-item.ts
+++ b/src/system/hooks/item-event-system/handlers/use-item.ts
@@ -25,6 +25,7 @@ interface UseItemHandlerConfigData {
     matchAll?: boolean | null;
     fastForward: boolean;
     advantageMode: AdvantageMode;
+    plotDie: boolean;
     temporaryModifiers?: string;
     temporaryDamageModifiers?: string;
 }
@@ -84,6 +85,10 @@ export function register() {
                     },
                     label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.AdvantageMode.Label`,
                 }),
+                plotDie: new foundry.data.fields.BooleanField({
+                    initial: false,
+                    label: 'DICE.Plot.RaiseTheStakes',
+                }),
                 temporaryModifiers: new foundry.data.fields.StringField({
                     initial: '',
                     label: `DICE.TemporaryBonus.Label`,
@@ -125,11 +130,14 @@ export function register() {
                     ? this.advantageMode
                     : (event.options?.advantageMode ?? AdvantageMode.None);
 
+            const plotDie = this.plotDie || !!event.options?.plotDie;
+
             await Promise.all(
                 itemsToUse.map((item) =>
                     item.use({
                         configurable,
                         advantageMode,
+                        plotDie,
                         temporaryModifiers: this.temporaryModifiers,
 
                         ...(item.hasDamage()

--- a/src/system/hooks/item-event-system/handlers/utils.ts
+++ b/src/system/hooks/item-event-system/handlers/utils.ts
@@ -1,0 +1,108 @@
+import { EquipHand, HoldType } from '@system/types/cosmere';
+
+import { CosmereItem, WeaponItem, ArmorItem } from '@system/documents/item';
+
+export const enum ItemTarget {
+    Self = 'self',
+    Sibling = 'sibling',
+    EquippedWeapon = 'equipped-weapon',
+    EquippedArmor = 'equipped-armor',
+    Global = 'global',
+}
+
+export const enum MatchMode {
+    Identifier = 'identifier',
+    Name = 'name',
+    UUID = 'uuid',
+}
+
+export async function matchItems(
+    item: CosmereItem,
+    target: ItemTarget,
+    uuid: string | null,
+    matchMode: MatchMode | null,
+    matchAll: boolean | null,
+) {
+    if (target === ItemTarget.Self) {
+        return [item];
+    } else if (target === ItemTarget.Sibling && item.actor && uuid) {
+        // Look up the reference item from uuid
+        const referenceItem = (await fromUuid(uuid)) as CosmereItem | null;
+        if (!referenceItem) return [];
+
+        const siblings = item.actor.items;
+
+        // Determine the match mode
+        matchMode =
+            matchMode === MatchMode.Identifier && !referenceItem.hasId()
+                ? MatchMode.Name
+                : matchMode;
+
+        // Get the matcher function
+        const matcher =
+            matchMode === MatchMode.Identifier
+                ? getIdentifierMatcher(referenceItem)
+                : matchMode === MatchMode.Name
+                  ? getNameMatcher(referenceItem)
+                  : getUUIDMatcher(referenceItem);
+
+        // Get the items to update
+        return matchAll
+            ? siblings.filter(matcher)
+            : [siblings.find(matcher)].filter((item) => !!item);
+    } else if (target === ItemTarget.EquippedWeapon && item.actor) {
+        const condition = (item: CosmereItem) =>
+            item.isWeapon() && item.system.equipped;
+
+        return matchAll
+            ? item.actor.items.filter(condition)
+            : [
+                  (item.actor.items.filter(condition) as WeaponItem[])
+                      .sort(compareWeaponEquipType)
+                      .find(() => true),
+              ].filter((item) => !!item);
+    } else if (target === ItemTarget.EquippedArmor && item.actor) {
+        const condition = (item: CosmereItem) =>
+            item.isArmor() && item.system.equipped;
+
+        return matchAll
+            ? item.actor.items.filter(condition)
+            : [item.actor.items.find(condition)].filter((item) => !!item);
+    } else if (target === ItemTarget.Global && uuid) {
+        // Look up the target item from uuid
+        return [(await fromUuid(uuid)) as CosmereItem | null].filter(
+            (item) => !!item,
+        );
+    } else {
+        throw new Error('Invalid target');
+    }
+}
+
+function getIdentifierMatcher(referenceItem: CosmereItem) {
+    return (item: CosmereItem) =>
+        item.hasId() && item.system.id === referenceItem.system.id;
+}
+
+function getNameMatcher(referenceItem: CosmereItem) {
+    return (item: CosmereItem) => item.name === referenceItem.name;
+}
+
+function getUUIDMatcher(referenceItem: CosmereItem) {
+    return (item: CosmereItem) => item.uuid === referenceItem.uuid;
+}
+
+function compareWeaponEquipType(a: WeaponItem, b: WeaponItem) {
+    const holdA = a.system.equip.hold;
+    const holdB = b.system.equip.hold;
+
+    if (holdA === HoldType.TwoHanded) return -1;
+    if (holdB === HoldType.TwoHanded) return 1;
+
+    const handA = a.system.equip.hand;
+    const handB = b.system.equip.hand;
+
+    if (handA === EquipHand.Main && handB === EquipHand.Off) return -1;
+    if (handA === EquipHand.Off && handB === EquipHand.Main) return 1;
+
+    return 0;
+}

--- a/src/system/hooks/item-event-system/index.ts
+++ b/src/system/hooks/item-event-system/index.ts
@@ -1,9 +1,9 @@
-import { CosmereDocument } from '@system/documents';
 import { CosmereItem } from '@system/documents/item';
 import { CosmereActor } from '@system/documents/actor';
 
 import { Event } from '@system/types/item/event-system';
 import { ItemEventTypeConfig } from '@system/types/config';
+import { AnyObject } from '@system/types/utils';
 
 import { registerEventTypes } from './events';
 import { registerHandlers } from './handlers';
@@ -122,7 +122,7 @@ async function handleEventHook(
     item: CosmereItem,
     eventType: string,
     config: ItemEventTypeConfig,
-    options?: object,
+    options?: AnyObject,
     sourceUserId?: string,
 ) {
     // Verify if the local user is the appropriate event execution host
@@ -142,7 +142,7 @@ async function handleEventHook(
     }
 
     // Fire the event
-    await fireEvent({ type: eventType, item });
+    await fireEvent({ type: eventType, item, options });
 
     // Update the last event time
     lastEventTime = Date.now();
@@ -287,7 +287,7 @@ function getTransform(type: string, config: ItemEventTypeConfig) {
                 userId,
             } as {
                 document: foundry.abstract.Document;
-                options?: object;
+                options?: AnyObject;
                 userId?: string;
             };
         })

--- a/src/system/types/config.ts
+++ b/src/system/types/config.ts
@@ -43,6 +43,8 @@ import {
     EventSystem as ItemEventSystem,
 } from './item';
 
+import { AnyObject } from './utils';
+
 import {
     ItemListSection,
     DynamicItemListSectionGenerator,
@@ -352,7 +354,7 @@ export interface ItemEventTypeConfig {
      */
     transform?: (...args: any[]) => {
         document: foundry.abstract.Document;
-        options?: object;
+        options?: AnyObject;
         userId?: string;
     };
     /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/src/system/types/hooks/item.ts
+++ b/src/system/types/hooks/item.ts
@@ -11,8 +11,14 @@ import { CosmereItem } from '@system/documents/item';
  * - modeDeactivateItem
  */
 
-export type UseItem = (item: CosmereItem) => void;
-export type PreUseItem = (item: CosmereItem) => boolean;
+export type UseItem = (
+    item: CosmereItem,
+    options: CosmereItem.UseOptions,
+) => void;
+export type PreUseItem = (
+    item: CosmereItem,
+    options: CosmereItem.UseOptions,
+) => boolean;
 
 export type ModeChangeItem = (item: CosmereItem) => void;
 export type PreModeChangeItem = (item: CosmereItem) => boolean;

--- a/src/system/types/item/event-system/event.ts
+++ b/src/system/types/item/event-system/event.ts
@@ -1,9 +1,10 @@
 import { CosmereItem } from '@system/documents/item';
-import { AnyMutableObject } from '@system/types/utils';
+import { AnyMutableObject, AnyObject } from '@system/types/utils';
 
 export type Event<
-    EventData extends AnyMutableObject = AnyMutableObject,
+    EventData = AnyMutableObject,
     T extends string = string,
+    TOptions extends object = AnyObject,
 > = {
     /**
      * The type of this event.
@@ -14,6 +15,8 @@ export type Event<
      * The item that triggered this event.
      */
     item: CosmereItem;
+
+    options?: TOptions;
 } & EventData;
 
 export namespace Event {

--- a/src/system/types/item/event-system/event.ts
+++ b/src/system/types/item/event-system/event.ts
@@ -42,4 +42,6 @@ export namespace Event {
          */
         Source = 'source',
     }
+
+    export type UseItem = Event<unknown, 'use', CosmereItem.UseOptions>;
 }

--- a/src/system/types/item/event-system/handler.ts
+++ b/src/system/types/item/event-system/handler.ts
@@ -17,6 +17,8 @@ export const enum HandlerType {
     GrantExpertises = 'grant-expertises',
     RemoveExpertises = 'remove-expertises',
 
+    UseItem = 'use-item',
+
     // General purpose
     UpdateItem = 'update-item',
     UpdateActor = 'update-actor',
@@ -27,7 +29,8 @@ export type HandlerConfig<T = unknown> = {
     type: HandlerType;
 } & T;
 
-export type HandlerExecutor<E extends Event = Event> = (
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type HandlerExecutor<E extends Event = Event<any, any, any>> = (
     event: E,
 ) => void | boolean | Promise<void | boolean>;
 

--- a/src/system/utils/generic.ts
+++ b/src/system/utils/generic.ts
@@ -1,4 +1,5 @@
-import { CosmereActor } from '../documents';
+import { CosmereActor } from '@system/documents/actor';
+import { CosmereItem } from '@system/documents/item';
 import {
     getSystemKeybinding,
     getSystemSetting,
@@ -84,21 +85,54 @@ export function getNullableFromFormInput<T>(formField: string | null) {
     return formField && formField !== NONE ? (formField as T) : null;
 }
 
+export interface ConfigurationMode {
+    fastForward: boolean;
+    advantageMode: AdvantageMode;
+    plotDie: boolean;
+}
+
 /**
  * Processes pressed keys and provided config values to determine final values for a roll, specifically:
  * if it should skip the configuration dialog, what advantage mode it is using, and if it has raised stakes.
- * @param {boolean} [configure] Should the roll dialog be skipped?
- * @param {boolean} [advantage] Is something granting this roll advantage?
- * @param {boolean} [disadvantage] Is something granting this roll disadvantage?
- * @param {boolean} [raiseStakes] Is something granting this roll raised stakes?
- * @returns {{fastForward: boolean, advantageMode: AdvantageMode, plotDie: boolean}} Whether a roll should fast forward, have a plot die, and its advantage mode.
+ * @param configure Should the roll dialog be skipped?
+ * @param advantage Is something granting this roll advantage?
+ * @param disadvantage Is something granting this roll disadvantage?
+ * @param raiseStakes Is something granting this roll raised stakes?
+ * @returns Whether a roll should fast forward, have a plot die, and its advantage mode.
  */
+export function determineConfigurationMode(
+    useOptions?: CosmereItem.UseOptions,
+): ConfigurationMode;
 export function determineConfigurationMode(
     configure?: boolean,
     advantage?: boolean,
     disadvantage?: boolean,
     raiseStakes?: boolean,
-) {
+): ConfigurationMode;
+export function determineConfigurationMode(
+    ...args:
+        | [CosmereItem.UseOptions?]
+        | [boolean?, boolean?, boolean?, boolean?]
+): ConfigurationMode {
+    const useOptions =
+        args.length === 1
+            ? (args[0] as CosmereItem.UseOptions | undefined)
+            : undefined;
+
+    const [configure, advantage, disadvantage, raiseStakes] =
+        args.length === 1
+            ? [
+                  useOptions?.configurable,
+                  useOptions?.advantageMode !== undefined
+                      ? useOptions.advantageMode === AdvantageMode.Advantage
+                      : undefined,
+                  useOptions?.advantageMode !== undefined
+                      ? useOptions.advantageMode === AdvantageMode.Disadvantage
+                      : undefined,
+                  useOptions?.plotDie,
+              ]
+            : args;
+
     const modifiers = {
         advantage: areKeysPressed(KEYBINDINGS.SKIP_DIALOG_ADVANTAGE),
         disadvantage: areKeysPressed(KEYBINDINGS.SKIP_DIALOG_DISADVANTAGE),

--- a/src/system/utils/handlebars/index.ts
+++ b/src/system/utils/handlebars/index.ts
@@ -503,6 +503,27 @@ Handlebars.registerHelper('entries', (obj: AnyObject) => {
     return Object.entries(obj).map(([key, value]) => ({ key, value }));
 });
 
+Handlebars.registerHelper('filterSelectOptions', ((
+    selectOptions: Record<string, string> | (() => Record<string, string>),
+    ...args: [...string[], Handlebars.HelperOptions]
+) => {
+    if (typeof selectOptions === 'function') selectOptions = selectOptions();
+
+    const filters = args.slice(0, -1);
+    const options = args[args.length - 1];
+
+    const filterSet = new Set(filters as unknown as string[]);
+    return Object.entries(selectOptions)
+        .filter(([key]) => !filterSet.has(key))
+        .reduce(
+            (acc, [key, value]) => {
+                acc[key] = value;
+                return acc;
+            },
+            {} as Record<string, string>,
+        );
+}) as unknown as Handlebars.HelperDelegate);
+
 export async function preloadHandlebarsTemplates() {
     const templates = Object.values(TEMPLATES).reduce(
         (partials, path) => {

--- a/src/system/utils/templates.ts
+++ b/src/system/utils/templates.ts
@@ -190,6 +190,7 @@ export const TEMPLATES = {
         'item/event-system/handlers/grant-expertises.hbs',
     IES_HANDLER_REMOVE_EXPERTISES:
         'item/event-system/handlers/remove-expertises.hbs',
+    IES_HANDLER_USE_ITEM: 'item/event-system/handlers/use-item.hbs',
     IES_HANDLER_UPDATE_ITEM: 'item/event-system/handlers/update-item.hbs',
     IES_HANDLER_UPDATE_ACTOR: 'item/event-system/handlers/update-actor.hbs',
 } as const;

--- a/src/templates/item/event-system/handlers/update-item.hbs
+++ b/src/templates/item/event-system/handlers/update-item.hbs
@@ -67,8 +67,6 @@
     {{/if}}
 {{/if}}
 
-<br>
-
 {{!-- Changes --}}
 {{app-document-changes-list 
     name="handler.changes"

--- a/src/templates/item/event-system/handlers/use-item.hbs
+++ b/src/templates/item/event-system/handlers/use-item.hbs
@@ -15,7 +15,7 @@
 {{/unless}}
 
 {{!-- UUID --}}
-{{#if (not (eq handler.target "self"))}}
+{{#if (or (eq handler.target "sibling") (eq handler.target "global"))}}
     <div class="form-group">
         <label>
             {{localize handler.schema.fields.uuid.label}}
@@ -48,25 +48,25 @@
             }}
         </div>
     </div>
+{{/if}}
 
-    {{!-- Match All --}}
-    {{#if (not (eq handler.matchMode "uuid"))}}
-        <div class="form-group">
-            <label>
-                {{localize handler.schema.fields.matchAll.label}}
-                <i class="info fa-regular fa-circle-question" 
-                    data-tooltip="{{localize handler.schema.fields.matchAll.hint}}"
-                ></i>
-            </label>
-            <div class="form-fields">
-                {{formInput handler.schema.fields.matchAll
-                    name="handler.matchAll"
-                    value=handler.matchAll
-                    localize=true
-                }}
-            </div>
+{{!-- Match All --}}
+{{#if (or (and (eq handler.target "sibling") (not (eq handler.matchMode "uuid"))) (eq handler.target "equipped-weapon") (eq handler.target "equipped-armor"))}}
+    <div class="form-group">
+        <label>
+            {{localize handler.schema.fields.matchAll.label}}
+            <i class="info fa-regular fa-circle-question" 
+                data-tooltip="{{localize handler.schema.fields.matchAll.hint}}"
+            ></i>
+        </label>
+        <div class="form-fields">
+            {{formInput handler.schema.fields.matchAll
+                name="handler.matchAll"
+                value=handler.matchAll
+                localize=true
+            }}
         </div>
-    {{/if}}
+    </div>
 {{/if}}
 
 {{#unless (eq event "use")}}

--- a/src/templates/item/event-system/handlers/use-item.hbs
+++ b/src/templates/item/event-system/handlers/use-item.hbs
@@ -97,6 +97,15 @@
     {{/if}}
 {{/unless}}
 
+{{!-- Plot die --}}
+{{formGroup handler.schema.fields.plotDie
+    name="handler.plotDie"
+    value=handler.plotDie
+    localize=true
+}}
+
+{{!-- Plot die bonus --}}
+
 {{!-- Temporary Modifiers --}}
 <div class="form-group">
     <label>

--- a/src/templates/item/event-system/handlers/use-item.hbs
+++ b/src/templates/item/event-system/handlers/use-item.hbs
@@ -1,0 +1,132 @@
+{{!-- Target --}}
+{{#unless (eq event "use")}}
+    {{formGroup handler.schema.fields.target
+        name="handler.target"
+        value=handler.target
+        localize=true
+    }}
+{{else}}
+    {{formGroup handler.schema.fields.target
+        name="handler.target"
+        value=handler.target
+        localize=true
+        choices=(filterSelectOptions handler.schema.fields.target.choices "self")
+    }}
+{{/unless}}
+
+{{!-- UUID --}}
+{{#if (not (eq handler.target "self"))}}
+    <div class="form-group">
+        <label>
+            {{localize handler.schema.fields.uuid.label}}
+        </label>
+        <div class="form-fields">
+            {{app-document-reference-input 
+                name="handler.uuid"
+                value=handler.uuid
+                type="Item"
+                placeholder="Drag and drop item here"
+            }}
+        </div>
+    </div>
+{{/if}}
+
+{{!-- Match Mode --}}
+{{#if (eq handler.target "sibling")}}
+    <div class="form-group">
+        <label>
+            {{localize handler.schema.fields.matchMode.label}}
+            <i class="info fa-regular fa-circle-question" 
+                data-tooltip="{{localize handler.schema.fields.matchMode.hint}}"
+            ></i>
+        </label>
+        <div class="form-fields">
+            {{formInput handler.schema.fields.matchMode
+                name="handler.matchMode"
+                value=handler.matchMode
+                localize=true
+            }}
+        </div>
+    </div>
+
+    {{!-- Match All --}}
+    {{#if (not (eq handler.matchMode "uuid"))}}
+        <div class="form-group">
+            <label>
+                {{localize handler.schema.fields.matchAll.label}}
+                <i class="info fa-regular fa-circle-question" 
+                    data-tooltip="{{localize handler.schema.fields.matchAll.hint}}"
+                ></i>
+            </label>
+            <div class="form-fields">
+                {{formInput handler.schema.fields.matchAll
+                    name="handler.matchAll"
+                    value=handler.matchAll
+                    localize=true
+                }}
+            </div>
+        </div>
+    {{/if}}
+{{/if}}
+
+{{#unless (eq event "use")}}
+    {{!-- Fast forward --}}
+    <div class="form-group">
+        <label>
+            {{localize handler.schema.fields.fastForward.label}}
+            <i class="info fa-regular fa-circle-question" 
+                data-tooltip="{{localize handler.schema.fields.fastForward.hint}}"
+            ></i>
+        </label>
+        <div class="form-fields">
+            {{formInput handler.schema.fields.fastForward
+                name="handler.fastForward"
+                value=handler.fastForward
+                localize=true
+            }}
+        </div>
+    </div>
+
+    {{#if handler.fastForward}}
+        {{!-- Advantage Mode --}}
+        {{formGroup handler.schema.fields.advantageMode
+            name="handler.advantageMode"
+            value=handler.advantageMode
+            localize=true
+        }}
+    {{/if}}
+{{/unless}}
+
+{{!-- Temporary Modifiers --}}
+<div class="form-group">
+    <label>
+        {{localize handler.schema.fields.temporaryModifiers.label}}
+        <i class="info fa-regular fa-circle-question" 
+            data-tooltip="{{localize handler.schema.fields.temporaryModifiers.hint}}"
+        ></i>
+    </label>
+    <div class="form-fields">
+        {{formInput handler.schema.fields.temporaryModifiers
+            name="handler.temporaryModifiers"
+            value=handler.temporaryModifiers
+            localize=true
+        }}
+    </div>
+</div>
+
+{{!-- Temporary Damage Modifiers --}}
+<div class="form-group">
+    <label>
+        {{localize handler.schema.fields.temporaryDamageModifiers.label}}
+        <i class="info fa-regular fa-circle-question" 
+            data-tooltip="{{localize handler.schema.fields.temporaryDamageModifiers.hint}}"
+        ></i>
+    </label>
+    <div class="form-fields">
+        {{formInput handler.schema.fields.temporaryDamageModifiers
+            name="handler.temporaryDamageModifiers"
+            value=handler.temporaryDamageModifiers
+            localize=true
+        }}
+    </div>
+</div>


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR implements the "Use Item" handler, which can be used to use/roll an item when an event occurs. If used with the "Used" event it will also forward some roll options from the triggering action to the use call (fast forwarding, advantage/disadvantage, plot die).

Includes some changes to the item document to include the options in the `useItem` and `preUseItem` hooks, improved handling of temporaryModifiers, and a fix to be able to use the override formula for damage rolls as part of an attack.

**Related Issue**  
Closes #381 

**How Has This Been Tested?**  
1. Open an actor
2. Add a one-handed weapon (weapon1) to the actor
3. Equip the weapon
4. Add a talent to the actor (preferably with no activation or utility)
5. Edit the talent and add a new event rule
6. Set trigger to "Used"
7. Set handler type to "Use Item"
8. Drag the weapon into the item field
9. Click "Update"
10. Use the item -> Ensure the attack roll dialog appears for the weapon
11. Use the item with advantage fast forwarding -> Ensure the attack gets rolled with advantage on the d20
12. Use the item with disadvantage fast forwarding -> Ensure the attack gets rolled with disadvantage on the d20
13. Use the item with plot die fast forwarding -> Ensure the attack gets rolled with a plot die
14. Edit the event rule
15. Enable "Raise the stakes"
16. Set temporary bonus to 5
17. Set damage bonus to 1d4
18. Click "Update"
19. Use the item -> Ensure "Raise the stakes" is on, the d20 roll includes an extra +5 and the damage includes an additional d4
20. Edit the event rule
21. Set target to "Equipped Weapon"
22. Click "Update"
23. Use the item -> Ensure the weapon gets rolled
24. Add a different one-handed weapon (weapon2) to the actor
25. Unequip weapon1
26. Equip weapon2
27. Use the item -> Ensure weapon2 gets rolled
28. Equip weapon1 in the main hand and weapon2 in the off hand
29. Use the item -> Ensure weapon1 gets rolled
30. Equip weapon2 in the main hand and weapon1 in the off hand
31. Use the item -> Ensure weapon2 gets rolled
32. Add a two-handed weapon (weapon3) to the actor
33. Equip weapon3
34. Use the item -> Ensure weapon3 gets rolled
35. Edit the event rule
36. Enable match all
37. Click "Update"
38. Use the item -> Ensure all weapons are rolled
39. Add an armor to the actor and equip it
40. Edit the event rule
41. Set target to "Equipped Armor"
42. Disabled match all
43. Click "Update"
44. Use the item -> Ensure the armor gets rolled

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/ff9810cc-b45f-4ed1-9981-755d73c787aa)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343