### PR TITLE
fix(adversary expertise mod): updated adversary skill pip template to…

### DIFF
--- a/src/templates/actors/adversary/components/skills.hbs
+++ b/src/templates/actors/adversary/components/skills.hbs
@@ -34,7 +34,7 @@
                 data-tooltip="{{localize skill.config.label}} ({{localize skill.attributeLabel}})">
                 <span class="name">{{localize skill.config.label}}</span>
                 <span class="separator">|</span>
-                <span>+{{skill.rank}}</span>
+                <span>+{{derived skill.mod}}</span>
             </div>
             {{/if}}
             {{/each}}


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Swapped the bonus display in the adversary skill chip to show total mod not just ranks.

**Related Issue**  
Closes #405 

**How Has This Been Tested?**  
By looking at the imported axehound adversary, see images below

**Screenshots (if applicable)**  
Before
![image](https://github.com/user-attachments/assets/c1484825-63db-41a8-bb9e-6d9a4d3fa306)

After
![image](https://github.com/user-attachments/assets/8799b2d2-799d-4427-883d-92e6b233f1b5)


**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: 12.343.