### PR TITLE
feat(item-embeds): add ancestry embed support

### DIFF
--- a/src/system/utils/embed/item/ancestry.ts
+++ b/src/system/utils/embed/item/ancestry.ts
@@ -1,0 +1,75 @@
+// Documents
+import {
+    AncestryItem,
+    TalentTreeItem,
+    CosmereItem,
+} from '@system/documents/item';
+
+// Talent tree embed
+import {
+    buildEmbedHTML as buildTalentTreeEmbedHTML,
+    createInlineEmbed as createTalentTreeInlineEmbed,
+} from './talent-tree';
+
+// Generics
+import {
+    buildEmbedHTML as buildGenericEmbedHTML,
+    createInlineEmbed as createGenericInlineEmbed,
+} from './generic';
+
+export async function buildEmbedHTML(
+    item: AncestryItem,
+    config: DocumentHTMLEmbedConfig,
+    options?: TextEditor.EnrichmentOptions,
+): Promise<HTMLElement | HTMLCollection | null> {
+    if (!(options?.relativeTo instanceof JournalEntryPage)) return null;
+
+    if (config.values?.includes('talents') && item.system.talentTree) {
+        // Get the talent tree item
+        const tree = (await fromUuid(
+            item.system.talentTree,
+        )) as unknown as TalentTreeItem;
+
+        // Build the talent tree embed HTML
+        return buildTalentTreeEmbedHTML(
+            tree,
+            foundry.utils.mergeObject(config, {
+                link: item.uuid,
+            }),
+            options,
+        );
+    } else {
+        return buildGenericEmbedHTML(item, config, options);
+    }
+}
+
+export async function createInlineEmbed(
+    item: AncestryItem,
+    content: HTMLElement | HTMLCollection,
+    config: DocumentHTMLEmbedConfig,
+    options?: TextEditor.EnrichmentOptions,
+): Promise<HTMLElement | null> {
+    if (config.values?.includes('talents') && item.system.talentTree) {
+        // Get the talent tree item
+        const tree = (await fromUuid(
+            item.system.talentTree,
+        )) as unknown as TalentTreeItem;
+
+        // Create the inline embed for the talent tree
+        return createTalentTreeInlineEmbed(
+            tree,
+            content,
+            foundry.utils.mergeObject(config, {
+                link: item.uuid,
+            }),
+            options,
+        );
+    } else {
+        return createGenericInlineEmbed(item, content, config, options);
+    }
+}
+
+export default {
+    buildEmbedHTML,
+    createInlineEmbed,
+};

--- a/src/system/utils/embed/item/generic.ts
+++ b/src/system/utils/embed/item/generic.ts
@@ -6,6 +6,7 @@ const ITEM_EMBED_TEMPLATES: Record<string, string | undefined> = {
     talent: TEMPLATES.ITEM_TALENT_EMBED,
     culture: TEMPLATES.ITEM_CULTURE_EMBED,
     action: TEMPLATES.ITEM_ACTION_EMBED,
+    ancestry: TEMPLATES.ITEM_ANCESTRY_EMBED,
 };
 
 export async function buildEmbedHTML(

--- a/src/system/utils/embed/item/index.ts
+++ b/src/system/utils/embed/item/index.ts
@@ -7,6 +7,7 @@ import cultureEmbed from './culture';
 import talentEmbed from './talent';
 import talentTreeEmbed from './talent-tree';
 import actionEmbed from './action';
+import ancestryEmbed from './ancestry';
 
 const EMBEDDERS: Record<ItemType, EmbedHelpers> = {
     [ItemType.Weapon]: {},
@@ -14,7 +15,7 @@ const EMBEDDERS: Record<ItemType, EmbedHelpers> = {
     [ItemType.Equipment]: {},
     [ItemType.Loot]: {},
 
-    [ItemType.Ancestry]: {},
+    [ItemType.Ancestry]: ancestryEmbed,
     [ItemType.Culture]: cultureEmbed,
     [ItemType.Path]: {},
     [ItemType.Specialty]: {},

--- a/src/system/utils/templates.ts
+++ b/src/system/utils/templates.ts
@@ -138,6 +138,7 @@ export const TEMPLATES = {
     ITEM_CULTURE_EMBED: 'item/culture/embed.hbs',
     ITEM_TALENT_TREE_EMBED: 'item/talent-tree/embed.hbs',
     ITEM_ACTION_EMBED: 'item/action/embed.hbs',
+    ITEM_ANCESTRY_EMBED: 'item/ancestry/embed.hbs',
 
     //CHAT
     CHAT_CARD_HEADER: 'chat/card-header.hbs',

--- a/src/templates/item/ancestry/embed.hbs
+++ b/src/templates/item/ancestry/embed.hbs
@@ -1,0 +1,8 @@
+<h3>
+    <span>{{default config.label item.name}}</span>
+    <a {{{linkDataStr}}}>
+        <i class="fa-solid fa-up-right-from-square"></i>
+    </a>
+</h3>
+
+{{{description}}}


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Adds `@Embed` support for ancestries. Ancestries embeds also have the ability to pass the `talents` flag (`@Embed[<uuid> talents]`), which instead embeds the associated talent tree.

**Related Issue**  
Partially Addresses #422 

**How Has This Been Tested?**  
1. Create journal
2. Create page
3. Edit page
4. Drag an ancestry, with an associated talent tree, onto the page
5. Replace `@UUID` with `@Embed`, set inline, and remove label
6. Save page
7. Ensure ancestry renders 
8. Click the link icon in the top right of the header, ensure the item opens
9. Close the item
10. Drag the ancestry directly onto a character sheet, ensure it gets added (grab anywhere)
11. Edit the page
12. add the `talents` flag to the embed (`@Embed[<uuid> inline talents]`)
13. Save the page
14. Ensure the ancestry's talent tree renders (as if through the talent tree embed)
15. Click the link icon in the top right, ensure the talents tab on the ancestry opens

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/acfe4bb0-8605-43b8-82cd-41d0bec5ce61)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: [insert version here].