### PR TITLE
feat(item embeds): add generic default embed support

### DIFF
--- a/src/system/utils/embed/item/action.ts
+++ b/src/system/utils/embed/item/action.ts
@@ -1,6 +1,0 @@
-import { buildEmbedHTML, createInlineEmbed } from './generic';
-
-export default {
-    buildEmbedHTML,
-    createInlineEmbed,
-};

--- a/src/system/utils/embed/item/culture.ts
+++ b/src/system/utils/embed/item/culture.ts
@@ -1,7 +1,0 @@
-// Generics
-import { createInlineEmbed, buildEmbedHTML, getLinkDataStr } from './generic';
-
-export default {
-    buildEmbedHTML,
-    createInlineEmbed,
-};

--- a/src/system/utils/embed/item/generic.ts
+++ b/src/system/utils/embed/item/generic.ts
@@ -25,7 +25,14 @@ export async function buildEmbedHTML(
             item.system.description?.value ??
                 item.system.description?.short ??
                 '',
-            options,
+            {
+                relativeTo: options?.relativeTo,
+                documents: options?.documents,
+                links: options?.links,
+                rollData: options?.rollData,
+                rolls: options?.rolls,
+                secrets: options?.secrets,
+            },
         );
 
     const headingTag =

--- a/src/system/utils/embed/item/generic.ts
+++ b/src/system/utils/embed/item/generic.ts
@@ -4,17 +4,17 @@ import { CosmereItem } from '@system/documents/item';
 import { TEMPLATES, renderSystemTemplate } from '@system/utils/templates';
 const ITEM_EMBED_TEMPLATES: Record<string, string | undefined> = {
     talent: TEMPLATES.ITEM_TALENT_EMBED,
-    culture: TEMPLATES.ITEM_CULTURE_EMBED,
     action: TEMPLATES.ITEM_ACTION_EMBED,
 };
