### PR TITLE
fix(talent tree view component): fix an issue causing connections to …

### DIFF
--- a/src/system/applications/item/components/talent-tree/canvas/elements/nodes/tree-node.ts
+++ b/src/system/applications/item/components/talent-tree/canvas/elements/nodes/tree-node.ts
@@ -382,17 +382,7 @@ export class TalentTreeNode extends BaseNode {
                             talentNode.prerequisites.some(
                                 (prereq) =>
                                     prereq.type ===
-                                        TalentTree.Node.Prerequisite.Type
-                                            .Talent &&
-                                    Array.from(prereq.talents).every((ref) =>
-                                        this.item.system.nodes.some(
-                                            (n) =>
-                                                n.type ===
-                                                    TalentTree.Node.Type
-                                                        .Talent &&
-                                                n.talentId === ref.id,
-                                        ),
-                                    ),
+                                    TalentTree.Node.Prerequisite.Type.Talent,
                             ),
                     )
                     .map((talentNode) =>


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes the issue causing the lines for nested tree root talent prerequisites to not get constructed if not all talents in the list are present on the tree. 

**Related Issue**  
Closes #340 

**How Has This Been Tested?**  
1. Open a talent tree that has the above described problem (i.e. radiant trees)
2. Ensure all the expected connections are there.

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343