### PR TITLE
feat(item embed): add talent embed support

### DIFF
--- a/src/declarations/foundry/client/data/abstract/client-document.d.ts
+++ b/src/declarations/foundry/client/data/abstract/client-document.d.ts
@@ -47,51 +47,6 @@ declare interface DocumentHTMLEmbedConfig
     label?: string;
 }
 
-/**
- * Options for enriching HTML content with various dynamic features.
- */
-declare interface EnrichmentOptions {
-    /**
-     * Include unrevealed secret tags in the final HTML? If false, unrevealed secret blocks will be removed.
-     * @default false
-     */
-    secrets?: boolean;
-
-    /**
-     * Replace dynamic document links?
-     * @default true
-     */
-    documents?: boolean;
-
-    /**
-     * Replace hyperlink content?
-     * @default true
-     */
-    links?: boolean;
-
-    /**
-     * Replace inline dice rolls?
-     * @default true
-     */
-    rolls?: boolean;
-
-    /**
-     * Replace embedded content?
-     * @default true
-     */
-    embeds?: boolean;
-
-    /**
-     * The data object providing context for inline rolls, or a function that produces it.
-     */
-    rollData?: object | Function;
-
-    /**
-     * A document to resolve relative UUIDs against.
-     */
-    relativeTo?: ClientDocument;
-}
-
 declare interface CreateDocumentLinkOptions {
     /**
      * A document to generate a link relative to.
@@ -171,7 +126,7 @@ declare class ClientDocument {
      */
     public async toEmbed(
         config: DocumentHTMLEmbedConfig,
-        options?: EnrichmentOptions,
+        options?: TextEditor.EnrichmentOption,
     ): Promise<HTMLElement | null>;
 
     /**
@@ -184,7 +139,7 @@ declare class ClientDocument {
      */
     protected async _buildEmbedHTML(
         config: DocumentHTMLEmbedConfig,
-        options?: EnrichmentOptions,
+        options?: TextEditor.EnrichmentOption,
     ): Promise<HTMLElement | HTMLCollection | null>;
 
     /**
@@ -197,7 +152,7 @@ declare class ClientDocument {
     protected async _createInlineEmbed(
         content: HTMLElement | HTMLCollection,
         config: DocumentHTMLEmbedConfig,
-        options?: EnrichmentOptions,
+        options?: TextEditor.EnrichmentOptions,
     ): Promise<HTMLElement | null>;
 
     /**
@@ -210,7 +165,7 @@ declare class ClientDocument {
     protected async _createFigureEmbed(
         content: HTMLElement | HTMLCollection,
         config: DocumentHTMLEmbedConfig,
-        options?: EnrichmentOptions,
+        options?: TextEditor.EnrichmentOption,
     ): Promise<HTMLElement | null>;
 
     /**

--- a/src/declarations/foundry/client/data/abstract/client-document.d.ts
+++ b/src/declarations/foundry/client/data/abstract/client-document.d.ts
@@ -3,6 +3,107 @@ declare type Mixin<
     BaseClass extends abstract new (...args: any[]) => any,
 > = BaseClass & MixinClass;
 
+/**
+ * Configuration for embedding HTML Document content.
+ */
+declare interface DocumentHTMLEmbedConfig
+    extends Record<string, string | boolean | number> {
+    /** Any strings that did not have a key name associated with them. */
+    values?: string[];
+
+    /** Classes to attach to the outermost element. */
+    classes?: string;
+
+    /**
+     * By default Documents are embedded inside a figure element. If this option is
+     * passed, the embed content will instead be included as part of the rest of the
+     * content flow, but still wrapped in a section tag for styling purposes.
+     * @default false
+     */
+    inline?: boolean;
+
+    /**
+     * Whether to include a content link to the original Document as a citation. This
+     * options is ignored if the Document is inlined.
+     * @default true
+     */
+    cite?: boolean;
+
+    /**
+     * Whether to include a caption. The caption will depend on the Document being
+     * embedded, but if an explicit label is provided, that will always be used as the
+     * caption. This option is ignored if the Document is inlined.
+     * @default true
+     */
+    caption?: boolean;
+
+    /**
+     * Controls whether the caption is rendered above or below the embedded content.
+     * @default "bottom"
+     */
+    captionPosition?: 'top' | 'bottom';
+
+    /** The label. */
+    label?: string;
+}
+
+/**
+ * Options for enriching HTML content with various dynamic features.
+ */
+declare interface EnrichmentOptions {
+    /**
+     * Include unrevealed secret tags in the final HTML? If false, unrevealed secret blocks will be removed.
+     * @default false
+     */
+    secrets?: boolean;
+
+    /**
+     * Replace dynamic document links?
+     * @default true
+     */
+    documents?: boolean;
+
+    /**
+     * Replace hyperlink content?
+     * @default true
+     */
+    links?: boolean;
+
+    /**
+     * Replace inline dice rolls?
+     * @default true
+     */
+    rolls?: boolean;
+
+    /**
+     * Replace embedded content?
+     * @default true
+     */
+    embeds?: boolean;
+
+    /**
+     * The data object providing context for inline rolls, or a function that produces it.
+     */
+    rollData?: object | Function;
+
+    /**
+     * A document to resolve relative UUIDs against.
+     */
+    relativeTo?: ClientDocument;
+}
+
+declare interface CreateDocumentLinkOptions {
+    /**
+     * A document to generate a link relative to.
+     */
+    relativeTo?: ClientDocument;
+
+    /**
+     * A custom label to use instead of the document's name.
+     */
+    label?: string;
+}
+
 declare function _ClientDocumentMixin<
     Schema extends foundry.abstract.DataModel = foundry.abstract.DataModel,
     Parent extends foundry.abstract.Document | null = null,
@@ -25,7 +126,10 @@ declare class ClientDocument {
     /**
      * Lazily obtain a FormApplication instance used to configure this Document, or null if no sheet is available.
      */
-    get sheet(): Application | foundry.applications.api.ApplicationV2 | null;
+    get sheet():
+        | Application
+        | foundry.applications.api.ApplicationV2<any, any, any>
+        | null;
 
     /**
      * Apply transformations of derivations to the values of the source data object.
@@ -56,4 +160,78 @@ declare class ClientDocument {
     public toAnchor(
         options?: Partial<TextEditor.EnrichmentAnchorOptions>,
     ): HTMLAnchorElement;
+
+    /**
+     * Convert a Document to some HTML display for embedding purposes.
+     * @param config            Configuration for embedding behavior.
+     * @param options           The original enrichment options for cases where the Document embed
+     *                               content also contains text that must be enriched.
+     * @returns                 A representation of the Document as HTML content, or null if such a
+     *                          representation could not be generated.
+     */
+    public async toEmbed(
+        config: DocumentHTMLEmbedConfig,
+        options?: EnrichmentOptions,
+    ): Promise<HTMLElement | null>;
+
+    /**
+     * A method that can be overridden by subclasses to customize embedded HTML generation.
+     * @param config            Configuration for embedding behavior.
+     * @param options           The original enrichment options for cases where the Document embed
+     *                               content also contains text that must be enriched.
+     * @returns                 Either a single root element to append, or a collection of
+     *                          elements that comprise the embedded content.
+     */
+    protected async _buildEmbedHTML(
+        config: DocumentHTMLEmbedConfig,
+        options?: EnrichmentOptions,
+    ): Promise<HTMLElement | HTMLCollection | null>;
+
+    /**
+     * A method that can be overridden by subclasses to customize inline embedded HTML generation.
+     * @param content           The embedded content.
+     * @param config            Configuration for embedding behavior.
+     * @param options           The original enrichment options for cases where the Document embed
+     *                          content also contains text that must be enriched.
+     */
+    protected async _createInlineEmbed(
+        content: HTMLElement | HTMLCollection,
+        config: DocumentHTMLEmbedConfig,
+        options?: EnrichmentOptions,
+    ): Promise<HTMLElement | null>;
+
+    /**
+     * A method that can be overridden by subclasses to customize the generation of the embed figure.
+     * @param content           The embedded content.
+     * @param config            Configuration for embedding behavior.
+     * @param options           The original enrichment options for cases where the Document embed
+     *                          content also contains text that must be enriched.
+     */
+    protected async _createFigureEmbed(
+        content: HTMLElement | HTMLCollection,
+        config: DocumentHTMLEmbedConfig,
+        options?: EnrichmentOptions,
+    ): Promise<HTMLElement | null>;
+
+    /**
+     * Create a content link for this document.
+     * @param eventData         The parsed object of data provided by the drop transfer event.
+     * @param options           Additional options to configure link generation.
+     */
+    protected _createDocumentLink(
+        eventData: object,
+        options?: CreateDocumentLinkOptions,
+    ): string;
+
+    /**
+     * Handle clicking on a content link for this document.
+     * @param event             The triggering click event.
+     */
+    protected _onClickDocumentLink(event: MouseEvent): any;
+
+    /**
+     * Serialize salient information about this Document when dragging it.
+     * @returns                 An object of drag data.
+     */
+    public toDragData(): object;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ import * as dataModels from './system/data';
 import * as documents from './system/documents';
 import * as dice from './system/dice';
 
+import Editor from './system/ui/editor';
+
 import CosmereAPI from './system/api';
 import CosmereUtils from './system/utils/global';
 
@@ -160,6 +162,9 @@ Hooks.once('init', async () => {
 
     // Load templates
     await preloadHandlebarsTemplates();
+
+    // Activate the editor listeners
+    Editor.activateListeners();
 
     // Set configuration through API
     applications.actor.configure();

--- a/src/style/sheets/journal.scss
+++ b/src/style/sheets/journal.scss
@@ -1,0 +1,10 @@
+.sheet.journal-sheet {
+    section[data-link] {
+        h2, h3 {
+            > a {
+                vertical-align: super;
+                font-size: 10pt;
+            }
+        }
+    }
+}

--- a/src/style/sheets/module.scss
+++ b/src/style/sheets/module.scss
@@ -3,3 +3,4 @@
 
 @import './actor/module.scss';
 @import './item/module.scss';
+@import './journal.scss';

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -355,7 +355,7 @@ export class CosmereItem<
     }
     protected override _buildEmbedHTML(
         config: DocumentHTMLEmbedConfig,
-        options?: EnrichmentOptions,
+        options?: TextEditor.EnrichmentOptions,
     ): Promise<HTMLElement | HTMLCollection | null> {
         const embedHelpers = getEmbedHelpers(this);
         return (
@@ -367,7 +367,7 @@ export class CosmereItem<
     protected override _createInlineEmbed(
         content: HTMLElement | HTMLCollection,
         config: DocumentHTMLEmbedConfig,
-        options?: EnrichmentOptions,
+        options?: TextEditor.EnrichmentOptions,
     ): Promise<HTMLElement | null> {
         const embedHelpers = getEmbedHelpers(this);
         return (
@@ -379,7 +379,7 @@ export class CosmereItem<
     protected override _createFigureEmbed(
         content: HTMLElement | HTMLCollection,
         config: DocumentHTMLEmbedConfig,
-        options?: EnrichmentOptions,
+        options?: TextEditor.EnrichmentOptions,
     ): Promise<HTMLElement | null> {
         const embedHelpers = getEmbedHelpers(this);
         return (

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -73,6 +73,7 @@ import {
 } from '@system/utils/generic';
 import { EnricherData } from '../utils/enrichers';
 import { renderSystemTemplate, TEMPLATES } from '@system/utils/templates';
+import { getEmbedHelpers } from '@system/utils/embed';
 
 // Dialogs
 import { AttackConfigurationDialog } from '@system/applications/dialogs/attack-configuration';
@@ -351,6 +352,40 @@ export class CosmereItem<
                 this.handleGoalComplete();
             }
         }
+    }
+    protected override _buildEmbedHTML(
+        config: DocumentHTMLEmbedConfig,
+        options?: EnrichmentOptions,
+    ): Promise<HTMLElement | HTMLCollection | null> {
+        const embedHelpers = getEmbedHelpers(this);
+        return (
+            embedHelpers.buildEmbedHTML?.(this, config, options) ??
+            super._buildEmbedHTML(config, options)
+        );
+    }
+
+    protected override _createInlineEmbed(
+        content: HTMLElement | HTMLCollection,
+        config: DocumentHTMLEmbedConfig,
+        options?: EnrichmentOptions,
+    ): Promise<HTMLElement | null> {
+        const embedHelpers = getEmbedHelpers(this);
+        return (
+            embedHelpers.createInlineEmbed?.(this, content, config, options) ??
+            super._createInlineEmbed(content, config, options)
+        );
+    }
+
+    protected override _createFigureEmbed(
+        content: HTMLElement | HTMLCollection,
+        config: DocumentHTMLEmbedConfig,
+        options?: EnrichmentOptions,
+    ): Promise<HTMLElement | null> {
+        const embedHelpers = getEmbedHelpers(this);
+        return (
+            embedHelpers.createFigureEmbed?.(this, content, config, options) ??
+            super._createFigureEmbed(content, config, options)
+        );
     }
 
     /* --- Event handlers --- */

--- a/src/system/ui/editor.ts
+++ b/src/system/ui/editor.ts
@@ -1,0 +1,50 @@
+import { AnyMutableObject, CosmereDocument } from '@system/types/utils';
+
+export function activateListeners() {
+    const body = $('body');
+    body.on('dragstart', 'section[data-link]', _onDragContentLink);
+}
+
+/**
+ * Begin a Drag+Drop workflow for a dynamic content link
+ * @param event   The originating drag event
+ * @private
+ */
+function _onDragContentLink(event: JQueryEventObject) {
+    event.stopPropagation();
+    const a = event.currentTarget as HTMLElement;
+    let dragData: AnyMutableObject | null = null;
+
+    // Case 1 - Compendium Link
+    if (a.dataset.pack) {
+        const pack = game.packs!.get(a.dataset.pack)!;
+        let id = a.dataset.id;
+        if (a.dataset.lookup && pack.index.size) {
+            const entry = pack.index.find(
+                (i) =>
+                    i._id === a.dataset.lookup ||
+                    (i as unknown as { name: string }).name ===
+                        a.dataset.lookup,
+            );
+            if (entry) id = entry._id;
+        }
+        if (!a.dataset.uuid && !id) return false;
+        const uuid = a.dataset.uuid ?? pack.getUuid(id!);
+        dragData = { type: a.dataset.type ?? pack.documentName, uuid };
+    }
+
+    // Case 2 - World Document Link
+    else {
+        const doc = fromUuidSync(a.dataset.uuid!) as CosmereDocument;
+        dragData = doc.toDragData() as AnyMutableObject;
+    }
+
+    (event.originalEvent as DragEvent).dataTransfer!.setData(
+        'text/plain',
+        JSON.stringify(dragData),
+    );
+}
+
+export default {
+    activateListeners,
+};

--- a/src/system/utils/embed/index.ts
+++ b/src/system/utils/embed/index.ts
@@ -1,0 +1,15 @@
+import { CosmereItem } from '@system/documents/item';
+
+// Embed helpers
+import getItemEmbedHelpers from './item';
+
+export function getEmbedHelpers(document: foundry.abstract.Document) {
+    switch (document.documentName) {
+        case 'Item':
+            return getItemEmbedHelpers((document as CosmereItem).type);
+        default:
+            return {}; // No embed helpers available for this document type
+    }
+}
+
+export default getEmbedHelpers;

--- a/src/system/utils/embed/item/generic.ts
+++ b/src/system/utils/embed/item/generic.ts
@@ -1,0 +1,85 @@
+import { CosmereItem } from '@system/documents/item';
+
+// Constants
+import { TEMPLATES, renderSystemTemplate } from '@system/utils/templates';
+const ITEM_EMBED_TEMPLATES: Record<string, string | undefined> = {
+    talent: TEMPLATES.ITEM_TALENT_EMBED,
+};
+
+export async function buildEmbedHTML(
+    item: CosmereItem,
+    config: DocumentHTMLEmbedConfig,
+    options?: EnrichmentOptions,
+): Promise<HTMLElement | HTMLCollection | null> {
+    if (!ITEM_EMBED_TEMPLATES[item.type]) return null;
+
+    // Create the link data string
+    const linkDataStr = getLinkDataStr(item);
+
+    // Enrich the description
+    let description = null;
+    if (item.hasDescription())
+        description = await TextEditor.enrichHTML(
+            item.system.description?.value ??
+                item.system.description?.short ??
+                '',
+        );
+
+    // Render template
+    const html = await renderSystemTemplate(ITEM_EMBED_TEMPLATES[item.type]!, {
+        item,
+        config,
+        options,
+        linkDataStr,
+        description,
+    });
+
+    // Get elements
+    const template = document.createElement('template');
+    template.innerHTML = html;
+    return template.content.children;
+}
+
+export function createInlineEmbed(
+    item: Item,
+    content: HTMLElement | HTMLCollection,
+    config: DocumentHTMLEmbedConfig,
+    options?: EnrichmentOptions,
+): Promise<HTMLElement | null> {
+    const section = document.createElement('section');
+    if (content instanceof HTMLCollection) section.append(...content);
+    else section.append(content);
+
+    section.classList.add('item-embed', 'talent');
+
+    // Parse the uuid
+    const { id, uuid, collection } = foundry.utils.parseUuid(item.uuid);
+
+    // Set attributes
+    section.setAttribute('draggable', 'true');
+    section.setAttribute('data-link', '');
+    section.dataset.uuid = uuid;
+    section.dataset.id = id;
+    section.dataset.type = item.documentName;
+
+    if (collection instanceof CompendiumCollection)
+        section.dataset.pack = collection.collection as string;
+
+    return Promise.resolve(section);
+}
+
+export function getLinkDataStr(
+    item: Item,
+    dataset?: Record<string, string>,
+): string {
+    // Generate content link
+    const link = item.toAnchor({ dataset });
+
+    // Get the dataset
+    const outputDataset = link.dataset;
+
+    // Create data string
+    return Object.entries(outputDataset)
+        .map(([key, value]) => `data-${key}="${value}"`)
+        .join(' ');
+}

--- a/src/system/utils/embed/item/generic.ts
+++ b/src/system/utils/embed/item/generic.ts
@@ -45,7 +45,7 @@ export function createInlineEmbed(
     item: Item,
     content: HTMLElement | HTMLCollection,
     config: DocumentHTMLEmbedConfig,
-    options?: EnrichmentOptions,
+    options?: TextEditor.EnrichmentOptions,
 ): Promise<HTMLElement | null> {
     const section = document.createElement('section');
     if (content instanceof HTMLCollection) section.append(...content);

--- a/src/system/utils/embed/item/generic.ts
+++ b/src/system/utils/embed/item/generic.ts
@@ -9,7 +9,7 @@ const ITEM_EMBED_TEMPLATES: Record<string, string | undefined> = {
 export async function buildEmbedHTML(
     item: CosmereItem,
     config: DocumentHTMLEmbedConfig,
-    options?: EnrichmentOptions,
+    options?: TextEditor.EnrichmentOptions,
 ): Promise<HTMLElement | HTMLCollection | null> {
     if (!ITEM_EMBED_TEMPLATES[item.type]) return null;
 
@@ -23,6 +23,7 @@ export async function buildEmbedHTML(
             item.system.description?.value ??
                 item.system.description?.short ??
                 '',
+            options,
         );
 
     // Render template
@@ -50,7 +51,7 @@ export function createInlineEmbed(
     if (content instanceof HTMLCollection) section.append(...content);
     else section.append(content);
 
-    section.classList.add('item-embed', 'talent');
+    section.classList.add('item-embed', item.type);
 
     // Parse the uuid
     const { id, uuid, collection } = foundry.utils.parseUuid(item.uuid);

--- a/src/system/utils/embed/item/index.ts
+++ b/src/system/utils/embed/item/index.ts
@@ -1,0 +1,36 @@
+// Types
+import { ItemType } from '@system/types/cosmere';
+import { EmbedHelpers } from '../types';
+
+// Embedders
+import talentEmbed from './talent';
+
+const EMBEDDERS: Record<ItemType, EmbedHelpers> = {
+    [ItemType.Weapon]: {},
+    [ItemType.Armor]: {},
+    [ItemType.Equipment]: {},
+    [ItemType.Loot]: {},
+
+    [ItemType.Ancestry]: {},
+    [ItemType.Culture]: {},
+    [ItemType.Path]: {},
+    [ItemType.Specialty]: {},
+    [ItemType.Talent]: talentEmbed,
+    [ItemType.Trait]: {},
+
+    [ItemType.Action]: {},
+
+    [ItemType.Injury]: {},
+    [ItemType.Connection]: {},
+    [ItemType.Goal]: {},
+
+    [ItemType.Power]: {},
+
+    [ItemType.TalentTree]: {},
+};
+
+export function getEmbedHelpers(type: ItemType) {
+    return EMBEDDERS[type] ?? {};
+}
+
+export default getEmbedHelpers;

--- a/src/system/utils/embed/item/talent.ts
+++ b/src/system/utils/embed/item/talent.ts
@@ -12,7 +12,7 @@ import { TEMPLATES, renderSystemTemplate } from '@system/utils/templates';
 export async function buildEmbedHTML(
     item: TalentItem,
     config: DocumentHTMLEmbedConfig,
-    options?: EnrichmentOptions,
+    options?: TextEditor.EnrichmentOptions,
 ): Promise<HTMLElement | HTMLCollection | null> {
     // Create the link data string
     const linkDataStr = getLinkDataStr(item);
@@ -39,6 +39,7 @@ export async function buildEmbedHTML(
     // Enrich the description
     const description = await TextEditor.enrichHTML(
         item.system.description?.value ?? item.system.description?.short ?? '',
+        options,
     );
 
     // Render template

--- a/src/system/utils/embed/item/talent.ts
+++ b/src/system/utils/embed/item/talent.ts
@@ -1,0 +1,63 @@
+import { TalentTree } from '@system/types/item';
+
+// Documents
+import { TalentItem, TalentTreeItem } from '@system/documents/item';
+
+// Generics
+import { createInlineEmbed, getLinkDataStr } from './generic';
+
+// Constants
+import { TEMPLATES, renderSystemTemplate } from '@system/utils/templates';
+
+export async function buildEmbedHTML(
+    item: TalentItem,
+    config: DocumentHTMLEmbedConfig,
+    options?: EnrichmentOptions,
+): Promise<HTMLElement | HTMLCollection | null> {
+    // Create the link data string
+    const linkDataStr = getLinkDataStr(item);
+
+    // Assign prerequisite based on the config
+    let prerequisite = null;
+    if (config.tree && typeof config.tree === 'string') {
+        const tree = (await fromUuid(config.tree)) as unknown as TalentTreeItem;
+
+        // Find the talent node in the tree (ignore nested trees)
+        const node = tree.system.nodes.find(
+            (n) =>
+                n.type === TalentTree.Node.Type.Talent &&
+                n.talentId === item.system.id,
+        ) as TalentTree.TalentNode | undefined;
+
+        if (node) {
+            prerequisite = node.prerequisites;
+        }
+    } else if (config.prerequisite && typeof config.prerequisite === 'string') {
+        prerequisite = config.prerequisite;
+    }
+
+    // Enrich the description
+    const description = await TextEditor.enrichHTML(
+        item.system.description?.value ?? item.system.description?.short ?? '',
+    );
+
+    // Render template
+    const html = await renderSystemTemplate(TEMPLATES.ITEM_TALENT_EMBED, {
+        item,
+        config,
+        options,
+        linkDataStr,
+        prerequisite,
+        description,
+    });
+
+    // Get elements
+    const template = document.createElement('template');
+    template.innerHTML = html;
+    return template.content.children;
+}
+
+export default {
+    buildEmbedHTML,
+    createInlineEmbed,
+};

--- a/src/system/utils/embed/types.ts
+++ b/src/system/utils/embed/types.ts
@@ -2,18 +2,18 @@ export interface EmbedHelpers {
     buildEmbedHTML?(
         document: foundry.abstract.Document,
         config: DocumentHTMLEmbedConfig,
-        options?: EnrichmentOptions,
+        options?: TextEditor.EnrichmentOptions,
     ): Promise<HTMLElement | HTMLCollection | null>;
     createInlineEmbed?(
         document: foundry.abstract.Document,
         content: HTMLElement | HTMLCollection,
         config: DocumentHTMLEmbedConfig,
-        options?: EnrichmentOptions,
+        options?: TextEditor.EnrichmentOptions,
     ): Promise<HTMLElement | null>;
     createFigureEmbed?(
         document: foundry.abstract.Document,
         content: HTMLElement | HTMLCollection,
         config: DocumentHTMLEmbedConfig,
-        options?: EnrichmentOptions,
+        options?: TextEditor.EnrichmentOptions,
     ): Promise<HTMLElement | null>;
 }

--- a/src/system/utils/embed/types.ts
+++ b/src/system/utils/embed/types.ts
@@ -1,0 +1,19 @@
+export interface EmbedHelpers {
+    buildEmbedHTML?(
+        document: foundry.abstract.Document,
+        config: DocumentHTMLEmbedConfig,
+        options?: EnrichmentOptions,
+    ): Promise<HTMLElement | HTMLCollection | null>;
+    createInlineEmbed?(
+        document: foundry.abstract.Document,
+        content: HTMLElement | HTMLCollection,
+        config: DocumentHTMLEmbedConfig,
+        options?: EnrichmentOptions,
+    ): Promise<HTMLElement | null>;
+    createFigureEmbed?(
+        document: foundry.abstract.Document,
+        content: HTMLElement | HTMLCollection,
+        config: DocumentHTMLEmbedConfig,
+        options?: EnrichmentOptions,
+    ): Promise<HTMLElement | null>;
+}

--- a/src/system/utils/handlebars/index.ts
+++ b/src/system/utils/handlebars/index.ts
@@ -70,6 +70,13 @@ Handlebars.registerHelper(
 Handlebars.registerHelper('lower', (str: string) => str.toLowerCase());
 Handlebars.registerHelper('upper', (str: string) => str.toUpperCase());
 
+Handlebars.registerHelper('typeof', (value: unknown) => {
+    if (value === null) return 'null';
+    if (value === undefined) return 'undefined';
+    if (Array.isArray(value)) return 'array';
+    return typeof value;
+});
+
 Handlebars.registerHelper(
     'perc',
     (value: number, max: number, floor = true) => {

--- a/src/system/utils/templates.ts
+++ b/src/system/utils/templates.ts
@@ -133,6 +133,9 @@ export const TEMPLATES = {
     ITEM_GOAL_REWARDS_LIST: 'item/goal/components/rewards-list.hbs',
     ITEM_TALENT_GRANT_RULES_LIST: 'item/talent/components/grant-rules-list.hbs',
 
+    // ITEM EMBEDDINGS
+    ITEM_TALENT_EMBED: 'item/talent/embed.hbs',
+
     //CHAT
     CHAT_CARD_HEADER: 'chat/card-header.hbs',
     CHAT_CARD_CONTENT: 'chat/card-content.hbs',

--- a/src/templates/item/talent/embed.hbs
+++ b/src/templates/item/talent/embed.hbs
@@ -1,0 +1,61 @@
+<h3>
+    <span>{{default config.label item.name}}</span>
+    <a {{{linkDataStr}}}>
+        <i class="fa-solid fa-up-right-from-square"></i>
+    </a>
+</h3>
+
+{{#if prerequisite}}
+    <p>
+        <span class="fontstyle2"><strong>Prerequisite:</strong></span>
+
+        {{#if (eq (typeof prerequisite) "string")}}
+            <span>{{{prerequisite}}}</span>
+        {{else}}
+            {{#if (eq prerequisite.size 0)}}
+                <span>none</span>
+            {{else}}
+                {{#each prerequisite as |prereq|}}
+                    {{#if (eq prereq.type "talent")}}
+                        {{#each prereq.talents as |talent|}}
+                            <span>{{talent.label}}</span>
+                            <span>
+                                {{lower (localize "GENERIC.Talent")}}{{#unless (or (not @last) @../last)}};{{/unless}}
+                            </span>
+                            {{#if (not @last)}}
+                                <span>or</span>  
+                            {{/if}}
+                        {{/each}}
+                    {{else if (eq prereq.type "attribute")}}
+                        <span>{{localize (concat "COSMERE.Attribute." prereq.attribute)}}</span>
+                        <span>
+                            {{prereq.value}}+{{#unless @last}};{{/unless}}
+                        </span>
+                    {{else if (eq prereq.type "skill")}}
+                        <span>{{localize (concat "COSMERE.Skill." prereq.skill)}}</span>
+                        <span>
+                            {{prereq.rank}}+{{#unless @last}};{{/unless}}
+                        </span>
+                    {{else if (eq prereq.type "level")}}
+                        <span>{{localize "GENERIC.Level"}}</span>
+                        <span>
+                            {{prereq.level}}+{{#unless @last}};{{/unless}}
+                        </span>
+                    {{else if (eq prereq.type "connection")}}
+                        <span>
+                            {{prereq.description}}{{#unless @last}};{{/unless}}
+                        </span>
+                    {{else if (eq prereq.type "ancestry")}}
+                        <span>{{prereq.ancestry.label}}</span>
+                        <span>{{lower (localize "GENERIC.Ancestry")}}{{#unless @last}};{{/unless}}</span>
+                    {{else if (eq prereq.type "culture")}}
+                        <span>{{prereq.culture.label}}</span>
+                        <span>{{lower (localize "GENERIC.Culture")}}{{#unless @last}};{{/unless}}</span>
+                    {{/if}}
+                {{/each}}
+            {{/if}}
+        {{/if}}
+    </p>
+{{/if}}
+
+{{{description}}}


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Adds `@Embed` support for talents and provides general scaffolding for `@Embed` support for other documents.

**Related Issue**  
Partially addresses #422 

**How Has This Been Tested?**  
1. Create journal
2. Create page
3. Edit page
4. Drag talent onto page
5. Change `@UUID` into `@Embed`, remove the label, and set inline
6. Save page
7. Ensure talent renders
8. Click link in header and ensure item opens
9. Drag talent from journal directly onto sheet (grab anywhere)
10. Edit page
11. Add `tree=<uuid>` within the square brackets, where `uuid` is that of a talent tree that contains the talent. 
12. Save page
13. Ensure talent renders and prerequisites are included

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/43ae60de-a7fa-40f6-a63c-8018c79188e9)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343