### PR TITLE
feat(enrichers): add content link enricher

### DIFF
--- a/src/style/sheets/journal.scss
+++ b/src/style/sheets/journal.scss
@@ -1,6 +1,6 @@
 .sheet.journal-sheet {
     section[data-link] {
-        h2, h3 {
+        h1, h2, h3, h4, h5, h6 {
             > a {
                 vertical-align: super;
                 font-size: 10pt;

--- a/src/system/hooks/index.ts
+++ b/src/system/hooks/index.ts
@@ -3,5 +3,6 @@ import './welcome';
 import './actor';
 import './item';
 import './enrichers';
+import './journal';
 
 export { register as registerItemEventSystem } from './item-event-system';

--- a/src/system/hooks/journal.ts
+++ b/src/system/hooks/journal.ts
@@ -1,0 +1,66 @@
+Hooks.on('renderJournalPageSheet', (app: JournalPageSheet, html: JQuery) => {
+    const page = app.document as JournalEntryPage;
+    const journalEntry = page.parent as unknown as JournalEntry;
+
+    html.find('section[data-link].content-link-anchor').each(function (
+        this: HTMLElement,
+    ) {
+        const section = $(this);
+
+        // Find matching closing section
+        const closingSection = section
+            .nextAll('section.content-link-anchor')
+            .first();
+
+        // Ensure a matching closing section exists
+        if (!closingSection.length) return;
+
+        // Remove empty p elements before and after the section
+        section.prev('p:empty').remove();
+        section.next('p:empty').remove();
+
+        // Remove empty p elements before and after the closing section
+        closingSection.prev('p:empty').remove();
+        closingSection.next('p:empty').remove();
+
+        // Get all the content between the sections
+        const content = section.nextUntil(closingSection);
+
+        // Remove the content from the main HTML
+        content.remove();
+
+        // If the first element of the content is a header, add the link
+        const header = content.first().filter('h2');
+        if (header.length) {
+            // Get all data attributes from the section
+            const dataAttributes = section.data();
+            const dataStr = Object.entries(dataAttributes)
+                .map(([key, value]) => `data-${key}="${value}"`)
+                .join(' ');
+
+            // Grab the text of the header
+            const headerText = header.text().trim();
+            if (headerText && header.children().length === 0) {
+                // Clear the header text
+                header.text('');
+
+                // Append the header text as span
+                header.append(`<span>${headerText}</span>`);
+            }
+
+            // Append the link to the header
+            header.append(
+                ` <a ${dataStr}><i class="fa-solid fa-up-right-from-square"></i></a>`,
+            );
+        }
+
+        // Move all the content into the section
+        section.append(content);
+
+        // Remove the closing section
+        closingSection.remove();
+
+        // Replace the content-link-anchor class with pseudo-embed
+        section.removeClass('content-link-anchor').addClass('pseudo-embed');
+    });
+});

--- a/src/system/hooks/journal.ts
+++ b/src/system/hooks/journal.ts
@@ -30,7 +30,7 @@ Hooks.on('renderJournalPageSheet', (app: JournalPageSheet, html: JQuery) => {
         content.remove();
 
         // If the first element of the content is a header, add the link
-        const header = content.first().filter('h2');
+        const header = content.first().filter('h1 h2 h3 h4 h5 h6');
         if (header.length) {
             // Get all data attributes from the section
             const dataAttributes = section.data();

--- a/src/system/hooks/journal.ts
+++ b/src/system/hooks/journal.ts
@@ -30,7 +30,7 @@ Hooks.on('renderJournalPageSheet', (app: JournalPageSheet, html: JQuery) => {
         content.remove();
 
         // If the first element of the content is a header, add the link
-        const header = content.first().filter('h1 h2 h3 h4 h5 h6');
+        const header = content.first().filter('h1, h2, h3, h4, h5, h6');
         if (header.length) {
             // Get all data attributes from the section
             const dataAttributes = section.data();

--- a/src/system/utils/enrichers.ts
+++ b/src/system/utils/enrichers.ts
@@ -56,6 +56,51 @@ export function registerCustomEnrichers() {
         //   pattern: /&(?<type>Reference)\[(?<config>[^\]]+)](?:{(?<label>[^}]+)})?/gi,
         //   enricher: enrichString
         // }
+        {
+            pattern: /@Link\[(?<uuid>.+)\]/gi,
+            enricher: (
+                match: RegExpMatchArray,
+                options?: TextEditor.EnrichmentOptions,
+            ) => {
+                // Get the UUID from the match
+                const uuid = match.groups?.uuid;
+                if (!uuid) return null;
+
+                // Create section element
+                const section = document.createElement('section');
+
+                // Add classes
+                section.classList.add('content-link-anchor');
+
+                // Parse the uuid
+                const { id, collection, type } = foundry.utils.parseUuid(uuid);
+
+                // Set attributes
+                section.setAttribute('draggable', 'true');
+                section.setAttribute('data-link', '');
+                section.dataset.uuid = uuid;
+                section.dataset.id = id;
+                section.dataset.type = type;
+
+                if (collection instanceof CompendiumCollection)
+                    section.dataset.pack = collection.collection as string;
+
+                // Return the section element
+                return section;
+            },
+        },
+        {
+            pattern: /@Link/gi,
+            enricher: (
+                match: RegExpMatchArray,
+                options?: TextEditor.EnrichmentOptions,
+            ) => {
+                // Create section element
+                const section = document.createElement('section');
+                section.classList.add('content-link-anchor');
+                return section;
+            },
+        },
     );
 }
 


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR adds a content link enricher (`@Link`) that can be used to add draggable content linking to any arbitrary journal content. This is useful for when you want embedding-link behavior but the desired journal content doesn't match the `@Embed` output (for example when the Item's description text differs from what you want to have included in the journal).

**Related Issue**  
Partially addresses #422 

**How Has This Been Tested?**  
1. Create journal
2. Create page
3. Edit page
4. Add some journal content, the first line should be a header
5. Drag an item onto the page, before the content
6. Change `@UUID` to `@Link`, remove label
7. Below content add `@Link`, no brackets (serves as closing tag)
8. Save page
9. Ensure header now has link icon
10. Click link icon, ensure it opens the linked document
11. Drag content onto a character sheet, ensure the linked item gets added

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/379fafca-4ee9-49fe-a18b-fca92d00fa74)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343