### PR TITLE
fix(characters): restore goal edit/remove functionality

### DIFF
--- a/src/templates/actors/character/components/goals-list.hbs
+++ b/src/templates/actors/character/components/goals-list.hbs
@@ -72,7 +72,7 @@
 <menu class="controls-dropdown">
     <li class="header-control">
         <button class="control"
-            data-action="edit-connection"
+            data-action="edit-goal"
         >
             <i class="fa-solid fa-pen-to-square"></i>
             <span>{{localize "GENERIC.Button.Edit"}}</span>
@@ -80,7 +80,7 @@
     </li>
     <li class="header-control">
         <button class="control"
-            data-action="remove-connection"
+            data-action="remove-goal"
         >
             <i class="fa-solid fa-trash"></i>
             <span>{{localize "GENERIC.Button.Remove"}}</span>


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
The goal context menu was not functioning, as the edit and remove options didn't do anything. This PR restores the old action names.

**Related Issue**  

**How Has This Been Tested?**  
1. Create a character.
2. Make sure they have at least one goal
3. Try to edit from the context menu
4. Try to remove from the context menu

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343.
