### PR TITLE
feat(sheets): add linked skills support for ancestries, cultures, weapons, and armor

### DIFF
--- a/src/declarations/foundry/common/abstract/fields.d.ts
+++ b/src/declarations/foundry/common/abstract/fields.d.ts
@@ -330,7 +330,7 @@ declare namespace foundry {
                     context?: DataFieldContext,
                 );
 
-                choices: string[] | object;
+                choices: string[] | object | (() => string[] | object);
             }
 
             class ObjectField extends DataField {}
@@ -348,6 +348,8 @@ declare namespace foundry {
             }
 
             class ArrayField extends DataField {
+                public readonly element: DataField;
+
                 constructor(
                     element: DataField,
                     options?: ArrayFieldOptions,

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -508,12 +508,6 @@
                     "PowerExists": "A power with identifier \"{identifier}\" already exists on {actor}."
                 }
             },
-            "Path": {
-                "LinkedSkills": {
-                    "Label": "Linked Skills",
-                    "Hint": "These skills are displayed alongside the path in the character sheet."
-                }
-            },
             "Talent": {
                 "Type": {
                     "Ancestry": "Ancestry",
@@ -1171,6 +1165,12 @@
                         "Label": "Talent Tree",
                         "Hint": "Talent tree that contains all talents for this path. This tree is displayed on the \"talents\" tab."
                     }
+                }
+            },
+            "General": {
+                "LinkedSkills": {
+                    "Label": "Linked Skills",
+                    "Hint": "These skills are displayed alongside the {type} in the character sheet."
                 }
             }
         },

--- a/src/style/sheets/actor/character.scss
+++ b/src/style/sheets/actor/character.scss
@@ -158,7 +158,8 @@
 
     app-character-ancestry,
     app-character-culture,
