### PR TITLE
Feat: Register Adversary Actions Action Type

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -467,6 +467,10 @@
                     "Ancestry": {
                         "label": "Ancestry Action",
                         "label_plural": "Ancestry Actions"
+                    },
+                    "Adversary": {
+                        "label": "Adversary Action",
+                        "label_plural": "Adversary Actions"
                     }
                 },
                 "Ancestry": {

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -1034,6 +1034,10 @@ const COSMERE: CosmereRPGConfig = {
                 label: 'COSMERE.Item.Action.Type.Ancestry.label',
                 labelPlural: 'COSMERE.Item.Action.Type.Ancestry.label_plural',
             },
+            [ActionType.Adversary]: {
+                label: 'COSMERE.Item.Action.Type.Adversary.label',
+                labelPlural: 'COSMERE.Item.Action.Type.Adversary.label_plural',
+            },
         },
         costs: {
             [ActionCostType.Action]: {

--- a/src/system/types/cosmere.ts
+++ b/src/system/types/cosmere.ts
@@ -233,6 +233,7 @@ export const enum EquipmentType {
 export const enum ActionType {
     Basic = 'basic',
     Ancestry = 'ancestry',
+    Adversary = 'adversary',
 }
 
 export const enum ActionCostType {


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Very simple addition to the config, registers an 'adversary action' subtype of action, alongside Ancestry Action and Basic Action.

**Related Issue**  
Closes #409 

**How Has This Been Tested?**  
Create an action, go to details tab, ensure that Adversary Action appears in the list.

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/20948e02-0ea1-4b26-8ba8-74872f1dfefc)

**Checklist:**  
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343.

**Additional context**  
N/A
