### PR TITLE
refactor: config register api changes

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1548,6 +1548,9 @@
             "ItemAlreadyInTree": "An item with id \"{itemId}\" already exists in the {name} talent tree",
             "ActorConditionImmune": "{actor} is immune to {condition}"
         },
+        "Error": {
+            "RegisteringConfigs": "Error while registering configs. Check console for details."
+        },
         "Enrichers": {
             "Test": {
                 "Against": "against",

--- a/src/system/api/actor.ts
+++ b/src/system/api/actor.ts
@@ -5,8 +5,7 @@ import {
     RegistrationLogType,
     SkillConfig,
 } from '@system/types/config';
-import { HOOKS } from '../constants/hooks';
-import { CosmereHooks } from '../types/hooks';
+import { RegistrationHelper } from './helper';
 
 interface SkillConfigData extends Omit<SkillConfig, 'key'> {
     /**
@@ -25,77 +24,69 @@ export function registerSkill(
         );
     }
 
-    Hooks.on<CosmereHooks.RegisterConfig>(
-        HOOKS.REGISTER_CONFIG,
-        (completed, logs) => {
-            const toRegister = {
-                key: data.id,
-                label: data.label,
-                attribute: data.attribute,
-                core: data.core,
-                hiddenUntilAcquired: data.hiddenUntilAcquired,
-            } as SkillConfig;
+    RegistrationHelper.registerCallback((completed, logs) => {
+        const toRegister = {
+            key: data.id,
+            label: data.label,
+            attribute: data.attribute,
+            core: data.core,
+            hiddenUntilAcquired: data.hiddenUntilAcquired,
+        } as SkillConfig;
 
-            const Register = () => {
-                completed[data.id] = options;
-                CONFIG.COSMERE.skills[data.id as Skill] = toRegister;
-                CONFIG.COSMERE.attributes[data.attribute].skills.push(
-                    data.id as Skill,
-                );
+        const Register = () => {
+            completed[data.id] = options;
+            CONFIG.COSMERE.skills[data.id as Skill] = toRegister;
+            CONFIG.COSMERE.attributes[data.attribute].skills.push(
+                data.id as Skill,
+            );
+            return true;
+        };
+
+        if (data.id in CONFIG.COSMERE.skills) {
+            // If the same object is already registered, we ignore the registration and mark it succesful.
+            if (
+                foundry.utils.objectsEqual(
+                    toRegister,
+                    CONFIG.COSMERE.skills[data.id as Skill],
+                )
+            ) {
                 return true;
-            };
-
-            if (data.id in CONFIG.COSMERE.skills) {
-                // If the same object is already registered, we ignore the registration and mark it succesful.
-                if (
-                    foundry.utils.objectsEqual(
-                        toRegister,
-                        CONFIG.COSMERE.skills[data.id as Skill],
-                    )
-                ) {
-                    return true;
-                }
-
-                // If the object is not the same, but force is true, we register anyway.
-                if (options.force ?? false) {
-                    logs.push({
-                        source: options.source,
-                        type: RegistrationLogType.Warn,
-                        message: `Force registering Skill with ID: ${data.id}`,
-                    });
-
-                    return Register();
-                }
-
-                // If the object was registered by a previous API call, compare priorities.
-                // If not, but the object still already exists, check that the priority is higher than 0 (i.e. higher than the default system config).
-                if (
-                    (data.id in completed &&
-                        (completed[data.id].priority ?? 0) <
-                            (options.priority ?? 0)) ||
-                    (!(data.id in completed) && (options.priority ?? 0) > 0)
-                ) {
-                    logs.push({
-                        source: options.source,
-                        type: RegistrationLogType.Warn,
-                        message: `Overriding Skill with ID: ${data.id} due to a higher priority value: ${options.priority}.`,
-                    });
-
-                    return Register();
-                    // If both conditions fail, the new registration has a lower priority than either system default or any previous registration
-                    // This means we can log this new registration as a failure and not register it.
-                } else {
-                    logs.push({
-                        source: options.source,
-                        type: RegistrationLogType.Error,
-                        message: `Failed to register Skill with ID: ${data.id} because there is already a higher priority registration.`,
-                    });
-
-                    return false;
-                }
             }
 
-            return Register();
-        },
-    );
+            // If the object was registered by a previous API call, compare priorities.
+            // If not, but the object still already exists, check that the priority is higher than 0 (i.e. higher than the default system config).
+            // If both conditions fail, the new registration has a lower priority than either system default or any previous registration.
+            // This means we can log this new registration as a failure and not register it.
+            if (
+                (data.id in completed &&
+                    (completed[data.id].priority ?? 0) <
+                        (options.priority ?? 0)) ||
+                (!(data.id in completed) && (options.priority ?? 0) > 0)
+            ) {
+                logs.push({
+                    source: options.source,
+                    type: RegistrationLogType.Warn,
+                    message: `Overriding Skill with ID: ${data.id} due to a higher priority value: ${options.priority}.`,
+                } as RegistrationLog);
+
+                return Register();
+            } else {
+                if (options.strict) {
+                    throw new Error(
+                        `Failed to register Skill with ID: ${data.id} due to conflicts.`,
+                    );
+                }
+
+                logs.push({
+                    source: options.source,
+                    type: RegistrationLogType.Error,
+                    message: `Failed to register Skill with ID: ${data.id} because there is already a higher priority registration.`,
+                } as RegistrationLog);
+
+                return false;
+            }
+        }
+
+        return Register();
+    });
 }

--- a/src/system/api/actor.ts
+++ b/src/system/api/actor.ts
@@ -7,21 +7,21 @@ import {
 } from '@system/types/config';
 import { RegistrationHelper } from './helper';
 
-interface SkillConfigData extends Omit<SkillConfig, 'key'> {
+interface SkillConfigData extends Omit<SkillConfig, 'key'>, RegistrationConfig {
     /**
      * Unique id for the skill.
      */
     id: string;
 }
 
-export function registerSkill(data: SkillConfigData & RegistrationConfig) {
+export function registerSkill(data: SkillConfigData) {
     if (!CONFIG.COSMERE) {
         throw new Error(
             'Cannot access API until after the system is initialized.',
         );
     }
 
-    const tag = `skill.${data.id}`;
+    const identifier = `skill.${data.id}`;
 
     const toRegister = {
         key: data.id,
@@ -31,8 +31,8 @@ export function registerSkill(data: SkillConfigData & RegistrationConfig) {
         hiddenUntilAcquired: data.hiddenUntilAcquired,
     } as SkillConfig;
 
-    const Register = () => {
-        RegistrationHelper.COMPLETED[tag] = data;
+    const register = () => {
+        RegistrationHelper.COMPLETED[identifier] = data;
         CONFIG.COSMERE.skills[data.id as Skill] = toRegister;
         CONFIG.COSMERE.attributes[data.attribute].skills.push(data.id as Skill);
         return true;
@@ -49,39 +49,8 @@ export function registerSkill(data: SkillConfigData & RegistrationConfig) {
             return true;
         }
 
-        // If the object was registered by a previous API call, compare priorities.
-        // If not, but the object still already exists, check that the priority is higher than 0 (i.e. higher than the default system config).
-        // If both conditions fail, the new registration has a lower priority than either system default or any previous registration.
-        // This means we can log this new registration as a failure and not register it.
-        if (
-            (tag in RegistrationHelper.COMPLETED &&
-                (RegistrationHelper.COMPLETED[tag].priority ?? 0) <
-                    (data.priority ?? 0)) ||
-            (!(tag in RegistrationHelper.COMPLETED) && (data.priority ?? 0) > 0)
-        ) {
-            RegistrationHelper.registerLog({
-                source: data.source,
-                type: RegistrationLogType.Warn,
-                message: `Overriding Skill with ID: ${data.id} due to a higher priority value: ${data.priority}.`,
-            } as RegistrationLog);
-
-            return Register();
-        } else {
-            if (data.strict) {
-                throw new Error(
-                    `Failed to register Skill with ID: ${data.id} due to conflicts.`,
-                );
-            }
-
-            RegistrationHelper.registerLog({
-                source: data.source,
-                type: RegistrationLogType.Error,
-                message: `Failed to register Skill with ID: ${data.id} because there is already a higher priority registration.`,
-            } as RegistrationLog);
-
-            return false;
-        }
+        return RegistrationHelper.tryRegisterConfig(identifier, data, register);
     }
 
-    return Register();
+    return register();
 }

--- a/src/system/api/actor.ts
+++ b/src/system/api/actor.ts
@@ -1,10 +1,5 @@
 import { Skill } from '@system/types/cosmere';
-import {
-    RegistrationConfig,
-    RegistrationLog,
-    RegistrationLogType,
-    SkillConfig,
-} from '@system/types/config';
+import { RegistrationConfig, SkillConfig } from '@system/types/config';
 import { RegistrationHelper } from './helper';
 
 interface SkillConfigData extends Omit<SkillConfig, 'key'>, RegistrationConfig {

--- a/src/system/api/actor.ts
+++ b/src/system/api/actor.ts
@@ -14,79 +14,74 @@ interface SkillConfigData extends Omit<SkillConfig, 'key'> {
     id: string;
 }
 
-export function registerSkill(
-    data: SkillConfigData,
-    options: RegistrationConfig,
-) {
+export function registerSkill(data: SkillConfigData & RegistrationConfig) {
     if (!CONFIG.COSMERE) {
         throw new Error(
             'Cannot access API until after the system is initialized.',
         );
     }
 
-    RegistrationHelper.registerCallback((completed, logs) => {
-        const toRegister = {
-            key: data.id,
-            label: data.label,
-            attribute: data.attribute,
-            core: data.core,
-            hiddenUntilAcquired: data.hiddenUntilAcquired,
-        } as SkillConfig;
+    const tag = `skill.${data.id}`;
 
-        const Register = () => {
-            completed[data.id] = options;
-            CONFIG.COSMERE.skills[data.id as Skill] = toRegister;
-            CONFIG.COSMERE.attributes[data.attribute].skills.push(
-                data.id as Skill,
-            );
+    const toRegister = {
+        key: data.id,
+        label: data.label,
+        attribute: data.attribute,
+        core: data.core,
+        hiddenUntilAcquired: data.hiddenUntilAcquired,
+    } as SkillConfig;
+
+    const Register = () => {
+        RegistrationHelper.COMPLETED[tag] = data;
+        CONFIG.COSMERE.skills[data.id as Skill] = toRegister;
+        CONFIG.COSMERE.attributes[data.attribute].skills.push(data.id as Skill);
+        return true;
+    };
+
+    if (data.id in CONFIG.COSMERE.skills) {
+        // If the same object is already registered, we ignore the registration and mark it succesful.
+        if (
+            foundry.utils.objectsEqual(
+                toRegister,
+                CONFIG.COSMERE.skills[data.id as Skill],
+            )
+        ) {
             return true;
-        };
-
-        if (data.id in CONFIG.COSMERE.skills) {
-            // If the same object is already registered, we ignore the registration and mark it succesful.
-            if (
-                foundry.utils.objectsEqual(
-                    toRegister,
-                    CONFIG.COSMERE.skills[data.id as Skill],
-                )
-            ) {
-                return true;
-            }
-
-            // If the object was registered by a previous API call, compare priorities.
-            // If not, but the object still already exists, check that the priority is higher than 0 (i.e. higher than the default system config).
-            // If both conditions fail, the new registration has a lower priority than either system default or any previous registration.
-            // This means we can log this new registration as a failure and not register it.
-            if (
-                (data.id in completed &&
-                    (completed[data.id].priority ?? 0) <
-                        (options.priority ?? 0)) ||
-                (!(data.id in completed) && (options.priority ?? 0) > 0)
-            ) {
-                logs.push({
-                    source: options.source,
-                    type: RegistrationLogType.Warn,
-                    message: `Overriding Skill with ID: ${data.id} due to a higher priority value: ${options.priority}.`,
-                } as RegistrationLog);
-
-                return Register();
-            } else {
-                if (options.strict) {
-                    throw new Error(
-                        `Failed to register Skill with ID: ${data.id} due to conflicts.`,
-                    );
-                }
-
-                logs.push({
-                    source: options.source,
-                    type: RegistrationLogType.Error,
-                    message: `Failed to register Skill with ID: ${data.id} because there is already a higher priority registration.`,
-                } as RegistrationLog);
-
-                return false;
-            }
         }
 
-        return Register();
-    });
+        // If the object was registered by a previous API call, compare priorities.
+        // If not, but the object still already exists, check that the priority is higher than 0 (i.e. higher than the default system config).
+        // If both conditions fail, the new registration has a lower priority than either system default or any previous registration.
+        // This means we can log this new registration as a failure and not register it.
+        if (
+            (tag in RegistrationHelper.COMPLETED &&
+                (RegistrationHelper.COMPLETED[tag].priority ?? 0) <
+                    (data.priority ?? 0)) ||
+            (!(tag in RegistrationHelper.COMPLETED) && (data.priority ?? 0) > 0)
+        ) {
+            RegistrationHelper.registerLog({
+                source: data.source,
+                type: RegistrationLogType.Warn,
+                message: `Overriding Skill with ID: ${data.id} due to a higher priority value: ${data.priority}.`,
+            } as RegistrationLog);
+
+            return Register();
+        } else {
+            if (data.strict) {
+                throw new Error(
+                    `Failed to register Skill with ID: ${data.id} due to conflicts.`,
+                );
+            }
+
+            RegistrationHelper.registerLog({
+                source: data.source,
+                type: RegistrationLogType.Error,
+                message: `Failed to register Skill with ID: ${data.id} because there is already a higher priority registration.`,
+            } as RegistrationLog);
+
+            return false;
+        }
+    }
+
+    return Register();
 }

--- a/src/system/api/actor.ts
+++ b/src/system/api/actor.ts
@@ -1,6 +1,12 @@
 import { Skill } from '@system/types/cosmere';
-
-import { SkillConfig } from '@system/types/config';
+import {
+    RegistrationConfig,
+    RegistrationLog,
+    RegistrationLogType,
+    SkillConfig,
+} from '@system/types/config';
+import { HOOKS } from '../constants/hooks';
+import { CosmereHooks } from '../types/hooks';
 
 interface SkillConfigData extends Omit<SkillConfig, 'key'> {
     /**
@@ -9,26 +15,87 @@ interface SkillConfigData extends Omit<SkillConfig, 'key'> {
     id: string;
 }
 
-export function registerSkill(data: SkillConfigData, force = false) {
-    if (!CONFIG.COSMERE)
-        throw new Error('Cannot access api until after system is initialized.');
-
-    if (data.id in CONFIG.COSMERE.skills && !force)
-        throw new Error('Cannot override existing skill config.');
-
-    if (force) {
-        console.warn('Registering skill with force=true.');
+export function registerSkill(
+    data: SkillConfigData,
+    options: RegistrationConfig,
+) {
+    if (!CONFIG.COSMERE) {
+        throw new Error(
+            'Cannot access API until after the system is initialized.',
+        );
     }
 
-    // Add to skills config
-    CONFIG.COSMERE.skills[data.id as Skill] = {
-        key: data.id,
-        label: data.label,
-        attribute: data.attribute,
-        core: data.core,
-        hiddenUntilAcquired: data.hiddenUntilAcquired,
-    };
+    Hooks.on<CosmereHooks.RegisterConfig>(
+        HOOKS.REGISTER_CONFIG,
+        (completed, logs) => {
+            const toRegister = {
+                key: data.id,
+                label: data.label,
+                attribute: data.attribute,
+                core: data.core,
+                hiddenUntilAcquired: data.hiddenUntilAcquired,
+            } as SkillConfig;
 
-    // Add to attribute's skills list
-    CONFIG.COSMERE.attributes[data.attribute].skills.push(data.id as Skill);
+            const Register = () => {
+                completed[data.id] = options;
+                CONFIG.COSMERE.skills[data.id as Skill] = toRegister;
+                CONFIG.COSMERE.attributes[data.attribute].skills.push(
+                    data.id as Skill,
+                );
+                return true;
+            };
+
+            if (data.id in CONFIG.COSMERE.skills) {
+                // If the same object is already registered, we ignore the registration and mark it succesful.
+                if (
+                    foundry.utils.objectsEqual(
+                        toRegister,
+                        CONFIG.COSMERE.skills[data.id as Skill],
+                    )
+                ) {
+                    return true;
+                }
+
+                // If the object is not the same, but force is true, we register anyway.
+                if (options.force ?? false) {
+                    logs.push({
+                        source: options.source,
+                        type: RegistrationLogType.Warn,
+                        message: `Force registering Skill with ID: ${data.id}`,
+                    });
+
+                    return Register();
+                }
+
+                // If the object was registered by a previous API call, compare priorities.
+                // If not, but the object still already exists, check that the priority is higher than 0 (i.e. higher than the default system config).
+                if (
+                    (data.id in completed &&
+                        (completed[data.id].priority ?? 0) <
+                            (options.priority ?? 0)) ||
+                    (!(data.id in completed) && (options.priority ?? 0) > 0)
+                ) {
+                    logs.push({
+                        source: options.source,
+                        type: RegistrationLogType.Warn,
+                        message: `Overriding Skill with ID: ${data.id} due to a higher priority value: ${options.priority}.`,
+                    });
+
+                    return Register();
+                    // If both conditions fail, the new registration has a lower priority than either system default or any previous registration
+                    // This means we can log this new registration as a failure and not register it.
+                } else {
+                    logs.push({
+                        source: options.source,
+                        type: RegistrationLogType.Error,
+                        message: `Failed to register Skill with ID: ${data.id} because there is already a higher priority registration.`,
+                    });
+
+                    return false;
+                }
+            }
+
+            return Register();
+        },
+    );
 }

--- a/src/system/api/general.ts
+++ b/src/system/api/general.ts
@@ -1,13 +1,14 @@
 import {
     CurrencyConfig,
-    SkillConfig,
-    PowerTypeConfig,
-    ActionTypeConfig,
     RegistrationConfig,
     RegistrationLogType,
     RegistrationLog,
 } from '@system/types/config';
 import { RegistrationHelper } from './helper';
+
+export function getCurrentRegistrations() {
+    return RegistrationHelper.COMPLETED;
+}
 
 interface CurrencyConfigData extends CurrencyConfig, RegistrationConfig {
     /**

--- a/src/system/api/general.ts
+++ b/src/system/api/general.ts
@@ -3,50 +3,91 @@ import {
     SkillConfig,
     PowerTypeConfig,
     ActionTypeConfig,
+    RegistrationConfig,
+    RegistrationLogType,
+    RegistrationLog,
 } from '@system/types/config';
+import { RegistrationHelper } from './helper';
 
-interface CurrencyConfigData extends CurrencyConfig {
+interface CurrencyConfigData extends CurrencyConfig, RegistrationConfig {
     /**
      * Unique id for the currency.
      */
     id: string;
 }
 
-export function registerCurrency(data: CurrencyConfigData, force = false) {
-    if (!CONFIG.COSMERE)
-        throw new Error('Cannot access api until after system is initialized.');
-
-    if (data.id in CONFIG.COSMERE.currencies && !force)
-        throw new Error('Cannot override existing currency config.');
-
-    if (force) {
-        console.warn('Registering currency with force=true.');
+export function registerCurrency(data: CurrencyConfigData) {
+    if (!CONFIG.COSMERE) {
+        throw new Error(
+            'Cannot access API until after the system is initialized.',
+        );
     }
 
+    const identifier = `currency.${data.id}`;
+
     // Ensure a base denomination is configured
-    if (!data.denominations.primary.some((d) => d.base))
-        throw new Error(`Currency ${data.id} must have a base denomination.`);
+    if (!data.denominations.primary.some((d) => d.base)) {
+        RegistrationHelper.registerLog({
+            source: data.source,
+            type: RegistrationLogType.Error,
+            message: `Failed to register config: ${identifier}. Currency must have a base denomination.`,
+        } as RegistrationLog);
+
+        return false;
+    }
+
     if (
         data.denominations.secondary &&
         !data.denominations.secondary.some((d) => d.base)
-    )
-        throw new Error(
-            `Secondary denominations for currency ${data.id} must have a base denomination.`,
-        );
+    ) {
+        RegistrationHelper.registerLog({
+            source: data.source,
+            type: RegistrationLogType.Error,
+            message: `Failed to register config: ${identifier}. Secondary denominations must have a base denomination.`,
+        } as RegistrationLog);
+
+        return false;
+    }
 
     // Get base denomination
     const baseDenomination = data.denominations.primary.find((d) => d.base)!;
 
     // Ensure base denomination has a unit
-    if (!baseDenomination.unit)
-        throw new Error(
-            `Base denomination ${baseDenomination.id} for currency ${data.id} must have a unit.`,
-        );
+    if (!baseDenomination.unit) {
+        RegistrationHelper.registerLog({
+            source: data.source,
+            type: RegistrationLogType.Error,
+            message: `Failed to register config: ${identifier}. Base denomination ${baseDenomination.id} must have a unit.`,
+        } as RegistrationLog);
 
-    // Add to currency config
-    CONFIG.COSMERE.currencies[data.id] = {
+        return false;
+    }
+
+    const toRegister = {
         label: data.label,
         icon: data.icon,
         denominations: data.denominations,
+    } as CurrencyConfig;
+
+    const register = () => {
+        RegistrationHelper.COMPLETED[identifier] = data;
+        CONFIG.COSMERE.currencies[data.id] = toRegister;
+        return true;
     };
+
+    if (data.id in CONFIG.COSMERE.currencies) {
+        // If the same object is already registered, we ignore the registration and mark it succesful.
+        if (
+            foundry.utils.objectsEqual(
+                toRegister,
+                CONFIG.COSMERE.currencies[data.id],
+            )
+        ) {
+            return true;
+        }
+
+        return RegistrationHelper.tryRegisterConfig(identifier, data, register);
+    }
+
+    return register();
 }

--- a/src/system/api/helper.ts
+++ b/src/system/api/helper.ts
@@ -57,6 +57,9 @@ export class RegistrationHelper {
 
     private static showLogs = foundry.utils.debounce(() => {
         console.log(this.logs);
+        ui.notifications.error(
+            'Error while registering configs. Check console for details.',
+        );
 
         //TODO SHOW LOG DIALOG
 

--- a/src/system/api/helper.ts
+++ b/src/system/api/helper.ts
@@ -56,7 +56,6 @@ export class RegistrationHelper {
     }
 
     private static showLogs = foundry.utils.debounce(() => {
-        console.log(this.COMPLETED);
         console.log(this.logs);
 
         //TODO SHOW LOG DIALOG

--- a/src/system/api/helper.ts
+++ b/src/system/api/helper.ts
@@ -1,39 +1,23 @@
 import { RegistrationConfig, RegistrationLog } from '../types/config';
 
 export class RegistrationHelper {
-    static REGISTER_DEBOUNCE_MS = 200;
+    static LOG_DEBOUNCE_MS = 200;
+    static COMPLETED: Record<string, RegistrationConfig> = {};
 
-    private static completed: Record<string, RegistrationConfig> = {};
     private static logs: RegistrationLog[] = [];
-    private static queue: ((
-        completed: Record<string, RegistrationConfig>,
-        logs: RegistrationLog[],
-    ) => boolean)[] = [];
 
-    static registerCallback(
-        callback: (
-            completed: Record<string, RegistrationConfig>,
-            logs: RegistrationLog[],
-        ) => boolean,
-    ) {
-        this.queue.push(callback);
-        this.runRegistrations();
+    static registerLog(log: RegistrationLog) {
+        this.logs.push(log);
+        this.showLogs();
     }
 
-    private static runRegistrations = foundry.utils.debounce(() => {
-        let success = true;
+    private static showLogs = foundry.utils.debounce(() => {
+        console.log(this.COMPLETED);
+        console.log(this.logs);
 
-        for (const registration of this.queue) {
-            success &&= registration(this.completed, this.logs);
-        }
+        //TODO SHOW LOG DIALOG
 
-        if (!success) {
-            //TODO DIALOG
-        }
-
-        console.log(this.completed);
-
-        // Clear this batch of queued registrations so we don't run them again.
-        this.queue = [];
-    }, this.REGISTER_DEBOUNCE_MS);
+        // Clear this batch of logs so we don't display them again.
+        this.logs = [];
+    }, this.LOG_DEBOUNCE_MS);
 }

--- a/src/system/api/helper.ts
+++ b/src/system/api/helper.ts
@@ -1,0 +1,39 @@
+import { RegistrationConfig, RegistrationLog } from '../types/config';
+
+export class RegistrationHelper {
+    static REGISTER_DEBOUNCE_MS = 200;
+
+    private static completed: Record<string, RegistrationConfig> = {};
+    private static logs: RegistrationLog[] = [];
+    private static queue: ((
+        completed: Record<string, RegistrationConfig>,
+        logs: RegistrationLog[],
+    ) => boolean)[] = [];
+
+    static registerCallback(
+        callback: (
+            completed: Record<string, RegistrationConfig>,
+            logs: RegistrationLog[],
+        ) => boolean,
+    ) {
+        this.queue.push(callback);
+        this.runRegistrations();
+    }
+
+    private static runRegistrations = foundry.utils.debounce(() => {
+        let success = true;
+
+        for (const registration of this.queue) {
+            success &&= registration(this.completed, this.logs);
+        }
+
+        if (!success) {
+            //TODO DIALOG
+        }
+
+        console.log(this.completed);
+
+        // Clear this batch of queued registrations so we don't run them again.
+        this.queue = [];
+    }, this.REGISTER_DEBOUNCE_MS);
+}

--- a/src/system/api/helper.ts
+++ b/src/system/api/helper.ts
@@ -58,7 +58,7 @@ export class RegistrationHelper {
     private static showLogs = foundry.utils.debounce(() => {
         console.log(this.logs);
         ui.notifications.error(
-            'Error while registering configs. Check console for details.',
+            game.i18n!.localize('GENERIC.Error.RegisteringConfigs'),
         );
 
         //TODO SHOW LOG DIALOG

--- a/src/system/api/helper.ts
+++ b/src/system/api/helper.ts
@@ -1,4 +1,8 @@
-import { RegistrationConfig, RegistrationLog } from '../types/config';
+import {
+    RegistrationConfig,
+    RegistrationLog,
+    RegistrationLogType,
+} from '../types/config';
 
 export class RegistrationHelper {
     static LOG_DEBOUNCE_MS = 200;
@@ -9,6 +13,46 @@ export class RegistrationHelper {
     static registerLog(log: RegistrationLog) {
         this.logs.push(log);
         this.showLogs();
+    }
+
+    static tryRegisterConfig(
+        identifier: string,
+        data: RegistrationConfig,
+        callback: () => boolean,
+    ) {
+        // If the object was registered by a previous API call, compare priorities.
+        // If not, but the object still already exists, check that the priority is higher than 0 (i.e. higher than the default system config).
+        if (
+            (identifier in RegistrationHelper.COMPLETED &&
+                (RegistrationHelper.COMPLETED[identifier].priority ?? 0) <
+                    (data.priority ?? 0)) ||
+            (!(identifier in RegistrationHelper.COMPLETED) &&
+                (data.priority ?? 0) > 0)
+        ) {
+            RegistrationHelper.registerLog({
+                source: data.source,
+                type: RegistrationLogType.Warn,
+                message: `Overriding config: ${identifier} due to a higher priority value: ${data.priority}.`,
+            } as RegistrationLog);
+
+            return callback();
+            // If both conditions fail, the new registration has a lower priority than either system default or any previous registration.
+            // This means we can log this new registration as a failure and not register it.
+        } else {
+            if (data.strict) {
+                throw new Error(
+                    `Failed to register config: ${identifier} due to conflicts.`,
+                );
+            }
+
+            RegistrationHelper.registerLog({
+                source: data.source,
+                type: RegistrationLogType.Error,
+                message: `Failed to register config: ${identifier} because there is already a higher priority registration.`,
+            } as RegistrationLog);
+
+            return false;
+        }
     }
 
     private static showLogs = foundry.utils.debounce(() => {

--- a/src/system/api/index.ts
+++ b/src/system/api/index.ts
@@ -3,6 +3,7 @@ export * from './actor';
 export * from './item';
 export * from './style';
 export * from './sheet';
+export * from './helper';
 
 import * as GeneralAPI from './general';
 import * as ActorAPI from './actor';

--- a/src/system/api/item.ts
+++ b/src/system/api/item.ts
@@ -19,272 +19,449 @@ import {
     ArmorConfig,
     CultureConfig,
     AncestryConfig,
+    RegistrationConfig,
+    RegistrationLogType,
+    RegistrationLog,
+    ItemEventHandlerTypeConfig,
 } from '@system/types/config';
 import { EventSystem as ItemEventSystem } from '@system/types/item';
 import { AnyObject } from '@system/types/utils';
 
 // Utils
 import * as EventSystemUtils from '@system/utils/item/event-system';
+import { RegistrationHelper } from './helper';
 
-interface PowerTypeConfigData extends PowerTypeConfig {
+interface PowerTypeConfigData extends PowerTypeConfig, RegistrationConfig {
     /**
      * Unique id for the power type.
      */
     id: string;
 }
 
-export function registerPowerType(data: PowerTypeConfigData, force = false) {
-    if (!CONFIG.COSMERE)
-        throw new Error('Cannot access api until after system is initialized.');
-
-    if (data.id in CONFIG.COSMERE.power.types && !force)
-        throw new Error('Cannot override existing power type config.');
-
-    if (force) {
-        console.warn('Registering power type with force=true.');
+export function registerPowerType(data: PowerTypeConfigData) {
+    if (!CONFIG.COSMERE) {
+        throw new Error(
+            'Cannot access API until after the system is initialized.',
+        );
     }
+
+    const identifier = `power.type.${data.id}`;
 
     if (data.id === 'none') {
-        throw new Error('Cannot register power type with id "none".');
+        RegistrationHelper.registerLog({
+            source: data.source,
+            type: RegistrationLogType.Error,
+            message: `Failed to register config: ${identifier}. Cannot register power type with id "none".`,
+        } as RegistrationLog);
+
+        return false;
     }
 
-    // Add to power types
-    CONFIG.COSMERE.power.types[data.id as PowerType] = {
+    const toRegister = {
         label: data.label,
         plural: data.plural,
+    } as PowerTypeConfig;
+
+    const register = () => {
+        RegistrationHelper.COMPLETED[identifier] = data;
+        CONFIG.COSMERE.power.types[data.id as PowerType] = toRegister;
+        return true;
     };
+
+    if (data.id in CONFIG.COSMERE.power.types) {
+        // If the same object is already registered, we ignore the registration and mark it succesful.
+        if (
+            foundry.utils.objectsEqual(
+                toRegister,
+                CONFIG.COSMERE.power.types[data.id as PowerType],
+            )
+        ) {
+            return true;
+        }
+
+        return RegistrationHelper.tryRegisterConfig(identifier, data, register);
+    }
+
+    return register();
 }
 
-interface PathTypeConfigData extends PathTypeConfig {
+interface PathTypeConfigData extends PathTypeConfig, RegistrationConfig {
     /**
      * Unique id for the path type.
      */
     id: string;
 }
 
-export function registerPathType(data: PathTypeConfigData, force = false) {
-    if (!CONFIG.COSMERE)
-        throw new Error('Cannot access api until after system is initialized.');
-
-    if (data.id in CONFIG.COSMERE.armors && !force)
-        throw new Error('Cannot override existing path type config.');
-
-    if (force) {
-        console.warn('Registering path type with force=true.');
+export function registerPathType(data: PathTypeConfigData) {
+    if (!CONFIG.COSMERE) {
+        throw new Error(
+            'Cannot access API until after the system is initialized.',
+        );
     }
 
-    // Add to path config
-    CONFIG.COSMERE.paths.types[data.id as PathType] = {
+    const identifier = `path.type.${data.id}`;
+
+    const toRegister = {
         label: data.label,
+    } as PathTypeConfig;
+
+    const register = () => {
+        RegistrationHelper.COMPLETED[identifier] = data;
+        CONFIG.COSMERE.paths.types[data.id as PathType] = toRegister;
+        return true;
     };
+
+    if (data.id in CONFIG.COSMERE.paths.types) {
+        // If the same object is already registered, we ignore the registration and mark it succesful.
+        if (
+            foundry.utils.objectsEqual(
+                toRegister,
+                CONFIG.COSMERE.paths.types[data.id as PathType],
+            )
+        ) {
+            return true;
+        }
+
+        return RegistrationHelper.tryRegisterConfig(identifier, data, register);
+    }
+
+    return register();
 }
 
-interface ActionTypeConfigData extends ActionTypeConfig {
+interface ActionTypeConfigData extends ActionTypeConfig, RegistrationConfig {
     /**
      * Unique id for the action type.
      */
     id: string;
 }
 
-export function registerActionType(data: ActionTypeConfigData, force = false) {
-    if (!CONFIG.COSMERE)
-        throw new Error('Cannot access api until after system is initialized.');
-
-    if (data.id in CONFIG.COSMERE.action.types && !force)
-        throw new Error('Cannot override existing action type config.');
-
-    if (force) {
-        console.warn('Registering action type with force=true.');
+export function registerActionType(data: ActionTypeConfigData) {
+    if (!CONFIG.COSMERE) {
+        throw new Error(
+            'Cannot access API until after the system is initialized.',
+        );
     }
 
-    // Add to action types
-    CONFIG.COSMERE.action.types[data.id as ActionType] = {
+    const identifier = `action.type.${data.id}`;
+
+    const toRegister = {
         label: data.label,
         labelPlural: data.labelPlural,
         hasMode: data.hasMode,
         subtitle: data.subtitle,
+    } as ActionTypeConfig;
+
+    const register = () => {
+        RegistrationHelper.COMPLETED[identifier] = data;
+        CONFIG.COSMERE.action.types[data.id as ActionType] = toRegister;
+        return true;
     };
+
+    if (data.id in CONFIG.COSMERE.action.types) {
+        // If the same object is already registered, we ignore the registration and mark it succesful.
+        if (
+            foundry.utils.objectsEqual(
+                toRegister,
+                CONFIG.COSMERE.action.types[data.id as ActionType],
+            )
+        ) {
+            return true;
+        }
+
+        return RegistrationHelper.tryRegisterConfig(identifier, data, register);
+    }
+
+    return register();
 }
 
-interface EquipmentTypeConfigData extends EquipmentTypeConfig {
+interface EquipmentTypeConfigData
+    extends EquipmentTypeConfig,
+        RegistrationConfig {
     /**
      * Unique id for the equipment type.
      */
     id: string;
 }
 
-export function registerEquipmentType(
-    data: EquipmentTypeConfigData,
-    force = false,
-) {
-    if (!CONFIG.COSMERE)
-        throw new Error('Cannot access api until after system is initialized.');
-
-    if (data.id in CONFIG.COSMERE.items.equipment.types && !force)
-        throw new Error('Cannot override existing equipment type config.');
-
-    if (force) {
-        console.warn('Registering equipment type with force=true.');
+export function registerEquipmentType(data: EquipmentTypeConfigData) {
+    if (!CONFIG.COSMERE) {
+        throw new Error(
+            'Cannot access API until after the system is initialized.',
+        );
     }
 
-    // Add to equipment types
-    CONFIG.COSMERE.items.equipment.types[data.id as EquipmentType] = {
+    const identifier = `equipment.type.${data.id}`;
+
+    const toRegister = {
         label: data.label,
+    } as EquipmentTypeConfig;
+
+    const register = () => {
+        RegistrationHelper.COMPLETED[identifier] = data;
+        CONFIG.COSMERE.items.equipment.types[data.id as EquipmentType] =
+            toRegister;
+        return true;
     };
+
+    if (data.id in CONFIG.COSMERE.items.equipment.types) {
+        // If the same object is already registered, we ignore the registration and mark it succesful.
+        if (
+            foundry.utils.objectsEqual(
+                toRegister,
+                CONFIG.COSMERE.items.equipment.types[data.id as EquipmentType],
+            )
+        ) {
+            return true;
+        }
+
+        return RegistrationHelper.tryRegisterConfig(identifier, data, register);
+    }
+
+    return register();
 }
 
-interface WeaponTypeConfigData extends WeaponTypeConfig {
+interface WeaponTypeConfigData extends WeaponTypeConfig, RegistrationConfig {
     /**
      * Unique id for the weapon type.
      */
     id: string;
 }
 
-export function registerWeaponType(data: WeaponTypeConfigData, force = false) {
-    if (!CONFIG.COSMERE)
-        throw new Error('Cannot access api until after system is initialized.');
-
-    if (data.id in CONFIG.COSMERE.items.weapon.types && !force)
-        throw new Error('Cannot override existing weapon type config.');
-
-    if (force) {
-        console.warn('Registering weapon type with force=true.');
+export function registerWeaponType(data: WeaponTypeConfigData) {
+    if (!CONFIG.COSMERE) {
+        throw new Error(
+            'Cannot access API until after the system is initialized.',
+        );
     }
 
-    // Add to weapon types
-    CONFIG.COSMERE.items.weapon.types[data.id as WeaponType] = {
+    const identifier = `weapon.type.${data.id}`;
+
+    const toRegister = {
         label: data.label,
+    } as WeaponTypeConfigData;
+
+    const register = () => {
+        RegistrationHelper.COMPLETED[identifier] = data;
+        CONFIG.COSMERE.items.weapon.types[data.id as WeaponType] = toRegister;
+        return true;
     };
+
+    if (data.id in CONFIG.COSMERE.items.weapon.types) {
+        // If the same object is already registered, we ignore the registration and mark it succesful.
+        if (
+            foundry.utils.objectsEqual(
+                toRegister,
+                CONFIG.COSMERE.items.weapon.types[data.id as WeaponType],
+            )
+        ) {
+            return true;
+        }
+
+        return RegistrationHelper.tryRegisterConfig(identifier, data, register);
+    }
+
+    return register();
 }
 
 /* --- Registry --- */
 
-interface WeaponConfigData extends WeaponConfig {
+interface WeaponConfigData extends WeaponConfig, RegistrationConfig {
     /**
      * Unique id for the weapon.
      */
     id: string;
 }
 
-export function registerWeapon(data: WeaponConfigData, force = false) {
-    if (!CONFIG.COSMERE)
-        throw new Error('Cannot access api until after system is initialized.');
-
-    if (data.id in CONFIG.COSMERE.weapons && !force)
-        throw new Error('Cannot override existing weapon config.');
-
-    if (force) {
-        console.warn('Registering weapon with force=true.');
+export function registerWeapon(data: WeaponConfigData) {
+    if (!CONFIG.COSMERE) {
+        throw new Error(
+            'Cannot access API until after the system is initialized.',
+        );
     }
 
-    // Add to weapons config
-    CONFIG.COSMERE.weapons[data.id as WeaponId] = {
+    const identifier = `weapon.${data.id}`;
+
+    const toRegister = {
         label: data.label,
         reference: data.reference,
         specialExpertise: data.specialExpertise,
+    } as WeaponConfig;
+
+    const register = () => {
+        RegistrationHelper.COMPLETED[identifier] = data;
+        CONFIG.COSMERE.weapons[data.id as WeaponId] = toRegister;
+        return true;
     };
+
+    if (data.id in CONFIG.COSMERE.weapons) {
+        // If the same object is already registered, we ignore the registration and mark it succesful.
+        if (
+            foundry.utils.objectsEqual(
+                toRegister,
+                CONFIG.COSMERE.weapons[data.id as WeaponId],
+            )
+        ) {
+            return true;
+        }
+
+        return RegistrationHelper.tryRegisterConfig(identifier, data, register);
+    }
+
+    return register();
 }
 
-interface ArmorConfigData extends ArmorConfig {
+interface ArmorConfigData extends ArmorConfig, RegistrationConfig {
     /**
      * Unique id for the armor.
      */
     id: string;
 }
 
-export function registerArmor(data: ArmorConfigData, force = false) {
-    if (!CONFIG.COSMERE)
-        throw new Error('Cannot access api until after system is initialized.');
-
-    if (data.id in CONFIG.COSMERE.armors && !force)
-        throw new Error('Cannot override existing armor config.');
-
-    if (force) {
-        console.warn('Registering armor with force=true.');
+export function registerArmor(data: ArmorConfigData) {
+    if (!CONFIG.COSMERE) {
+        throw new Error(
+            'Cannot access API until after the system is initialized.',
+        );
     }
 
-    // Add to armors config
-    CONFIG.COSMERE.armors[data.id as unknown as ArmorId] = {
+    const identifier = `armor.${data.id}`;
+
+    const toRegister = {
         label: data.label,
         reference: data.reference,
+    } as ArmorConfig;
+
+    const register = () => {
+        RegistrationHelper.COMPLETED[identifier] = data;
+        CONFIG.COSMERE.armors[data.id as unknown as ArmorId] = toRegister;
+        return true;
     };
+
+    if (data.id in CONFIG.COSMERE.armors) {
+        // If the same object is already registered, we ignore the registration and mark it succesful.
+        if (
+            foundry.utils.objectsEqual(
+                toRegister,
+                CONFIG.COSMERE.armors[data.id as unknown as ArmorId],
+            )
+        ) {
+            return true;
+        }
+
+        return RegistrationHelper.tryRegisterConfig(identifier, data, register);
+    }
+
+    return register();
 }
 
-interface CultureConfigData extends CultureConfig {
+interface CultureConfigData extends CultureConfig, RegistrationConfig {
     /**
      * Unique id for the culture.
      */
     id: string;
 }
 
-export function registerCulture(data: CultureConfigData, force = false) {
-    if (!CONFIG.COSMERE)
-        throw new Error('Cannot access api until after system is initialized.');
-
-    if (data.id in CONFIG.COSMERE.armors && !force)
-        throw new Error('Cannot override existing culture config.');
-
-    if (force) {
-        console.warn('Registering culture with force=true.');
+export function registerCulture(data: CultureConfigData) {
+    if (!CONFIG.COSMERE) {
+        throw new Error(
+            'Cannot access API until after the system is initialized.',
+        );
     }
 
-    // Add to cultures config
-    CONFIG.COSMERE.cultures[data.id] = {
+    const identifier = `culture.${data.id}`;
+
+    const toRegister = {
         label: data.label,
         reference: data.reference,
+    } as CultureConfig;
+
+    const register = () => {
+        RegistrationHelper.COMPLETED[identifier] = data;
+        CONFIG.COSMERE.cultures[data.id] = toRegister;
+        return true;
     };
+
+    if (data.id in CONFIG.COSMERE.cultures) {
+        // If the same object is already registered, we ignore the registration and mark it succesful.
+        if (
+            foundry.utils.objectsEqual(
+                toRegister,
+                CONFIG.COSMERE.cultures[data.id],
+            )
+        ) {
+            return true;
+        }
+
+        return RegistrationHelper.tryRegisterConfig(identifier, data, register);
+    }
+
+    return register();
 }
 
-interface AncestryConfigData extends AncestryConfig {
+interface AncestryConfigData extends AncestryConfig, RegistrationConfig {
     /**
      * Unique id for the ancestry.
      */
     id: string;
 }
 
-export function registerAncestry(data: AncestryConfigData, force = false) {
-    if (!CONFIG.COSMERE)
-        throw new Error('Cannot access api until after system is initialized.');
-
-    if (data.id in CONFIG.COSMERE.armors && !force)
-        throw new Error('Cannot override existing ancestry config.');
-
-    if (force) {
-        console.warn('Registering ancestry with force=true.');
+export function registerAncestry(data: AncestryConfigData) {
+    if (!CONFIG.COSMERE) {
+        throw new Error(
+            'Cannot access API until after the system is initialized.',
+        );
     }
 
-    // Add to ancestry config
-    CONFIG.COSMERE.ancestries[data.id] = {
+    const identifier = `ancestry.${data.id}`;
+
+    const toRegister = {
         label: data.label,
         reference: data.reference,
+    } as CultureConfig;
+
+    const register = () => {
+        RegistrationHelper.COMPLETED[identifier] = data;
+        CONFIG.COSMERE.ancestries[data.id] = toRegister;
+        return true;
     };
+
+    if (data.id in CONFIG.COSMERE.ancestries) {
+        // If the same object is already registered, we ignore the registration and mark it succesful.
+        if (
+            foundry.utils.objectsEqual(
+                toRegister,
+                CONFIG.COSMERE.ancestries[data.id],
+            )
+        ) {
+            return true;
+        }
+
+        return RegistrationHelper.tryRegisterConfig(identifier, data, register);
+    }
+
+    return register();
 }
 
 interface ItemEventTypeConfigData
     extends Omit<ItemEventTypeConfig, 'host'>,
-        Partial<Pick<ItemEventTypeConfig, 'host'>> {
+        Partial<Pick<ItemEventTypeConfig, 'host'>>,
+        RegistrationConfig {
     /**
      * Unique id for the item event type.
      */
     type: string;
 }
 
-export function registerItemEventType(
-    data: ItemEventTypeConfigData,
-    force = false,
-) {
-    if (!CONFIG.COSMERE)
-        throw new Error('Cannot access api until after system is initialized.');
-
-    if (data.type in CONFIG.COSMERE.items.events.types && !force)
-        throw new Error('Cannot override existing item event type config.');
-
-    if (force) {
-        console.warn('Registering item event type with force=true.');
+export function registerItemEventType(data: ItemEventTypeConfigData) {
+    if (!CONFIG.COSMERE) {
+        throw new Error(
+            'Cannot access API until after the system is initialized.',
+        );
     }
 
-    // Add to item event types
-    CONFIG.COSMERE.items.events.types[data.type] = {
+    const identifier = `item.event.type.${data.type}`;
+
+    const toRegister = {
         label: data.label,
         description: data.description,
         hook: data.hook,
@@ -292,10 +469,32 @@ export function registerItemEventType(
         filter: data.filter,
         condition: data.condition,
         transform: data.transform,
+    } as ItemEventTypeConfig;
+
+    const register = () => {
+        RegistrationHelper.COMPLETED[identifier] = data;
+        CONFIG.COSMERE.items.events.types[data.type] = toRegister;
+        return true;
     };
+
+    if (data.type in CONFIG.COSMERE.items.events.types) {
+        // If the same object is already registered, we ignore the registration and mark it succesful.
+        if (
+            foundry.utils.objectsEqual(
+                toRegister,
+                CONFIG.COSMERE.items.events.types[data.type],
+            )
+        ) {
+            return true;
+        }
+
+        return RegistrationHelper.tryRegisterConfig(identifier, data, register);
+    }
+
+    return register();
 }
 
-interface ItemEventHandlerConfigData {
+interface ItemEventHandlerConfigData extends RegistrationConfig {
     type: string;
     label: string;
     description?: string | (() => string);
@@ -312,21 +511,26 @@ interface ItemEventHandlerConfigData {
     );
 }
 
-export function registerItemEventHandlerType(
-    data: ItemEventHandlerConfigData,
-    force = false,
-) {
-    if (!CONFIG.COSMERE)
-        throw new Error('Cannot access api until after system is initialized.');
+export function registerItemEventHandlerType(data: ItemEventHandlerConfigData) {
+    if (!CONFIG.COSMERE) {
+        throw new Error(
+            'Cannot access API until after the system is initialized.',
+        );
+    }
 
-    if (data.type === 'none')
-        throw new Error('Cannot register item event handler with type "none".');
+    const identifier = `item.event.handler.${data.type}`;
 
-    if (data.type in CONFIG.COSMERE.items.events.handlers && !force)
-        throw new Error('Cannot override existing item event handler type.');
+    if (data.type === 'none') {
+        RegistrationHelper.registerLog({
+            source: data.source,
+            type: RegistrationLogType.Error,
+            message: `Failed to register config: ${identifier}. Cannot register item event handler with type "none".`,
+        } as RegistrationLog);
 
-    // Add to event handlers config
-    CONFIG.COSMERE.items.events.handlers[data.type] = {
+        return false;
+    }
+
+    const toRegister = {
         label: data.label,
         description: data.description,
         documentClass: EventSystemUtils.constructHandlerClass(
@@ -334,5 +538,27 @@ export function registerItemEventHandlerType(
             data.executor,
             data.config,
         ),
+    } as ItemEventHandlerTypeConfig;
+
+    const register = () => {
+        RegistrationHelper.COMPLETED[identifier] = data;
+        CONFIG.COSMERE.items.events.handlers[data.type] = toRegister;
+        return true;
     };
+
+    if (data.type in CONFIG.COSMERE.items.events.handlers) {
+        // If the same object is already registered, we ignore the registration and mark it succesful.
+        if (
+            foundry.utils.objectsEqual(
+                toRegister,
+                CONFIG.COSMERE.items.events.handlers[data.type],
+            )
+        ) {
+            return true;
+        }
+
+        return RegistrationHelper.tryRegisterConfig(identifier, data, register);
+    }
+
+    return register();
 }

--- a/src/system/api/style.ts
+++ b/src/system/api/style.ts
@@ -1,21 +1,37 @@
 import { Theme } from '@system/types/cosmere';
+import { RegistrationConfig } from '../types/config';
+import { RegistrationHelper } from './helper';
 
-interface ThemeConfigData {
+interface ThemeConfigData extends RegistrationConfig {
     id: string;
     label: string;
 }
 
-export function registerTheme(data: ThemeConfigData, force = false) {
-    if (!CONFIG.COSMERE)
-        throw new Error('Cannot access api until after system is initialized.');
-
-    if (data.id in CONFIG.COSMERE.themes && !force)
-        throw new Error('Cannot override existing theme config.');
-
-    if (force) {
-        console.warn('Registering theme with force=true.');
+export function registerTheme(data: ThemeConfigData) {
+    if (!CONFIG.COSMERE) {
+        throw new Error(
+            'Cannot access API until after the system is initialized.',
+        );
     }
 
-    // Add to themes config
-    CONFIG.COSMERE.themes[data.id as Theme] = data.label;
+    const identifier = `theme.${data.id}`;
+
+    const toRegister = data.label;
+
+    const register = () => {
+        RegistrationHelper.COMPLETED[identifier] = data;
+        CONFIG.COSMERE.themes[data.id as Theme] = toRegister;
+        return true;
+    };
+
+    if (data.id in CONFIG.COSMERE.themes) {
+        // If the same object is already registered, we ignore the registration and mark it succesful.
+        if (CONFIG.COSMERE.themes[data.id as Theme] === toRegister) {
+            return true;
+        }
+
+        return RegistrationHelper.tryRegisterConfig(identifier, data, register);
+    }
+
+    return register();
 }

--- a/src/system/applications/actor/components/actions-list.ts
+++ b/src/system/applications/actor/components/actions-list.ts
@@ -633,12 +633,16 @@ ActorActionsListComponent.register('app-actor-actions-list');
 export function configure() {
     // Register static sections
     Object.values(STATIC_SECTIONS).forEach((section) => {
-        cosmereRPG.api.registerActionListSection(section);
+        cosmereRPG.api.registerActionListSection({
+            ...section,
+            source: SYSTEM_ID,
+        });
     });
 
     // Register dynamic sections
     Object.values(DYNAMIC_SECTIONS).forEach((gen) => {
         cosmereRPG.api.registerActionListDynamicSectionGenerator({
+            source: SYSTEM_ID,
             id: gen.name,
             generator: gen,
         });

--- a/src/system/constants/hooks.ts
+++ b/src/system/constants/hooks.ts
@@ -1,21 +1,24 @@
 import { SYSTEM_ID } from '@system/constants';
 
 export const HOOKS = {
-    /* ----- Actor hooks ----- */
+    /* ----- Config API Hooks ----- */
+    REGISTER_CONFIG: `${SYSTEM_ID}.registerConfig`,
+
+    /* ----- Actor Hooks ----- */
     /* -- Damage application hooks -- */
     PRE_APPLY_DAMAGE: `${SYSTEM_ID}.preApplyDamage`,
     APPLY_DAMAGE: `${SYSTEM_ID}.applyDamage`,
 
-    /* -- Injury application hooks -- */
+    /* -- Injury Application Hooks -- */
     PRE_APPLY_INJURY: `${SYSTEM_ID}.preApplyInjury`,
     APPLY_INJURY: `${SYSTEM_ID}.applyInjury`,
 
-    /* -- Rest hooks -- */
+    /* -- Rest Hooks -- */
     PRE_REST: `${SYSTEM_ID}.preRest`,
     REST: `${SYSTEM_ID}.rest`,
 
-    /* ----- Item hooks ----- */
-    /* -- Item activation/usage hooks -- */
+    /* ----- Item Hooks ----- */
+    /* -- Item Activation/Usage Hooks -- */
     USE_ITEM: `${SYSTEM_ID}.useItem`,
     PRE_USE_ITEM: `${SYSTEM_ID}.preUseItem`,
     MODE_ACTIVATE_ITEM: `${SYSTEM_ID}.modeActivateItem`,
@@ -51,11 +54,11 @@ export const HOOKS = {
      */
     PRE_COMPLETE_GOAL: `${SYSTEM_ID}.preCompleteGoal`,
 
-    /* ----- Chat message hooks ----- */
-    /* -- Message interaction hooks -- */
+    /* ----- Chat Message Hooks ----- */
+    /* -- Message Interaction Hooks -- */
     MESSAGE_INTERACTED: `${SYSTEM_ID}.chatMessageInteract`,
 
-    /* ----- Roll hooks ----- */
+    /* ----- Roll Hooks ----- */
     PRE_ROLL: (context: string) =>
         `${SYSTEM_ID}.pre${context.toLowerCase().capitalize()}Roll`,
     ROLL: (context: string) => `${SYSTEM_ID}.${context.toLowerCase()}Roll`,
@@ -85,13 +88,13 @@ export const HOOKS = {
     PRE_ATTACK_ROLL_CONFIGURATION: `${SYSTEM_ID}.preAttackRollConfiguration`,
     ATTACK_ROLL_CONFIGURATION: `${SYSTEM_ID}.attackRollConfiguration`,
 
-    /* ---- Migration hooks ----- */
+    /* ---- Migration Hooks ----- */
     PRE_MIGRATION: `${SYSTEM_ID}.preMigration`,
     MIGRATION: `${SYSTEM_ID}.migration`,
     PRE_MIGRATE_VERSION: `${SYSTEM_ID}.preMigrateVersion`,
     MIGRATE_VERSION: `${SYSTEM_ID}.migrateVersion`,
 
-    /* ----- Enricher hooks ----- */
+    /* ----- Enricher Hooks ----- */
     TRIGGER_ENRICHER: (type: 'Test' | 'Damage') =>
         `${SYSTEM_ID}.trigger${type.toLowerCase().capitalize()}Enricher`,
     TRIGGER_TEST_ENRICHER: `${SYSTEM_ID}.triggerTestEnricher`,

--- a/src/system/constants/hooks.ts
+++ b/src/system/constants/hooks.ts
@@ -1,9 +1,6 @@
 import { SYSTEM_ID } from '@system/constants';
 
 export const HOOKS = {
-    /* ----- Config API Hooks ----- */
-    REGISTER_CONFIG: `${SYSTEM_ID}.registerConfig`,
-
     /* ----- Actor Hooks ----- */
     /* -- Damage application hooks -- */
     PRE_APPLY_DAMAGE: `${SYSTEM_ID}.preApplyDamage`,

--- a/src/system/hooks/item-event-system/events.ts
+++ b/src/system/hooks/item-event-system/events.ts
@@ -8,6 +8,7 @@ import { DeepPartial } from '@system/types/utils';
 
 // Constants
 import { HOOKS } from '@system/constants/hooks';
+import { SYSTEM_ID } from '@src/system/constants';
 
 type EventDefinition = Omit<ItemEventTypeConfig, 'label' | 'host'> &
     Partial<Pick<ItemEventTypeConfig, 'host'>> & {
@@ -110,6 +111,7 @@ const EVENTS: EventDefinition[] = [
 export function registerEventTypes() {
     EVENTS.forEach(({ type, hook, host, filter, condition, transform }) => {
         cosmereRPG.api.registerItemEventType({
+            source: SYSTEM_ID,
             type,
             hook,
             host,

--- a/src/system/hooks/item-event-system/handlers/execute-macro.ts
+++ b/src/system/hooks/item-event-system/handlers/execute-macro.ts
@@ -28,6 +28,7 @@ export function register() {
         CONFIG.Macro.typeLabels;
 
     cosmereRPG.api.registerItemEventHandlerType({
+        source: SYSTEM_ID,
         type: HandlerType.ExecuteMacro,
         label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.ExecuteMacro}.Title`,
         description: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.ExecuteMacro}.Description`,

--- a/src/system/hooks/item-event-system/handlers/grant-expertises.ts
+++ b/src/system/hooks/item-event-system/handlers/grant-expertises.ts
@@ -17,6 +17,7 @@ interface GrantExpertiseHandlerConfigData {
 
 export function register() {
     cosmereRPG.api.registerItemEventHandlerType({
+        source: SYSTEM_ID,
         type: HandlerType.GrantExpertises,
         label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.GrantExpertises}.Title`,
         description: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.GrantExpertises}.Description`,

--- a/src/system/hooks/item-event-system/handlers/grant-items.ts
+++ b/src/system/hooks/item-event-system/handlers/grant-items.ts
@@ -33,6 +33,7 @@ interface GrantItemsHandlerConfigData {
 
 export function register() {
     cosmereRPG.api.registerItemEventHandlerType({
+        source: SYSTEM_ID,
         type: HandlerType.GrantItems,
         label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.GrantItems}.Title`,
         description: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.GrantItems}.Description`,

--- a/src/system/hooks/item-event-system/handlers/modify-attribute.ts
+++ b/src/system/hooks/item-event-system/handlers/modify-attribute.ts
@@ -25,6 +25,7 @@ interface ModifyAttributeHandlerConfigData {
 
 export function register() {
     cosmereRPG.api.registerItemEventHandlerType({
+        source: SYSTEM_ID,
         type: HandlerType.ModifyAttribute,
         label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.ModifyAttribute}.Title`,
         description: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.ModifyAttribute}.Description`,

--- a/src/system/hooks/item-event-system/handlers/modify-skill-rank.ts
+++ b/src/system/hooks/item-event-system/handlers/modify-skill-rank.ts
@@ -19,6 +19,7 @@ interface ModifySkillRankHandlerConfigData {
 
 export function register() {
     cosmereRPG.api.registerItemEventHandlerType({
+        source: SYSTEM_ID,
         type: HandlerType.ModifySkillRank,
         label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.ModifySkillRank}.Title`,
         description: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.ModifySkillRank}.Description`,

--- a/src/system/hooks/item-event-system/handlers/remove-expertises.ts
+++ b/src/system/hooks/item-event-system/handlers/remove-expertises.ts
@@ -17,6 +17,7 @@ interface RemoveExpertiseHandlerConfigData {
 
 export function register() {
     cosmereRPG.api.registerItemEventHandlerType({
+        source: SYSTEM_ID,
         type: HandlerType.RemoveExpertises,
         label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.RemoveExpertises}.Title`,
         description: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.RemoveExpertises}.Description`,

--- a/src/system/hooks/item-event-system/handlers/remove-items.ts
+++ b/src/system/hooks/item-event-system/handlers/remove-items.ts
@@ -28,6 +28,7 @@ interface RemoveItemsHandlerConfigData {
 
 export function register() {
     cosmereRPG.api.registerItemEventHandlerType({
+        source: SYSTEM_ID,
         type: HandlerType.RemoveItems,
         label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.RemoveItems}.Title`,
         description: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.RemoveItems}.Description`,

--- a/src/system/hooks/item-event-system/handlers/set-attribute.ts
+++ b/src/system/hooks/item-event-system/handlers/set-attribute.ts
@@ -25,6 +25,7 @@ interface SetAttributeHandlerConfigData {
 
 export function register() {
     cosmereRPG.api.registerItemEventHandlerType({
+        source: SYSTEM_ID,
         type: HandlerType.SetAttribute,
         label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.SetAttribute}.Title`,
         description: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.SetAttribute}.Description`,

--- a/src/system/hooks/item-event-system/handlers/set-skill-rank.ts
+++ b/src/system/hooks/item-event-system/handlers/set-skill-rank.ts
@@ -19,6 +19,7 @@ interface SetSkillRankHandlerConfigData {
 
 export function register() {
     cosmereRPG.api.registerItemEventHandlerType({
+        source: SYSTEM_ID,
         type: HandlerType.SetSkillRank,
         label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.SetSkillRank}.Title`,
         description: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.SetSkillRank}.Description`,

--- a/src/system/hooks/item-event-system/handlers/update-actor.ts
+++ b/src/system/hooks/item-event-system/handlers/update-actor.ts
@@ -23,6 +23,7 @@ interface UpdateActorHandlerConfigData {
 
 export function register() {
     cosmereRPG.api.registerItemEventHandlerType({
+        source: SYSTEM_ID,
         type: HandlerType.UpdateActor,
         label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UpdateActor}.Title`,
         description: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UpdateActor}.Description`,

--- a/src/system/hooks/item-event-system/handlers/update-item.ts
+++ b/src/system/hooks/item-event-system/handlers/update-item.ts
@@ -21,6 +21,7 @@ interface UpdateItemHandlerConfigData {
 
 export function register() {
     cosmereRPG.api.registerItemEventHandlerType({
+        source: SYSTEM_ID,
         type: HandlerType.UpdateItem,
         label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UpdateItem}.Title`,
         description: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UpdateItem}.Description`,

--- a/src/system/hooks/item-event-system/handlers/use-item.ts
+++ b/src/system/hooks/item-event-system/handlers/use-item.ts
@@ -23,6 +23,7 @@ interface UseItemHandlerConfigData {
 
 export function register() {
     cosmereRPG.api.registerItemEventHandlerType({
+        source: SYSTEM_ID,
         type: HandlerType.UseItem,
         label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.Title`,
         description: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.Description`,

--- a/src/system/types/config.ts
+++ b/src/system/types/config.ts
@@ -54,8 +54,8 @@ import { CosmereItem } from '@system/documents/item';
 
 export interface RegistrationConfig {
     source: string;
-    force?: boolean;
     priority?: number;
+    strict?: boolean;
 }
 
 export interface RegistrationLog {

--- a/src/system/types/config.ts
+++ b/src/system/types/config.ts
@@ -52,6 +52,24 @@ import {
 
 import { CosmereItem } from '@system/documents/item';
 
+export interface RegistrationConfig {
+    source: string;
+    force?: boolean;
+    priority?: number;
+}
+
+export interface RegistrationLog {
+    source: string;
+    type: RegistrationLogType;
+    message: string;
+}
+
+export enum RegistrationLogType {
+    Warn = 'warn',
+    Error = 'error',
+    Debug = 'debug',
+}
+
 export interface SizeConfig {
     label: string;
     size?: number;

--- a/src/system/types/hooks/api.ts
+++ b/src/system/types/hooks/api.ts
@@ -1,6 +1,0 @@
-import { RegistrationConfig, RegistrationLog } from '../config';
-
-export type RegisterConfig = (
-    completed: Record<string, RegistrationConfig>,
-    logs: RegistrationLog[],
-) => boolean;

--- a/src/system/types/hooks/api.ts
+++ b/src/system/types/hooks/api.ts
@@ -1,0 +1,6 @@
+import { RegistrationConfig, RegistrationLog } from '../config';
+
+export type RegisterConfig = (
+    completed: Record<string, RegistrationConfig>,
+    logs: RegistrationLog[],
+) => boolean;

--- a/src/system/types/hooks/module.ts
+++ b/src/system/types/hooks/module.ts
@@ -5,4 +5,3 @@ export * from './migration';
 export * from './item';
 export * from './rolls';
 export * from './enricher';
-export * from './api';

--- a/src/system/types/hooks/module.ts
+++ b/src/system/types/hooks/module.ts
@@ -5,3 +5,4 @@ export * from './migration';
 export * from './item';
 export * from './rolls';
 export * from './enricher';
+export * from './api';


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [ ] Feature
- [X] Refactor
- [ ] Other (please describe):

**Description**  
This PR overhauls the config registration API so that it no longer breaks the whole stack when an error is encountered. Instead, it creates a stack of error logs that will eventually be displayed into a pop-up dialog that notifies the user. Individual failures now are gracefully handled and the registration process continues (unless a strict flag is passed).

Improvements are also made to what is considered a failure and what isn't. If a config registration is identical to one already existing, it is simply marked as successful and ignored (for use by the multiple premium modules registering the same things, for example). Also, this PR introduces a system of priority values for registrations so that modules can decide to override an already existing config if they have a higher priority than the existing registration.

**Related Issue**  
_This PR must be linked to an existing issue. Please specify the related issue number and whether this PR fully or partially resolves it. Use the format `Closes #<issue-number>` or `Partially addresses #<issue-number>`._

**How Has This Been Tested?**  
I have tested these changes using the Stormlight Handbook registrations, which have all been converted to this new method in this PR here: https://github.com/the-metalworks/stormlight-handbook/pull/93

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/9bcd0f2f-509a-4cc9-af36-a8cb40919760)
![image](https://github.com/user-attachments/assets/5d24f113-1c9f-43e3-a77a-a98586cf255f)

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: [insert version here].