### PR TITLE
feat(item embed): add talent tree embed support

### DIFF
--- a/src/style/sheets/journal.scss
+++ b/src/style/sheets/journal.scss
@@ -7,4 +7,37 @@
             }
         }
     }
+
+    section.item-embed.talent-tree {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+
+        .embed {
+            > section {
+                position: relative;
+                display: flex;
+                flex: 1;
+
+                width: 100%;
+                height: 100%;
+
+                .controls {
+                    position: absolute;
+                    top: .2em;
+                    right: .2em;
+                    z-index: 1;
+
+                    font-weight: bold;
+                    font-size: 1.2em;
+                    color: var(--cosmere-color-accent);
+                }
+
+                > app-talent-tree-view {
+                    width: 100%;
+                    height: 100%;
+                }
+            }
+        }
+    }
 }

--- a/src/system/applications/item/base.ts
+++ b/src/system/applications/item/base.ts
@@ -17,7 +17,10 @@ import { renderSystemTemplate, TEMPLATES } from '@src/system/utils/templates';
 
 // Mixins
 import { ComponentHandlebarsApplicationMixin } from '@system/applications/component-system';
-import { TabsApplicationMixin } from '@system/applications/mixins';
+import {
+    TabsApplicationMixin,
+    TabApplicationRenderOptions,
+} from '@system/applications/mixins';
 import { DescriptionItemData } from '@src/system/data/item/mixins/description';
 import { ItemConsumeData } from '@src/system/data/item/mixins/activatable';
 import { SYSTEM_ID } from '@src/system/constants';
@@ -28,9 +31,16 @@ export interface BaseItemSheetRenderContext {
     item: CosmereItem;
 }
 
+export type BaseItemSheetConfiguration =
+    foundry.applications.api.DocumentSheetV2.Configuration;
+
+export interface BaseItemSheetRenderOptions
+    extends foundry.applications.api.DocumentSheetV2.RenderOptions,
+        TabApplicationRenderOptions {}
+
 export class BaseItemSheet extends TabsApplicationMixin(
     ComponentHandlebarsApplicationMixin(ItemSheetV2),
-)<AnyObject> {
+)<AnyObject, BaseItemSheetConfiguration, BaseItemSheetRenderOptions> {
     /**
      * NOTE: Unbound methods is the standard for defining actions and forms
      * within ApplicationV2

--- a/src/system/applications/item/embeds/talent-tree-embed.ts
+++ b/src/system/applications/item/embeds/talent-tree-embed.ts
@@ -1,0 +1,115 @@
+import { DeepPartial, AnyObject } from '@system/types/utils';
+
+// Documents
+import { CosmereItem, TalentTreeItem } from '@system/documents/item';
+
+// Mixins
+import { ComponentHandlebarsApplicationMixin } from '@system/applications/component-system';
+
+// ApplicationV2
+const { ApplicationV2 } = foundry.applications.api;
+
+// Components
+import { TalentTreeViewComponent } from '@system/applications/item/components/talent-tree/talent-tree-view';
+
+// Canvas
+import { Viewport } from '@system/applications/canvas';
+
+// Utils
+import { getLinkDataStr } from '@system/utils/embed/item/generic';
+
+// Constants
+import { SYSTEM_ID } from '@src/system/constants';
+import { TEMPLATES } from '@src/system/utils/templates';
+import HandlebarsApplicationMixin from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/client-esm/applications/api/handlebars-application.mjs';
+
+interface TalentTreeEmbedConfiguration
+    extends DeepPartial<foundry.applications.api.ApplicationV2.Configuration> {
+    item: TalentTreeItem;
+    linkedItem?: CosmereItem;
+    view?: Viewport.View;
+}
+
+interface TalentTreeEmbedRenderContext extends AnyObject {
+    item: TalentTreeItem;
+}
+
+export class TalentTreeEmbed extends ComponentHandlebarsApplicationMixin(
+    ApplicationV2,
+)<TalentTreeEmbedRenderContext> {
+    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
+        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
+        {
+            classes: [SYSTEM_ID, 'embed', 'talent-tree'],
+            position: {
+                width: 600,
+                top: 0,
+                left: 0,
+            },
+            window: {
+                frame: false,
+            },
+            tag: 'div',
+        },
+    );
+
+    static PARTS = foundry.utils.mergeObject(
+        foundry.utils.deepClone(super.PARTS),
+        {
+            content: {
+                template: `systems/${SYSTEM_ID}/templates/${TEMPLATES.ITEM_TALENT_TREE_EMBED}`,
+            },
+        },
+    );
+
+    #item: TalentTreeItem;
+
+    public view?: Partial<Omit<Viewport.View, 'width' | 'height'>>;
+    public linkedItem?: CosmereItem;
+
+    public constructor(options: TalentTreeEmbedConfiguration) {
+        // Get the aspect ratio of the talent tree
+        const aspectRatio =
+            options.item.system.viewBounds.width /
+            options.item.system.viewBounds.height;
+
+        // Get configured width
+        const width = (options.position?.width ??
+            TalentTreeEmbed.DEFAULT_OPTIONS.position!.width!) as number;
+
+        // Calculate height based on aspect ratio
+        const height = width / aspectRatio;
+
+        super(
+            foundry.utils.mergeObject(options, {
+                position: {
+                    height: height,
+                },
+            }),
+        );
+        this.#item = options.item;
+        this.view = options.view;
+        this.linkedItem = options.linkedItem;
+    }
+
+    /* --- Accessors --- */
+
+    public get item(): TalentTreeItem {
+        return this.#item;
+    }
+
+    /* --- Context --- */
+
+    public async _prepareContext(
+        options: DeepPartial<foundry.applications.api.ApplicationV2.RenderOptions>,
+    ) {
+        return {
+            ...(await super._prepareContext(options)),
+            item: this.item,
+            view: this.view,
+            linkDataStr: getLinkDataStr(this.linkedItem ?? this.item, {
+                tab: 'talents',
+            }),
+        };
+    }
+}

