### PR TITLE
feat(item embed): add action embed support

### DIFF
--- a/src/system/utils/embed/item/action.ts
+++ b/src/system/utils/embed/item/action.ts
@@ -1,0 +1,6 @@
+import { buildEmbedHTML, createInlineEmbed } from './generic';
+
+export default {
+    buildEmbedHTML,
+    createInlineEmbed,
+};

--- a/src/system/utils/embed/item/generic.ts
+++ b/src/system/utils/embed/item/generic.ts
@@ -4,6 +4,7 @@ import { CosmereItem } from '@system/documents/item';
 import { TEMPLATES, renderSystemTemplate } from '@system/utils/templates';
 const ITEM_EMBED_TEMPLATES: Record<string, string | undefined> = {
     talent: TEMPLATES.ITEM_TALENT_EMBED,
+    action: TEMPLATES.ITEM_ACTION_EMBED,
 };
 
 export async function buildEmbedHTML(

--- a/src/system/utils/embed/item/index.ts
+++ b/src/system/utils/embed/item/index.ts
@@ -4,6 +4,7 @@ import { EmbedHelpers } from '../types';
 
 // Embedders
 import talentEmbed from './talent';
+import actionEmbed from './action';
 
 const EMBEDDERS: Record<ItemType, EmbedHelpers> = {
     [ItemType.Weapon]: {},
@@ -18,7 +19,7 @@ const EMBEDDERS: Record<ItemType, EmbedHelpers> = {
     [ItemType.Talent]: talentEmbed,
     [ItemType.Trait]: {},
 
-    [ItemType.Action]: {},
+    [ItemType.Action]: actionEmbed,
 
     [ItemType.Injury]: {},
     [ItemType.Connection]: {},

--- a/src/system/utils/templates.ts
+++ b/src/system/utils/templates.ts
@@ -135,6 +135,7 @@ export const TEMPLATES = {
 
     // ITEM EMBEDDINGS
     ITEM_TALENT_EMBED: 'item/talent/embed.hbs',
+    ITEM_ACTION_EMBED: 'item/action/embed.hbs',
 
     //CHAT
     CHAT_CARD_HEADER: 'chat/card-header.hbs',

--- a/src/templates/item/action/embed.hbs
+++ b/src/templates/item/action/embed.hbs
@@ -1,0 +1,13 @@
+<h3>
+    <span>{{default config.label item.name}}</span>
+    {{#if item.system.activation.cost.type}}
+        <span>
+            (<em class="cosmere-icon">{{#if (eq item.system.activation.cost.type "act")}}{{item.system.activation.cost.value}}{{else}}{{cosmereDingbat item.system.activation.cost.type}}{{/if}}</em>)
+        </span>
+    {{/if}}
+    <a {{{linkDataStr}}}>
+        <i class="fa-solid fa-up-right-from-square"></i>
+    </a>
+</h3>
+
+{{{description}}}


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Add `@Embed` support for actions.

**Related Issue**  
Partially addresses #422 

**How Has This Been Tested?**  
1. Create journal
2. Create page
3. Edit page
4. Drag action onto page
5. Replace `@UUID` with `@Embed`, set inline, and remove label
6. Save page
7. Ensure action is rendered
8. Click link in top right and ensure it links to the item
9. Drag action from journal directly onto sheet (grab anywhere)

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/3fb8d122-50f3-4e03-b7f5-3c4015217bd7)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343