+
+const HEADING_TAGS: string[] = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
+const DEFAULT_HEADING_TAG = 'h3';
 
 export async function buildEmbedHTML(
     item: CosmereItem,
     config: DocumentHTMLEmbedConfig,
     options?: TextEditor.EnrichmentOptions,
 ): Promise<HTMLElement | HTMLCollection | null> {
-    if (!ITEM_EMBED_TEMPLATES[item.type]) return null;
-
     // Create the link data string
     const linkDataStr = getLinkDataStr(item);
 
@@ -28,13 +28,22 @@ export async function buildEmbedHTML(
             options,
         );
 
+    const headingTag =
+        config.values?.find((v) => HEADING_TAGS.includes(v)) ??
+        DEFAULT_HEADING_TAG;
+
+    // Get the template
+    const hbsTemplate =
+        ITEM_EMBED_TEMPLATES[item.type] ?? TEMPLATES.ITEM_GENERIC_EMBED;
+
     // Render template
-    const html = await renderSystemTemplate(ITEM_EMBED_TEMPLATES[item.type]!, {
+    const html = await renderSystemTemplate(hbsTemplate, {
         item,
         config,
         options,
         linkDataStr,
         description,
+        headingTag,
     });
 
     // Get elements
@@ -86,3 +95,9 @@ export function getLinkDataStr(
         .map(([key, value]) => `data-${key}="${value}"`)
         .join(' ');
 }
+
+export default {
+    buildEmbedHTML,
+    createInlineEmbed,
+    getLinkDataStr,
+};

--- a/src/system/utils/embed/item/index.ts
+++ b/src/system/utils/embed/item/index.ts
@@ -3,37 +3,36 @@ import { ItemType } from '@system/types/cosmere';
 import { EmbedHelpers } from '../types';
 
 // Embedders
-import cultureEmbed from './culture';
 import talentEmbed from './talent';
 import talentTreeEmbed from './talent-tree';
-import actionEmbed from './action';
+import genericEmbed from './generic';
 
-const EMBEDDERS: Record<ItemType, EmbedHelpers> = {
-    [ItemType.Weapon]: {},
-    [ItemType.Armor]: {},
-    [ItemType.Equipment]: {},
-    [ItemType.Loot]: {},
+const EMBEDDERS: Record<ItemType, EmbedHelpers | null> = {
+    [ItemType.Weapon]: null,
+    [ItemType.Armor]: null,
+    [ItemType.Equipment]: null,
+    [ItemType.Loot]: null,
 
-    [ItemType.Ancestry]: {},
-    [ItemType.Culture]: cultureEmbed,
-    [ItemType.Path]: {},
-    [ItemType.Specialty]: {},
+    [ItemType.Ancestry]: null,
+    [ItemType.Culture]: null,
+    [ItemType.Path]: null,
+    [ItemType.Specialty]: null,
     [ItemType.Talent]: talentEmbed,
-    [ItemType.Trait]: {},
+    [ItemType.Trait]: null,
 
-    [ItemType.Action]: actionEmbed,
+    [ItemType.Action]: null,
 
-    [ItemType.Injury]: {},
-    [ItemType.Connection]: {},
-    [ItemType.Goal]: {},
+    [ItemType.Injury]: null,
+    [ItemType.Connection]: null,
+    [ItemType.Goal]: null,
 
-    [ItemType.Power]: {},
+    [ItemType.Power]: null,
 
     [ItemType.TalentTree]: talentTreeEmbed,
 };
 
-export function getEmbedHelpers(type: ItemType) {
-    return EMBEDDERS[type] ?? {};
+export function getEmbedHelpers(type: ItemType): EmbedHelpers {
+    return EMBEDDERS[type] ?? genericEmbed;
 }
 
 export default getEmbedHelpers;

--- a/src/system/utils/embed/item/talent.ts
+++ b/src/system/utils/embed/item/talent.ts
@@ -39,7 +39,14 @@ export async function buildEmbedHTML(
     // Enrich the description
     const description = await TextEditor.enrichHTML(
         item.system.description?.value ?? item.system.description?.short ?? '',
-        options,
+        {
+            relativeTo: options?.relativeTo,
+            documents: options?.documents,
+            links: options?.links,
+            rollData: options?.rollData,
+            rolls: options?.rolls,
+            secrets: options?.secrets,
+        },
     );
 
     // Render template

--- a/src/system/utils/templates.ts
+++ b/src/system/utils/templates.ts
@@ -135,9 +135,9 @@ export const TEMPLATES = {
 
     // ITEM EMBEDDINGS
     ITEM_TALENT_EMBED: 'item/talent/embed.hbs',
-    ITEM_CULTURE_EMBED: 'item/culture/embed.hbs',
     ITEM_TALENT_TREE_EMBED: 'item/talent-tree/embed.hbs',
     ITEM_ACTION_EMBED: 'item/action/embed.hbs',
+    ITEM_GENERIC_EMBED: 'item/generic/embed.hbs',
 
     //CHAT
     CHAT_CARD_HEADER: 'chat/card-header.hbs',

--- a/src/templates/item/action/embed.hbs
+++ b/src/templates/item/action/embed.hbs
@@ -1,4 +1,4 @@
-<h3>
+<{{{headingTag}}}>
     <span>{{default config.label item.name}}</span>
     {{#if item.system.activation.cost.type}}
         <span>
@@ -8,6 +8,6 @@
     <a {{{linkDataStr}}}>
         <i class="fa-solid fa-up-right-from-square"></i>
     </a>
-</h3>
+</{{{headingTag}}}>
 
 {{{description}}}

--- a/src/templates/item/generic/embed.hbs
+++ b/src/templates/item/generic/embed.hbs
@@ -1,8 +1,8 @@
-<h3>
+<{{{headingTag}}}>
     <span>{{default config.label item.name}}</span>
     <a {{{linkDataStr}}}>
         <i class="fa-solid fa-up-right-from-square"></i>
     </a>
-</h3>
+</{{{headingTag}}}>
 
 {{{description}}}


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Adds default `@Embed` handling for all item types. Default embedding renders the item name and description and enabled dragging. 
This PR also moves cultures and actions over to use the default embedding.

**Related Issue**  
Partially Addresses #422 

**How Has This Been Tested?**  
1. Create Journal
2. Create Page 
3. Edit page
4. Drag weapon onto page
5. Drag armor onto page
7. Drag equipment item onto page
8. Drag loot item onto page
9. Drag culture onto page
10. Drag adversary feature onto page
11. Drag action onto page
12. Drag injury item onto page
13. Drag connection onto page
14. Drag goal onto page
15. Drag power onto page
16. For each item: Replace  `@UUID` with `@Embed`, set inline, and remove label
17. Save page
18. Ensure each item's embed has rendered properly
19. Click the link icon in the top right of the header for each item, ensure the item is opened, then close the item
20. Drag each item directly from the page onto a character sheet, ensure they get added

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/fbd69bc4-2600-4b14-8839-ff7add36bdde)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343