--- a/src/system/applications/item/mixins/talents-tab.ts
+++ b/src/system/applications/item/mixins/talents-tab.ts
@@ -1,5 +1,5 @@
 import { TalentTreeItem } from '@system/documents/item';
-import { ConstructorOf, DeepPartial } from '@system/types/utils';
+import { ConstructorOf, DeepPartial, AnyObject } from '@system/types/utils';
 import { Talent } from '@system/types/item';
 
 // Components
@@ -36,7 +36,7 @@ export function TalentsTabMixin<
 
         /* --- Lifecycle --- */
 
-        protected _onFirstRender(context: unknown, options: unknown): void {
+        protected _onFirstRender(context: AnyObject, options: unknown): void {
             super._onFirstRender(context, options);
 
             // Invoke on tab change

--- a/src/system/applications/mixins/tabs.ts
+++ b/src/system/applications/mixins/tabs.ts
@@ -37,6 +37,14 @@ export interface ApplicationTab {
     enabled?: boolean;
 }
 
+export interface TabApplicationRenderOptions
+    extends foundry.applications.api.ApplicationV2.RenderOptions {
+    /**
+     * The initial tab to show for the primary tab group, when rendering the application.
+     */
+    tab?: string;
+}
+
 /**
  * Mixin that adds standardized tabs to an ApplicationV2
  */
@@ -85,6 +93,22 @@ export function TabsApplicationMixin<
         protected onTabChange(tab: string, group: string) {}
 
         /* --- Context --- */
+
+        protected _onFirstRender(
+            context: unknown,
+            options: TabApplicationRenderOptions,
+        ): void {
+            super._onFirstRender(context, options);
+
+            // Set the initial tab for the primary tab group
+            if (
+                options.tab &&
+                this.tabGroups[PRIMARY_TAB_GROUP] !== options.tab &&
+                this.tabs[options.tab]
+            ) {
+                this.changeTab(options.tab, PRIMARY_TAB_GROUP);
+            }
+        }
 
         public async _prepareContext(
             options: Partial<foundry.applications.api.ApplicationV2.RenderOptions>,

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -53,6 +53,9 @@ import { EventsItemData } from '@system/data/item/mixins/events';
 import { DeflectItemData } from '@system/data/item/mixins/deflect';
 import { LinkedSkillsItemData } from '@system/data/item/mixins/linked-skills';
 
+// Sheet
+import { BaseItemSheet } from '@system/applications/item/base';
+
 // Rolls
 import {
     d20Roll,
@@ -338,6 +341,10 @@ export class CosmereItem<
         void this.setFlag(SYSTEM_ID, 'source', value);
     }
 
+    public get sheet(): BaseItemSheet | null {
+        return super.sheet as BaseItemSheet | null;
+    }
+
     /* --- Lifecycle --- */
 
     override _onUpdate(_changes: object, options: object, userId: string) {
@@ -353,6 +360,12 @@ export class CosmereItem<
             }
         }
     }
+
+    protected override _onClickDocumentLink(event: MouseEvent) {
+        const target = event.currentTarget as HTMLElement;
+        return this.sheet?.render(true, { tab: target.dataset.tab });
+    }
+
     protected override _buildEmbedHTML(
         config: DocumentHTMLEmbedConfig,
         options?: TextEditor.EnrichmentOptions,

--- a/src/system/utils/embed/item/index.ts
+++ b/src/system/utils/embed/item/index.ts
@@ -4,6 +4,7 @@ import { EmbedHelpers } from '../types';
 
 // Embedders
 import talentEmbed from './talent';
+import talentTreeEmbed from './talent-tree';
 
 const EMBEDDERS: Record<ItemType, EmbedHelpers> = {
     [ItemType.Weapon]: {},
@@ -26,7 +27,7 @@ const EMBEDDERS: Record<ItemType, EmbedHelpers> = {
 
     [ItemType.Power]: {},
 
-    [ItemType.TalentTree]: {},
+    [ItemType.TalentTree]: talentTreeEmbed,
 };
 
 export function getEmbedHelpers(type: ItemType) {

--- a/src/system/utils/embed/item/talent-tree.ts
+++ b/src/system/utils/embed/item/talent-tree.ts
@@ -1,0 +1,123 @@
+// Documents
+import { TalentTreeItem, CosmereItem } from '@system/documents/item';
+
+// Application
+import { TalentTreeEmbed } from '@system/applications/item/embeds/talent-tree-embed';
+
+const EMBEDDED_APPS: Record<
+    string,
+    Record<string, Record<string, TalentTreeEmbed>>
+> = {};
+
+export async function buildEmbedHTML(
+    item: TalentTreeItem,
+    config: DocumentHTMLEmbedConfig,
+    options?: TextEditor.EnrichmentOptions,
+): Promise<HTMLElement | HTMLCollection | null> {
+    if (!(options?.relativeTo instanceof JournalEntryPage)) return null;
+
+    // Create the embedded application
+    const embededApp = await getEmbedApp(item, options.relativeTo, config);
+
+    // Return target
+    return $(
+        `<div class="embed-talent-tree-target" data-id="${embededApp.id}"></div>`,
+    )[0];
+}
+
+export function createInlineEmbed(
+    item: TalentTreeItem,
+    content: HTMLElement | HTMLCollection,
+    config: DocumentHTMLEmbedConfig,
+    options?: TextEditor.EnrichmentOptions,
+): Promise<HTMLElement | null> {
+    const section = document.createElement('section');
+    if (content instanceof HTMLCollection) section.append(...content);
+    else section.append(content);
+
+    section.classList.add('item-embed', 'talent-tree');
+
+    return Promise.resolve(section);
+}
+
+async function getEmbedApp(
+    item: TalentTreeItem,
+    page: JournalEntryPage,
+    config: DocumentHTMLEmbedConfig,
+): Promise<TalentTreeEmbed> {
+    const journalEntry = page.parent as unknown as JournalEntry;
+
+    if (!EMBEDDED_APPS[journalEntry.uuid])
+        EMBEDDED_APPS[journalEntry.uuid] = {};
+    if (!EMBEDDED_APPS[journalEntry.uuid][page.id])
+        EMBEDDED_APPS[journalEntry.uuid][page.id] = {};
+    if (!EMBEDDED_APPS[journalEntry.uuid][page.id][item.id]) {
+        EMBEDDED_APPS[journalEntry.uuid][page.id][item.id] =
+            new TalentTreeEmbed({
+                item,
+                position: { width: (config.width ?? 600) as number },
+            });
+    }
+
+    const app = EMBEDDED_APPS[journalEntry.uuid][page.id][item.id];
+
+    if (config.x || config.y || config.zoom) {
+        app.view = {};
+
+        if (config.x) app.view.x = config.x as number;
+        if (config.y) app.view.y = config.y as number;
+        if (config.zoom) app.view.zoom = config.zoom as number;
+    } else {
+        app.view = undefined;
+    }
+
+    if (config.link) {
+        app.linkedItem = (await fromUuid(
+            config.link as string,
+        )) as unknown as CosmereItem;
+    }
+
+    return app;
+}
+
+Hooks.on('renderJournalPageSheet', (app: JournalPageSheet, html: JQuery) => {
+    const page = app.document as JournalEntryPage;
+    const journalEntry = page.parent as unknown as JournalEntry;
+
+    if (!EMBEDDED_APPS[journalEntry.uuid]?.[page.id]) return;
+
+    // Get all embedded applications for this page
+    const embedApps = Object.values(EMBEDDED_APPS[journalEntry.uuid][page.id]);
+
+    setTimeout(() => {
+        // Render each embedded application
+        embedApps.forEach(async (embedApp) => {
+            // Render the application
+            await embedApp.render(true);
+
+            // Find and replace the target element in the HTML
+            html.find(
+                `.embed-talent-tree-target[data-id="${embedApp.id}"]`,
+            ).replaceWith(embedApp.element);
+        });
+    }, 10);
+});
+
+Hooks.on('closeJournalSheet', (app: JournalPageSheet) => {
+    const journalEntry = app.document as JournalEntryPage;
+
+    if (!EMBEDDED_APPS[journalEntry.uuid]) return;
+
+    Object.values(EMBEDDED_APPS[journalEntry.uuid]).forEach((pageApps) => {
+        Object.values(pageApps).forEach((embedApp) => {
+            void embedApp.close();
+        });
+    });
+
+    delete EMBEDDED_APPS[journalEntry.uuid];
+});
+
+export default {
+    buildEmbedHTML,
+    createInlineEmbed,
+};

--- a/src/system/utils/templates.ts
+++ b/src/system/utils/templates.ts
@@ -135,6 +135,7 @@ export const TEMPLATES = {
 
     // ITEM EMBEDDINGS
     ITEM_TALENT_EMBED: 'item/talent/embed.hbs',
+    ITEM_TALENT_TREE_EMBED: 'item/talent-tree/embed.hbs',
 
     //CHAT
     CHAT_CARD_HEADER: 'chat/card-header.hbs',

--- a/src/templates/item/talent-tree/embed.hbs
+++ b/src/templates/item/talent-tree/embed.hbs
@@ -1,0 +1,12 @@
+<section>
+    {{app-talent-tree-view
+        tree=item
+        view=view
+        boundView=true
+    }}
+    <div class="controls">
+        <a {{{linkDataStr}}}>
+            <i class="fa-solid fa-up-right-from-square"></i>
+        </a>
+    </div>
+</section>


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Adds `@Embed` support for talent trees.

**Related Issue**  
Partially addresses #422 

**How Has This Been Tested?**  
1. Create journal
2. Create page
3. Edit page
4. Drag talent tree item onto page
5. Replace `@UUID` with `@Embed`, remove label and set inline
6. Save page
7. Ensure talent tree renders
8. Click link in top right corner, and ensure talent tree item opens
9. Edit page
10. Include `link=<uuid>` where `uuid` is the uuid of a Path Item 
11. Save page
12. Click link in top right corner, ensure the linked item's talent tab now opens
13. Edit page
14. Include `x=150 y=150 zoom=.6` (may have to set these to different values for your talent tree)
15. Save page
16. Ensure the talent tree embed is now offset to the specified location and changed to the configured zoom level

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/379c2df2-6a6b-4185-a27c-be11937c7c8d)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343