### PR TITLE
fix(enrichers): support alternate enricher spellings

### DIFF
--- a/src/system/utils/enrichers.ts
+++ b/src/system/utils/enrichers.ts
@@ -146,10 +146,10 @@ function buildTestLabel(
         }
         linkLabel = `${linkLabel}${game.i18n?.localize('GENERIC.Test')}`;
     }
-    if (config.dc && !config.defence)
+    if (config.dc && !config.defense)
         postLink = `${game.i18n?.localize('GENERIC.Enrichers.Test.Against')} ${game.i18n?.localize('GENERIC.DC')} ${config.dc as string | number}`;
-    if (config.defence)
-        postLink = `${game.i18n?.localize('GENERIC.Enrichers.Test.VsDefense')} ${config.defenceName as string} ${game.i18n?.localize('COSMERE.Actor.Statistics.Defense')}${config.dc ? ` (${game.i18n?.localize('GENERIC.DC')}: ${config.dc as number})` : ''}`;
+    if (config.defense)
+        postLink = `${game.i18n?.localize('GENERIC.Enrichers.Test.VsDefense')} ${config.defenseName as string} ${game.i18n?.localize('COSMERE.Actor.Statistics.Defense')}${config.dc ? ` (${game.i18n?.localize('GENERIC.DC')}: ${config.dc as number})` : ''}`;
     return { linkLabel, postLink };
 }
 
@@ -301,16 +301,22 @@ function enrichTest(
             config.dc = 0;
         }
     }
+
+    // Account for regional differences
     if (config.defence) {
-        config.defenceName =
+        config.defense = config.defence;
+        delete config.defence;
+    }
+    if (config.defense) {
+        config.defenseName =
             game.i18n?.localize(
-                CONFIG.COSMERE.attributeGroups[config.defence as AttributeGroup]
+                CONFIG.COSMERE.attributeGroups[config.defense as AttributeGroup]
                     .label,
             ) ??
             game.i18n?.localize('COSMERE.Actor.Statistics.Defense') ??
             'Bad Config';
         config.dc =
-            data.target?.def[config.defence as 'phy' | 'spi' | 'cog'] ?? 0;
+            data.target?.def[config.defense as 'phy' | 'spi' | 'cog'] ?? 0;
     }
 
     const labelText = label


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR changes the test enricher to default to "defense," as spelled in the books and throughout the rest of the system. However, it continues to support the spelling "defence."

This is not a systematic fix for the linked issue, seeing as occurrences like this are likely to be rare and on a case-by-case basis.

**Related Issue**  
Closes #379 

**How Has This Been Tested?**  
1. Add a test enricher to a description or note field.
2. Use both spellings ("defense" and "defence")
3. Confirm that both work as intended when parsed

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343.
