### PR TITLE
feat(item embed): add culture embed support

### DIFF
--- a/src/system/utils/embed/item/culture.ts
+++ b/src/system/utils/embed/item/culture.ts
@@ -1,0 +1,7 @@
+// Generics
+import { createInlineEmbed, buildEmbedHTML, getLinkDataStr } from './generic';
+
+export default {
+    buildEmbedHTML,
+    createInlineEmbed,
+};

--- a/src/system/utils/embed/item/generic.ts
+++ b/src/system/utils/embed/item/generic.ts
@@ -4,6 +4,7 @@ import { CosmereItem } from '@system/documents/item';
 import { TEMPLATES, renderSystemTemplate } from '@system/utils/templates';
 const ITEM_EMBED_TEMPLATES: Record<string, string | undefined> = {
     talent: TEMPLATES.ITEM_TALENT_EMBED,
+    culture: TEMPLATES.ITEM_CULTURE_EMBED,
 };
 
 export async function buildEmbedHTML(

--- a/src/system/utils/embed/item/index.ts
+++ b/src/system/utils/embed/item/index.ts
@@ -3,6 +3,7 @@ import { ItemType } from '@system/types/cosmere';
 import { EmbedHelpers } from '../types';
 
 // Embedders
+import cultureEmbed from './culture';
 import talentEmbed from './talent';
 
 const EMBEDDERS: Record<ItemType, EmbedHelpers> = {
@@ -12,7 +13,7 @@ const EMBEDDERS: Record<ItemType, EmbedHelpers> = {
     [ItemType.Loot]: {},
 
     [ItemType.Ancestry]: {},
-    [ItemType.Culture]: {},
+    [ItemType.Culture]: cultureEmbed,
     [ItemType.Path]: {},
     [ItemType.Specialty]: {},
     [ItemType.Talent]: talentEmbed,

--- a/src/system/utils/templates.ts
+++ b/src/system/utils/templates.ts
@@ -135,6 +135,7 @@ export const TEMPLATES = {
 
     // ITEM EMBEDDINGS
     ITEM_TALENT_EMBED: 'item/talent/embed.hbs',
+    ITEM_CULTURE_EMBED: 'item/culture/embed.hbs',
 
     //CHAT
     CHAT_CARD_HEADER: 'chat/card-header.hbs',

--- a/src/templates/item/culture/embed.hbs
+++ b/src/templates/item/culture/embed.hbs
@@ -1,0 +1,8 @@
+<h3>
+    <span>{{default config.label item.name}}</span>
+    <a {{{linkDataStr}}}>
+        <i class="fa-solid fa-up-right-from-square"></i>
+    </a>
+</h3>
+
+{{{description}}}


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Adds `@Embed` support for cultures

**Related Issue**  
Partially addresses #422

**How Has This Been Tested?**  
1. Create journal
2. Create page
3. Edit page
4. Drag culture onto the page
5. Change `@UUID` into `@Embed`, remove the label, and set inline
6. Save page
7. Ensure culture renders
8. Click link in the header and ensure item opens
9. Drag culture from journal directly onto sheet (grab anywhere)

**Screenshots (if applicable)**
![image](https://github.com/user-attachments/assets/d035613c-ee2d-4710-a6c2-f35329ce209a)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343