-    app-character-paths-list .path {
+    app-character-paths-list .path,
+    app-character-skill-linked-item {
         position: relative;        
 
         .border-box {

--- a/src/system/applications/actor/components/character/ancestry.ts
+++ b/src/system/applications/actor/components/character/ancestry.ts
@@ -1,11 +1,16 @@
 import { ItemType } from '@system/types/cosmere';
 import { ConstructorOf } from '@system/types/utils';
-import { SYSTEM_ID } from '@src/system/constants';
-import { TEMPLATES } from '@src/system/utils/templates';
+
+// Documents
+import { AncestryItem } from '@system/documents/item';
 
 // Component imports
 import { HandlebarsApplicationComponent } from '@system/applications/component-system';
 import { BaseActorSheet, BaseActorSheetRenderContext } from '../../base';
+
+// Constants
+import { SYSTEM_ID } from '@src/system/constants';
+import { TEMPLATES } from '@src/system/utils/templates';
 
 export class CharacterAncestryComponent extends HandlebarsApplicationComponent<
     ConstructorOf<BaseActorSheet>
@@ -26,16 +31,17 @@ export class CharacterAncestryComponent extends HandlebarsApplicationComponent<
     /* --- Actions --- */
 
     private static onRemove(this: CharacterAncestryComponent) {
-        void this.application.actor.items
-            .find((item) => item.type === ItemType.Ancestry)
-            ?.delete();
+        void this.ancestry?.delete();
     }
 
     private static onView(this: CharacterAncestryComponent) {
-        const ancestryItem = this.application.actor.items.find(
-            (item) => item.type === ItemType.Ancestry,
-        );
-        void ancestryItem?.sheet?.render(true);
+        void this.ancestry?.sheet?.render(true);
+    }
+
+    /* --- Accessors --- */
+
+    public get ancestry(): AncestryItem | undefined {
+        return this.application.actor.ancestry;
     }
 
     /* --- Context --- */
@@ -44,19 +50,42 @@ export class CharacterAncestryComponent extends HandlebarsApplicationComponent<
         params: object,
         context: BaseActorSheetRenderContext,
     ) {
-        // Find the ancestry
-        const ancestryItem = this.application.actor.items.find(
-            (item) => item.type === ItemType.Ancestry,
-        );
+        const hasAncestry = !!this.ancestry;
 
         return Promise.resolve({
             ...context,
 
-            ...(ancestryItem
+            hasAncestry,
+
+            ...(hasAncestry
                 ? {
                       ancestry: {
-                          label: ancestryItem.name,
-                          img: ancestryItem.img,
+                          label: this.ancestry.name,
+                          img: this.ancestry.img,
+                          skills: this.ancestry.system.linkedSkills
+                              .filter(
+                                  (skillId) =>
+                                      this.application.actor.system.skills[
+                                          skillId
+                                      ].unlocked === true,
+                              )
+                              .map((skillId) => ({
+                                  id: skillId,
+                                  label: CONFIG.COSMERE.skills[skillId].label,
+                                  attribute:
+                                      CONFIG.COSMERE.skills[skillId].attribute,
+                                  attributeLabel:
+                                      CONFIG.COSMERE.attributes[
+                                          CONFIG.COSMERE.skills[skillId]
+                                              .attribute
+                                      ].label,
+                                  rank: this.application.actor.system.skills[
+                                      skillId
+                                  ].rank,
+                                  mod: this.application.actor.system.skills[
+                                      skillId
+                                  ].mod,
+                              })),
                       },
                   }
                 : {}),

--- a/src/system/applications/actor/components/character/index.ts
+++ b/src/system/applications/actor/components/character/index.ts
@@ -4,3 +4,4 @@ import './ancestry';
 import './goals-list';
 import './connections-list';
 import './culture';
+import './skill-linked-item';

--- a/src/system/applications/actor/components/character/skill-linked-item.ts
+++ b/src/system/applications/actor/components/character/skill-linked-item.ts
@@ -1,24 +1,26 @@
-import { CultureItem } from '@system/documents/item';
+import { CosmereItem } from '@system/documents/item';
 import { ConstructorOf } from '@system/types/utils';
-import { SYSTEM_ID } from '@src/system/constants';
-import { TEMPLATES } from '@src/system/utils/templates';
 
 // Component imports
 import { HandlebarsApplicationComponent } from '@system/applications/component-system';
 import { BaseActorSheetRenderContext } from '../../base';
 import { CharacterSheet } from '../../character-sheet';
 
+// Constants
+import { SYSTEM_ID } from '@system/constants';
+import { TEMPLATES } from '@system/utils/templates';
+
 // NOTE: Must use type here instead of interface as an interface doesn't match AnyObject type
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type Params = {
-    culture: CultureItem;
+    item: CosmereItem;
 };
 
-export class CharacterCultureComponent extends HandlebarsApplicationComponent<
+export class CharacterSkillLinkedItemComponent extends HandlebarsApplicationComponent<
     ConstructorOf<CharacterSheet>,
     Params
 > {
-    static TEMPLATE = `systems/${SYSTEM_ID}/templates/${TEMPLATES.ACTOR_CHARACTER_CULTURE}`;
+    static readonly TEMPLATE = `systems/${SYSTEM_ID}/templates/${TEMPLATES.ACTOR_CHARACTER_SKILL_LINKED_ITEM}`;
 
     /**
      * NOTE: Unbound methods is the standard for defining actions
@@ -26,46 +28,39 @@ export class CharacterCultureComponent extends HandlebarsApplicationComponent<
      */
     /* eslint-disable @typescript-eslint/unbound-method */
     static ACTIONS = {
-        remove: this.onRemove,
         view: this.onView,
     };
     /* eslint-enable @typescript-eslint/unbound-method */
 
     /* --- Actions --- */
 
-    private static onRemove(this: CharacterCultureComponent) {
-        void this.params!.culture.delete();
-    }
-
-    private static onView(this: CharacterCultureComponent) {
-        void this.params!.culture.sheet?.render(true);
+    private static onView(
+        this: CharacterSkillLinkedItemComponent,
+        event: Event,
+    ) {
+        void this.item.sheet?.render(true);
     }
 
     /* --- Accessors --- */
 
-    public get item(): CultureItem {
-        return this.params!.culture;
-    }
-
-    public get culture(): CultureItem {
-        return this.params!.culture;
+    public get item(): CosmereItem {
+        return this.params!.item;
     }
 
     /* --- Context --- */
 
     public _prepareContext(
-        params: Params,
+        params: object,
         context: BaseActorSheetRenderContext,
     ) {
         return Promise.resolve({
             ...context,
-
-            culture: {
-                label: this.culture.name,
-                img: this.culture.img,
-            },
-            skills: this.culture.hasLinkedSkills()
-                ? this.culture.system.linkedSkills
+            item: this.item,
+            id: this.item.id,
+            img: this.item.img,
+            typeLabel: this.item.isTyped() ? this.item.system.typeLabel : null,
+            skills: this.item.hasLinkedSkills()
+                ? this.item.system.linkedSkills
                       .filter(
                           (skillId) =>
                               this.application.actor.system.skills[skillId]
@@ -90,4 +85,4 @@ export class CharacterCultureComponent extends HandlebarsApplicationComponent<
 }
 
 // Register the component
-CharacterCultureComponent.register('app-character-culture');
+CharacterSkillLinkedItemComponent.register('app-character-skill-linked-item');

--- a/src/system/applications/actor/components/skills-group.ts
+++ b/src/system/applications/actor/components/skills-group.ts
@@ -10,7 +10,10 @@ import { BaseActorSheet, BaseActorSheetRenderContext } from '../base';
 // NOTE: Must use type here instead of interface as an interface doesn't match AnyObject type
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type Params = {
-    'group-id': AttributeGroup;
+    /**
+     * The attribute group id to display skills for.
+     */
+    'group-id'?: AttributeGroup;
 
     /**
      * Whether or not to display only core skills.
@@ -18,6 +21,12 @@ type Params = {
      * @default true
      */
     core?: boolean;
+
+    /**
+     * Explicit list of skills to display.
+     * If provided, this will override the skills in the group and the `core` flag.
+     */
+    skills?: Skill[];
 };
 
 export class ActorSkillsGroupComponent extends HandlebarsApplicationComponent<
@@ -26,28 +35,52 @@ export class ActorSkillsGroupComponent extends HandlebarsApplicationComponent<
 > {
     static TEMPLATE = `systems/${SYSTEM_ID}/templates/${TEMPLATES.ACTOR_BASE_SKILLS_GROUP}`;
 
+    /* --- Accessors --- */
+
+    get skillIds(): Skill[] {
+        if (this.params?.skills) {
+            return this.params.skills;
+        } else {
+            // Ensure group-id is provided
+            if (!this.params?.['group-id'])
+                throw new Error(
+                    'ActorSkillsGroupComponent: No group-id provided.',
+                );
+
+            // Get the group id from params
+            const groupId = this.params['group-id'];
+
+            // Get the attribute group config
+            const groupConfig = CONFIG.COSMERE.attributeGroups[groupId];
+
+            // Get the skill ids
+            const skillIds = groupConfig.attributes
+                .map((attrId) => CONFIG.COSMERE.attributes[attrId])
+                .map((attr) => attr.skills)
+                .flat()
+                .filter(
+                    (skillId) =>
+                        this.params!.core === false ||
+                        CONFIG.COSMERE.skills[skillId].core,
+                )
+                .sort((a, b) => a.localeCompare(b)); // Sort alphabetically
+
+            return skillIds;
+        }
+    }
+
     /* --- Context --- */
 
     public _prepareContext(
         params: Params,
         context: BaseActorSheetRenderContext,
     ) {
-        // Get the attribute group config
-        const groupConfig = CONFIG.COSMERE.attributeGroups[params['group-id']];
-
-        // Get the skill ids
-        const skillIds = groupConfig.attributes
-            .map((attrId) => CONFIG.COSMERE.attributes[attrId])
-            .map((attr) => attr.skills)
-            .flat()
-            .sort((a, b) => a.localeCompare(b)); // Sort alphabetically
-
         return Promise.resolve({
             ...context,
 
             id: params['group-id'],
 
-            skills: skillIds
+            skills: this.skillIds
                 .map((skillId) => {
                     // Get skill
                     const skill = this.application.actor.system.skills[skillId];
@@ -69,7 +102,6 @@ export class ActorSkillsGroupComponent extends HandlebarsApplicationComponent<
                         active: !config.hiddenUntilAcquired || skill.rank >= 1,
                     };
                 })
-                .filter((skill) => params.core === false || skill.config.core) // Filter out non-core skills
                 .sort((a, b) => {
                     const _a = a.config.hiddenUntilAcquired ? 1 : 0;
                     const _b = b.config.hiddenUntilAcquired ? 1 : 0;

--- a/src/system/applications/component-system/system.ts
+++ b/src/system/applications/component-system/system.ts
@@ -285,6 +285,8 @@ export function deregisterApplicationInstance(
         ComponentHandlebarsApplication<ApplicationV2Constructor<AnyObject>>
     >,
 ) {
+    console.log('Deregistering application instance:', application.id);
+
     // Destroy all components that belonged to this application
     Object.keys(componentRegistry).forEach((componentRef) => {
         if (componentRef.startsWith(application.id)) {
@@ -297,6 +299,8 @@ export function deregisterApplicationInstance(
 }
 
 export function destroyComponent(componentRef: string, recursive = true) {
+    console.log('Destroying component:', componentRef, recursive);
+
     // Get component instance
     const instance = getComponentInstance(componentRef);
     if (!instance)
@@ -625,7 +629,7 @@ export function removeOrphanedComponents(applicationId: string) {
     components.forEach(([ref, { dirty, selector, instance }]) => {
         if (dirty) {
             // Destroy component
-            destroyComponent(ref);
+            destroyComponent(ref, false);
         }
     });
 }

--- a/src/system/applications/item/base.ts
+++ b/src/system/applications/item/base.ts
@@ -323,6 +323,9 @@ export class BaseItemSheet extends TabsApplicationMixin(
             proseDescName: this.proseDescName,
             proseDescHtml: this.proseDescHtml,
             expandDefault: expandDefaultSetting,
+            typeLabel: game
+                .i18n!.localize(`TYPES.Item.${this.item.type}`)
+                .toLowerCase(),
         };
     }
 

--- a/src/system/applications/item/components/details-id.ts
+++ b/src/system/applications/item/components/details-id.ts
@@ -17,9 +17,6 @@ export class DetailsIdComponent extends HandlebarsApplicationComponent<
         return Promise.resolve({
             ...context,
             hasId: this.application.item.hasId(),
-            type: game
-                .i18n!.localize(`TYPES.Item.${this.application.item.type}`)
-                .toLowerCase(),
         });
     }
 }

--- a/src/system/applications/item/components/details-linked-skills.ts
+++ b/src/system/applications/item/components/details-linked-skills.ts
@@ -1,0 +1,44 @@
+import { ConstructorOf } from '@system/types/utils';
+import { SYSTEM_ID } from '@src/system/constants';
+import { TEMPLATES } from '@src/system/utils/templates';
+
+// Component imports
+import { HandlebarsApplicationComponent } from '@system/applications/component-system';
+import { BaseItemSheet, BaseItemSheetRenderContext } from '../base';
+
+export class DetailsLinkedSkillsComponent extends HandlebarsApplicationComponent<
+    ConstructorOf<BaseItemSheet>
+> {
+    static TEMPLATE = `systems/${SYSTEM_ID}/templates/${TEMPLATES.ITEM_DETAILS_LINKED_SKILLS}`;
+
+    /* --- Context --- */
+
+    public _prepareContext(params: never, context: BaseItemSheetRenderContext) {
+        const hasLinkedSkills = this.application.item.hasLinkedSkills();
+        if (!hasLinkedSkills)
+            return Promise.resolve({ ...context, hasLinkedSkills });
+
+        let linkedSkillsOptions = (
+            (
+                (
+                    this.application.item
+                        .system as unknown as foundry.abstract.DataModel
+                ).schema.getField(
+                    'linkedSkills',
+                ) as foundry.data.fields.ArrayField
+            ).element as foundry.data.fields.StringField
+        ).choices;
+
+        if (linkedSkillsOptions instanceof Function)
+            linkedSkillsOptions = linkedSkillsOptions();
+
+        return Promise.resolve({
+            ...context,
+            hasLinkedSkills,
+            linkedSkillsOptions,
+        });
+    }
+}
+
+// Register the component
+DetailsLinkedSkillsComponent.register('app-item-details-linked-skills');

--- a/src/system/applications/item/components/index.ts
+++ b/src/system/applications/item/components/index.ts
@@ -10,6 +10,7 @@ import './details-attack';
 import './details-damage';
 import './details-modality';
 import './details-talents-provider';
+import './details-linked-skills';
 import './properties';
 
 import './talent';

--- a/src/system/applications/item/culture-sheet.ts
+++ b/src/system/applications/item/culture-sheet.ts
@@ -30,6 +30,17 @@ export class CultureItemSheet extends BaseItemSheet {
         },
     );
 
+    static TABS = foundry.utils.mergeObject(
+        foundry.utils.deepClone(super.TABS),
+        {
+            details: {
+                label: 'COSMERE.Item.Sheet.Tabs.Details',
+                icon: '<i class="fa-solid fa-circle-info"></i>',
+                sortIndex: 15,
+            },
+        },
+    );
+
     get item(): CultureItem {
         return super.document;
     }

--- a/src/system/applications/item/path-sheet.ts
+++ b/src/system/applications/item/path-sheet.ts
@@ -53,27 +53,4 @@ export class PathItemSheet extends TalentsTabMixin(
     get item(): PathItem {
         return super.document;
     }
-
-    /* --- Context --- */
-
-    public async _prepareContext(
-        options: DeepPartial<foundry.applications.api.ApplicationV2.RenderOptions>,
-    ) {
-        // Get non-core (locked) skills
-        const linkedSkillsOptions = Object.entries(CONFIG.COSMERE.skills)
-            .filter(([key, config]) => !config.core)
-            .reduce(
-                (acc, [key, config]) => ({
-                    ...acc,
-                    [key]: config.label,
-                }),
-                {},
-            );
-
-        return {
-            ...(await super._prepareContext(options)),
-
-            linkedSkillsOptions,
-        };
-    }
 }

--- a/src/system/data/item/ancestry.ts
+++ b/src/system/data/item/ancestry.ts
@@ -13,6 +13,10 @@ import {
     TalentsProviderData,
 } from './mixins/talents-provider';
 import { EventsItemMixin, EventsItemData } from './mixins/events';
+import {
+    LinkedSkillsMixin,
+    LinkedSkillsItemData,
+} from './mixins/linked-skills';
 
 interface TalentGrant {
     uuid: string;
@@ -29,7 +33,8 @@ export interface AncestryItemData
     extends IdItemData,
         DescriptionItemData,
         TalentsProviderData,
-        EventsItemData {
+        EventsItemData,
+        LinkedSkillsItemData {
     size: Size;
     type: {
         id: CreatureType;
@@ -65,6 +70,7 @@ export class AncestryItemDataModel extends DataModelMixin<
     }),
     TalentsProviderMixin(),
     EventsItemMixin(),
+    LinkedSkillsMixin(),
 ) {
     static defineSchema() {
         return foundry.utils.mergeObject(super.defineSchema(), {

--- a/src/system/data/item/armor.ts
+++ b/src/system/data/item/armor.ts
@@ -18,6 +18,10 @@ import { DeflectItemMixin, DeflectItemData } from './mixins/deflect';
 import { PhysicalItemMixin, PhysicalItemData } from './mixins/physical';
 import { ExpertiseItemMixin, ExpertiseItemData } from './mixins/expertise';
 import { EventsItemMixin, EventsItemData } from './mixins/events';
+import {
+    LinkedSkillsMixin,
+    LinkedSkillsItemData,
+} from './mixins/linked-skills';
 
 export interface ArmorItemData
     extends IdItemData,
@@ -28,7 +32,8 @@ export interface ArmorItemData
         TraitsItemData<ArmorTraitId>,
         DeflectItemData,
         PhysicalItemData,
-        EventsItemData {}
+        EventsItemData,
+        LinkedSkillsItemData {}
 
 export class ArmorItemDataModel extends DataModelMixin<
     ArmorItemData,
@@ -52,4 +57,5 @@ export class ArmorItemDataModel extends DataModelMixin<
     DeflectItemMixin(),
     PhysicalItemMixin(),
     EventsItemMixin(),
+    LinkedSkillsMixin(),
 ) {}

--- a/src/system/data/item/culture.ts
+++ b/src/system/data/item/culture.ts
@@ -8,11 +8,16 @@ import {
     DescriptionItemData,
 } from './mixins/description';
 import { EventsItemMixin, EventsItemData } from './mixins/events';
+import {
+    LinkedSkillsMixin,
+    LinkedSkillsItemData,
+} from './mixins/linked-skills';
 
 export interface CultureItemData
     extends IdItemData,
         DescriptionItemData,
-        EventsItemData {}
+        EventsItemData,
+        LinkedSkillsItemData {}
 
 export class CultureItemDataModel extends DataModelMixin<
     CultureItemData,
@@ -26,6 +31,7 @@ export class CultureItemDataModel extends DataModelMixin<
         value: 'COSMERE.Item.Type.Culture.desc_placeholder',
     }),
     EventsItemMixin(),
+    LinkedSkillsMixin(),
 ) {
     static defineSchema() {
         return foundry.utils.mergeObject(super.defineSchema(), {});

--- a/src/system/data/item/mixins/linked-skills.ts
+++ b/src/system/data/item/mixins/linked-skills.ts
@@ -1,0 +1,48 @@
+import { PathType, Skill } from '@system/types/cosmere';
+
+import { CosmereItem } from '@system/documents';
+
+export interface LinkedSkillsItemData {
+    /**
+     * The non-core skills linked to this item.
+     * These skills are displayed with the item in the sheet.
+     */
+    linkedSkills: Skill[];
+}
+
+export function LinkedSkillsMixin<P extends CosmereItem>() {
+    return (
+        base: typeof foundry.abstract.TypeDataModel<LinkedSkillsItemData, P>,
+    ) => {
+        return class extends base {
+            static defineSchema() {
+                return foundry.utils.mergeObject(super.defineSchema(), {
+                    linkedSkills: new foundry.data.fields.ArrayField(
+                        new foundry.data.fields.StringField({
+                            required: true,
+                            nullable: false,
+                            blank: false,
+                            choices: () =>
+                                Object.entries(CONFIG.COSMERE.skills)
+                                    .filter(([key, skill]) => !skill.core)
+                                    .reduce(
+                                        (acc, [key, skill]) => ({
+                                            ...acc,
+                                            [key]: skill.label,
+                                        }),
+                                        {},
+                                    ),
+                        }),
+                        {
+                            required: true,
+                            nullable: false,
+                            initial: [],
+                            label: 'COSMERE.Item.General.LinkedSkills.Label',
+                            hint: 'COSMERE.Item.General.LinkedSkills.Hint',
+                        },
+                    ),
+                });
+            }
+        };
+    };
+}

--- a/src/system/data/item/mixins/typed.ts
+++ b/src/system/data/item/mixins/typed.ts
@@ -10,6 +10,9 @@ interface TypedItemMixinOptions<Type extends string = string> {
 
 export interface TypedItemData<T extends string = string> {
     type: T;
+
+    readonly typeLabel: string;
+    readonly typeSelectOptions: Record<string | number, string>;
 }
 
 export function TypedItemMixin<
@@ -41,9 +44,11 @@ export function TypedItemMixin<
             }
 
             get typeSelectOptions(): Record<string | number, string> {
-                const choices = (
+                let choices = (
                     this.schema.fields.type as foundry.data.fields.StringField
                 ).choices;
+
+                if (choices instanceof Function) choices = choices();
 
                 if (Array.isArray(choices)) {
                     return (choices as string[]).reduce(
@@ -56,6 +61,11 @@ export function TypedItemMixin<
                 } else {
                     return choices as Record<string, string>;
                 }
+            }
+
+            get typeLabel(): string {
+                const options = this.typeSelectOptions;
+                return options[this.type] ?? this.type;
             }
         };
     };

--- a/src/system/data/item/path.ts
+++ b/src/system/data/item/path.ts
@@ -14,19 +14,18 @@ import {
     TalentsProviderData,
 } from './mixins/talents-provider';
 import { EventsItemMixin, EventsItemData } from './mixins/events';
+import {
+    LinkedSkillsMixin,
+    LinkedSkillsItemData,
+} from './mixins/linked-skills';
 
 export interface PathItemData
     extends IdItemData,
         TypedItemData<PathType>,
         DescriptionItemData,
         TalentsProviderData,
-        EventsItemData {
-    /**
-     * The non-core skills linked to this path.
-     * These skills are displayed with the path in the sheet.
-     */
-    linkedSkills: Skill[];
-}
+        EventsItemData,
+        LinkedSkillsItemData {}
 
 export class PathItemDataModel extends DataModelMixin<
     PathItemData,
@@ -50,34 +49,10 @@ export class PathItemDataModel extends DataModelMixin<
     }),
     TalentsProviderMixin(),
     EventsItemMixin(),
+    LinkedSkillsMixin(),
 ) {
     static defineSchema() {
         return foundry.utils.mergeObject(super.defineSchema(), {
-            linkedSkills: new foundry.data.fields.ArrayField(
-                new foundry.data.fields.StringField({
-                    required: true,
-                    nullable: false,
-                    blank: false,
-                    choices: () =>
-                        Object.entries(CONFIG.COSMERE.skills)
-                            .filter(([key, skill]) => !skill.core)
-                            .reduce(
-                                (acc, [key, skill]) => ({
-                                    ...acc,
-                                    [key]: skill.label,
-                                }),
-                                {},
-                            ),
-                }),
-                {
-                    required: true,
-                    nullable: false,
-                    initial: [],
-                    label: 'COSMERE.Item.Path.LinkedSkills.Label',
-                    hint: 'COSMERE.Item.Path.LinkedSkills.Hint',
-                },
-            ),
-
             // TODO: Advancements
         });
     }

--- a/src/system/data/item/weapon.ts
+++ b/src/system/data/item/weapon.ts
@@ -28,6 +28,10 @@ import { TraitsItemMixin, TraitsItemData } from './mixins/traits';
 import { PhysicalItemMixin, PhysicalItemData } from './mixins/physical';
 import { ExpertiseItemMixin, ExpertiseItemData } from './mixins/expertise';
 import { EventsItemMixin, EventsItemData } from './mixins/events';
+import {
+    LinkedSkillsMixin,
+    LinkedSkillsItemData,
+} from './mixins/linked-skills';
 
 export interface WeaponItemData
     extends IdItemData<WeaponId>,
@@ -40,7 +44,8 @@ export interface WeaponItemData
         ExpertiseItemData,
         TraitsItemData<WeaponTraitId>,
         Partial<PhysicalItemData>,
-        EventsItemData {}
+        EventsItemData,
+        LinkedSkillsItemData {}
 
 export class WeaponItemDataModel extends DataModelMixin<
     WeaponItemData,
@@ -89,6 +94,7 @@ export class WeaponItemDataModel extends DataModelMixin<
     TraitsItemMixin(),
     PhysicalItemMixin(),
     EventsItemMixin(),
+    LinkedSkillsMixin(),
 ) {
     static defineSchema() {
         return foundry.utils.mergeObject(super.defineSchema(), {});

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -217,6 +217,44 @@ export class CosmereActor<
         return this.items.filter((i) => i.isTalent());
     }
 
+    public get skillLinkedItems(): CosmereItem[] {
+        return this.items
+            .filter(
+                (item) =>
+                    !item.isPath() && !item.isAncestry() && !item.isCulture(),
+            )
+            .filter(
+                (item) =>
+                    item.hasLinkedSkills() &&
+                    item.system.linkedSkills.length > 0 &&
+                    item.system.linkedSkills.some((skill) =>
+                        this.unlockedSkills.includes(skill),
+                    ),
+            );
+    }
+
+    /**
+     * List of all non-core (unlocked) skills of this actor.
+     */
+    public get unlockedSkills(): Skill[] {
+        return Object.entries(this.system.skills)
+            .filter(([, skill]) => skill.unlocked)
+            .map(([skill]) => skill as Skill);
+    }
+
+    /**
+     * A list of all non-core (unlocked) skills of this actor that
+     * do not have an associated path.
+     */
+    public get orphanedSkills(): Skill[] {
+        return this.unlockedSkills.filter(
+            (skill) =>
+                !this.items
+                    .filter((item) => item.hasLinkedSkills())
+                    .some((path) => path.system.linkedSkills.includes(skill)),
+        );
+    }
+
     /* --- Type Guards --- */
 
     public isCharacter(): this is CharacterActor {

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -51,6 +51,7 @@ import { ModalityItemData } from '@system/data/item/mixins/modality';
 import { TalentsProviderData } from '@system/data/item/mixins/talents-provider';
 import { EventsItemData } from '@system/data/item/mixins/events';
 import { DeflectItemData } from '@system/data/item/mixins/deflect';
+import { LinkedSkillsItemData } from '@system/data/item/mixins/linked-skills';
 
 // Rolls
 import {
@@ -270,6 +271,13 @@ export class CosmereItem<
      */
     public hasEvents(): this is CosmereItem<EventsItemData> {
         return 'events' in this.system;
+    }
+
+    /**
+     * Whether or not this item supports linked skills.
+     */
+    public hasLinkedSkills(): this is CosmereItem<LinkedSkillsItemData> {
+        return 'linkedSkills' in this.system;
     }
 
     /* --- Accessors --- */

--- a/src/system/utils/templates.ts
+++ b/src/system/utils/templates.ts
@@ -59,6 +59,8 @@ export const TEMPLATES = {
     ACTOR_CHARACTER_CONNECTIONS_LIST:
         'actors/character/components/connections-list.hbs',
     ACTOR_CHARACTER_GOALS_LIST: 'actors/character/components/goals-list.hbs',
+    ACTOR_CHARACTER_SKILL_LINKED_ITEM:
+        'actors/character/components/skill-linked-item.hbs',
 
     // ACTOR ADVERSARY
     ACTOR_ADVERSARY_HEADER: 'actors/adversary/parts/header.hbs',
@@ -120,6 +122,7 @@ export const TEMPLATES = {
     ITEM_DETAILS_TYPE: 'item/components/details-type.hbs',
     ITEM_DETAILS_TALENTS_PROVIDER:
         'item/components/details-talents-provider.hbs',
+    ITEM_DETAILS_LINKED_SKILLS: 'item/components/details-linked-skills.hbs',
 
     ITEM_EFFECTS_LIST: 'item/components/effects-list.hbs',
     ITEM_EVENT_RULES_LIST: 'item/components/event-rules-list.hbs',

--- a/src/templates/actors/character/components/ancestry.hbs
+++ b/src/templates/actors/character/components/ancestry.hbs
@@ -1,31 +1,46 @@
-{{#if ancestry}}
-<div class="border-box">
-    <div class="wrapper">
-        <div class="details">
-            <div class="title" data-action="view">        
-                <span class="name">
-                    {{ancestry.label}}            
-                    {{#if isEditMode}}
-                    <div class="controls">
-                        <a data-action="remove"
-                            data-tooltip="GENERIC.Button.Remove"
-                        >
-                            <i class="fa-solid fa-xmark"></i>
-                        </a>
-                    </div>
-                    {{/if}}
-                </span>
-                <span class="item-type">{{localize "COSMERE.Item.Type.Ancestry.label"}}</span>        
+{{#if hasAncestry}}
+    <div class="border-box">
+        <div class="wrapper">
+            <div class="details">
+                <div class="title" data-action="view">        
+                    <span class="name">
+                        {{ancestry.label}}            
+                        {{#if isEditMode}}
+                            <div class="controls">
+                                <a data-action="remove"
+                                    data-tooltip="GENERIC.Button.Remove"
+                                >
+                                    <i class="fa-solid fa-xmark"></i>
+                                </a>
+                            </div>
+                        {{/if}}
+                    </span>
+                    <span class="item-type">{{localize "COSMERE.Item.Type.Ancestry.label"}}</span>        
+                </div> 
             </div> 
-        </div> 
-    </div>
-    {{#if ancestry.img}}
-    <div class="background-img">
-        <img src="{{ancestry.img}}">
-    </div>
-    {{/if}}  
-</div>    
-{{> box-corners }}    
+
+            {{!-- Skills --}}
+            {{#if (gt ancestry.skills.length 0)}}
+                <ul class="skill-list">
+                    {{#each ancestry.skills as |skill|}}
+                        <li class="skill" data-id="{{skill.id}}">
+                            {{app-actor-skill
+                                skill=skill.id
+                                readonly=(not @root.isEditMode)
+                                pips=true
+                            }}
+                        </li>
+                    {{/each}}
+                </ul>
+            {{/if}}
+        </div>
+        {{#if ancestry.img}}
+            <div class="background-img">
+                <img src="{{ancestry.img}}">
+            </div>
+        {{/if}}  
+    </div>    
+    {{> box-corners }}    
 {{else}}
     <div class="ancestry drop-area">
         <span>{{localize "COSMERE.Actor.Sheet.AncestryPlaceholder"}}</span>

--- a/src/templates/actors/character/components/culture.hbs
+++ b/src/templates/actors/character/components/culture.hbs
@@ -1,6 +1,7 @@
 {{#if culture}}
 <div class="border-box">
     <div class="wrapper">
+        {{!-- Details --}}
         <div class="details">
             <div class="title" data-action="view">    
                 <span class="name">
@@ -18,15 +19,30 @@
                 <span class="item-type">{{localize "TYPES.Item.culture"}}</span>
             </div>
         </div>
+
+        {{!-- Skills --}}
+        {{#if (gt skills.length 0)}}
+            <ul class="skill-list">
+                {{#each skills as |skill|}}
+                    <li class="skill" data-id="{{skill.id}}">
+                        {{app-actor-skill
+                            skill=skill.id
+                            readonly=(not @root.isEditMode)
+                            pips=true
+                        }}
+                    </li>
+                {{/each}}
+            </ul>
+        {{/if}}
     </div>    
     {{!-- NOTE: Currently available culture images are too low resolution to use here.
         Uncomment the following block if higher resolution images are available
         --}}
-    {{!-- {{#if culture.img}}
-    <div class="background-img">
-        <img src="{{culture.img}}">
-    </div>
-    {{/if}} --}}
+    {{#if culture.img}}
+        <div class="background-img">
+            <img src="{{culture.img}}">
+        </div>
+    {{/if}}
 </div>    
 {{> box-corners }}   
 {{else}}

--- a/src/templates/actors/character/components/skill-linked-item.hbs
+++ b/src/templates/actors/character/components/skill-linked-item.hbs
@@ -1,0 +1,34 @@
+<div class="border-box">
+    <div class="wrapper">
+        {{!-- Details --}}
+        <div class="details">        
+            <div class="title" data-action="view">
+                <span class="name">{{item.name}}</span>
+                <span class="item-type">{{localize typeLabel}} {{localize (concat "TYPES.Item." item.type)}}</span>
+            </div>
+        </div>
+
+        {{!-- Skills --}}
+        {{#if (gt skills.length 0)}}
+            <ul class="skill-list">
+                {{#each skills as |skill|}}
+                    <li class="skill" data-id="{{skill.id}}">
+                        {{app-actor-skill
+                            skill=skill.id
+                            readonly=(not @root.isEditMode)
+                            pips=true
+                        }}
+                    </li>
+                {{/each}}
+            </ul>
+        {{/if}}
+    </div>        
+
+    {{!-- Background image --}}
+    {{#if img}}
+        <div class="background-img">
+            <img src="{{img}}">
+        </div>
+    {{/if}}
+</div>
+{{> box-corners }}

--- a/src/templates/actors/character/partials/char-details-tab.hbs
+++ b/src/templates/actors/character/partials/char-details-tab.hbs
@@ -5,6 +5,10 @@
         {{#each @root.attributeGroups as |group|}}
             {{app-actor-skills-group group-id=group}}
         {{/each}}
+
+        {{#if (gt @root.actor.orphanedSkills.length 0)}}
+            {{app-actor-skills-group skills=@root.actor.orphanedSkills}}
+        {{/if}}
     </section>
     <section>
         <div class="lineage">
@@ -27,6 +31,10 @@
             {{/if}}
             
             {{app-character-paths-list}}
+
+            {{#each @root.actor.skillLinkedItems as |item|}}
+                {{app-character-skill-linked-item item=item}}
+            {{/each}}
         </div>
     </section>
 </div>

--- a/src/templates/item/ancestry/partials/ancestry-details-tab.hbs
+++ b/src/templates/item/ancestry/partials/ancestry-details-tab.hbs
@@ -18,6 +18,7 @@
                 </div>                
             </div>
         </div>
+        {{app-item-details-linked-skills}}
     </fieldset>
     <fieldset>
         <legend>{{localize "COSMERE.Item.Sheet.Ancestry.Advancement"}}</legend>

--- a/src/templates/item/armor/partials/armor-details-tab.hbs
+++ b/src/templates/item/armor/partials/armor-details-tab.hbs
@@ -4,6 +4,7 @@
     <fieldset>
         <legend>{{localize "COSMERE.Item.Sheet.Basics"}}</legend>
         {{app-item-details-id}}
+        {{app-item-details-linked-skills}}
     </fieldset>
     {{app-item-details-equip}}
     {{app-item-details-activation}}

--- a/src/templates/item/components/details-id.hbs
+++ b/src/templates/item/components/details-id.hbs
@@ -2,7 +2,7 @@
 <div class="form-group">
     <label>
         {{localize systemFields.id.label}} 
-        <i class="info fa-regular fa-circle-question" data-tooltip="{{localize systemFields.id.hint type=type}}"></i>
+        <i class="info fa-regular fa-circle-question" data-tooltip="{{localize systemFields.id.hint type=typeLabel}}"></i>
     </label>
     {{app-id-input
         name="system.id"

--- a/src/templates/item/components/details-linked-skills.hbs
+++ b/src/templates/item/components/details-linked-skills.hbs
@@ -1,0 +1,18 @@
+{{#if hasLinkedSkills}}
+    <div class="item-details-form">
+        <div class="form-group">
+            <label>
+                {{localize @root.systemFields.linkedSkills.label}}
+                <i class="info fa-regular fa-circle-question"
+                    data-tooltip="{{localize @root.systemFields.linkedSkills.hint type=typeLabel}}"></i>
+            </label>
+            <div class="form-fields">
+                {{app-multi-value-select
+                    name="system.linkedSkills"
+                    value=@root.item.system.linkedSkills
+                    options=@root.linkedSkillsOptions
+                }}
+            </div>
+        </div>
+    </div>
+{{/if}}

--- a/src/templates/item/partials/item-details-tab.hbs
+++ b/src/templates/item/partials/item-details-tab.hbs
@@ -5,6 +5,7 @@
         <legend>{{localize "COSMERE.Item.Sheet.Basics"}}</legend>
         {{app-item-details-id}}
         {{app-item-details-type}}
+        {{app-item-details-linked-skills}}
     </fieldset>
     {{app-item-details-equip}}
     {{app-item-details-activation}}

--- a/src/templates/item/path/parts/content.hbs
+++ b/src/templates/item/path/parts/content.hbs
@@ -5,7 +5,7 @@
         <section class="tab-body">
             {{> item-description-tab}}
             {{> item-talents-tab}}
-            {{> path-details-tab}}
+            {{> item-details-tab}}
             {{> item-events-tab}}
             {{> item-effects-tab}}
         </section>


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR adds support for linked skills for ancestries, cultures, weapons and armor. It also adds a fallback skill group below the existing three where any unlocked skill not linked to any items end up.

**Related Issue**  
Closes #199 

**How Has This Been Tested?**  
1. Open actor
2. Add 6 different powers to a character
3. Add an ancestry to the character -> edit and set the linked skills to one of the powers
4. Add a culture to the character -> edit and set the linked skills to one of the powers
5. Add a path to the character -> edit and set the linked skills to one of the powers
6. Add a weapon to the character -> edit and set the linked skills to one of the powers
7. Add an armor to the character -> edit and set the linked skills to one of the powers
8. Ensure that the final power's skill ends up in the section below the core skills
9. Edit the weapon and remove the linked skills
10. Edit the armor and remove the linked skills

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/c1f6a6ac-bfd0-4f0f-a814-b4f425ca48a6)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343