### PR TITLE
feat(talent tree): add ancestry and culture prerequisite options

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -527,11 +527,13 @@
                 },
                 "Prerequisite": {
                     "Type": {
-                        "Talent": "Talent",
-                        "Attribute": "Attribute",
-                        "Skill": "Skill",
-                        "Connection": "Connection",
-                        "Level": "Level"
+                        "talent": "Talent",
+                        "attribute": "Attribute",
+                        "skill": "Skill",
+                        "connection": "Connection",
+                        "level": "Level",
+                        "ancestry": "Ancestry",
+                        "culture": "Culture"
                     },
                     "Mode": {
                         "AnyOf": "Any of",
@@ -539,6 +541,12 @@
                     },
                     "Level": {
                         "Label": "Level"
+                    },
+                    "Ancestry": {
+                        "Label": "Ancestry"
+                    },
+                    "Culture": {
+                        "Label": "Culture"
                     }
                 },
                 "GrantRule": {

--- a/src/system/applications/item/components/talent-tree/node-prerequisites.ts
+++ b/src/system/applications/item/components/talent-tree/node-prerequisites.ts
@@ -160,20 +160,34 @@ export class NodePrerequisitesComponent extends HandlebarsApplicationComponent<
             ...(rule.type === TalentTree.Node.Prerequisite.Type.Talent
                 ? {
                       talents: await Promise.all(
-                          rule.talents.map(async (ref) => {
-                              // Look up doc
-                              const doc = (await fromUuid(
-                                  ref.uuid,
-                              )) as unknown as CosmereItem;
-
-                              return {
-                                  ...ref,
-                                  link: doc.toAnchor().outerHTML,
-                              };
-                          }),
+                          rule.talents.map(this.prepareRefContext.bind(this)),
                       ),
                   }
                 : {}),
+
+            ...(rule.type === TalentTree.Node.Prerequisite.Type.Ancestry
+                ? {
+                      ancestry: await this.prepareRefContext(rule.ancestry),
+                  }
+                : {}),
+
+            ...(rule.type === TalentTree.Node.Prerequisite.Type.Culture
+                ? {
+                      culture: await this.prepareRefContext(rule.culture),
+                  }
+                : {}),
+        };
+    }
+
+    private async prepareRefContext(ref: TalentTree.Node.Prerequisite.ItemRef) {
+        if (!ref) return ref;
+
+        // Look up doc
+        const doc = (await fromUuid(ref.uuid)) as unknown as CosmereItem;
+
+        return {
+            ...ref,
+            link: doc.toAnchor().outerHTML,
         };
     }
 

--- a/src/system/applications/item/dialogs/talent-tree/edit-node-prerequisite.ts
+++ b/src/system/applications/item/dialogs/talent-tree/edit-node-prerequisite.ts
@@ -1,5 +1,5 @@
 import { Attribute, Skill } from '@system/types/cosmere';
-import { TalentTreeItem } from '@system/documents/item';
+import { TalentTreeItem, CosmereItem } from '@system/documents/item';
 import { TalentTree } from '@system/types/item';
 import { AnyObject } from '@system/types/utils';
 import { TalentItemData } from '@system/data/item/talent';
@@ -98,8 +98,6 @@ export class EditNodePrerequisiteDialog extends ComponentHandlebarsApplicationMi
                     ? Array.from(old.talents.keys())
                     : [];
 
-            console.log('prevTalents', prevTalents);
-
             // Figure out which talents have been removed
             const removedTalents = prevTalents.filter(
                 (id) =>
@@ -149,7 +147,7 @@ export class EditNodePrerequisiteDialog extends ComponentHandlebarsApplicationMi
 
     /* --- Form --- */
 
-    protected static onFormEvent(
+    protected static async onFormEvent(
         this: EditNodePrerequisiteDialog,
         event: Event,
         form: HTMLFormElement,
@@ -182,6 +180,38 @@ export class EditNodePrerequisiteDialog extends ComponentHandlebarsApplicationMi
             formData.has('level')
         ) {
             this.data.level = parseInt(formData.get('level') as string);
+        } else if (
+            this.data.type === TalentTree.Node.Prerequisite.Type.Ancestry &&
+            formData.has('ancestry')
+        ) {
+            const ancestryUuid = formData.get('ancestry') as string;
+            const ancestry = (await fromUuid(
+                ancestryUuid,
+            )) as unknown as CosmereItem;
+
+            if (ancestry?.isAncestry()) {
+                this.data.ancestry = {
+                    uuid: ancestry.uuid,
+                    id: ancestry.system.id,
+                    label: ancestry.name,
+                };
+            }
+        } else if (
+            this.data.type === TalentTree.Node.Prerequisite.Type.Culture &&
+            formData.has('culture')
+        ) {
+            const cultureUuid = formData.get('culture') as string;
+            const culture = (await fromUuid(
+                cultureUuid,
+            )) as unknown as CosmereItem;
+
+            if (culture?.isCulture()) {
+                this.data.culture = {
+                    uuid: culture.uuid,
+                    id: culture.system.id,
+                    label: culture.name,
+                };
+            }
         }
 
         // Render

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -855,15 +855,19 @@ const COSMERE: CosmereRPGConfig = {
                 prerequisite: {
                     types: {
                         [TalentTree.Node.Prerequisite.Type.Talent]:
-                            'COSMERE.Item.Talent.Prerequisite.Type.Talent',
+                            'COSMERE.Item.Talent.Prerequisite.Type.talent',
                         [TalentTree.Node.Prerequisite.Type.Attribute]:
-                            'COSMERE.Item.Talent.Prerequisite.Type.Attribute',
+                            'COSMERE.Item.Talent.Prerequisite.Type.attribute',
                         [TalentTree.Node.Prerequisite.Type.Skill]:
-                            'COSMERE.Item.Talent.Prerequisite.Type.Skill',
+                            'COSMERE.Item.Talent.Prerequisite.Type.skill',
                         [TalentTree.Node.Prerequisite.Type.Connection]:
-                            'COSMERE.Item.Talent.Prerequisite.Type.Connection',
+                            'COSMERE.Item.Talent.Prerequisite.Type.connection',
                         [TalentTree.Node.Prerequisite.Type.Level]:
-                            'COSMERE.Item.Talent.Prerequisite.Type.Level',
+                            'COSMERE.Item.Talent.Prerequisite.Type.level',
+                        [TalentTree.Node.Prerequisite.Type.Ancestry]:
+                            'COSMERE.Item.Talent.Prerequisite.Type.ancestry',
+                        [TalentTree.Node.Prerequisite.Type.Culture]:
+                            'COSMERE.Item.Talent.Prerequisite.Type.culture',
                     },
                 },
             },

--- a/src/system/data/item/fields/talent-tree-node-collection.ts
+++ b/src/system/data/item/fields/talent-tree-node-collection.ts
@@ -203,6 +203,58 @@ class TalentTreeNodeField extends foundry.data.fields.SchemaField {
                             initial: 0,
                             label: 'COSMERE.Item.Talent.Prerequisite.Level.Label',
                         }),
+
+                        // Ancestry
+                        ancestry: new foundry.data.fields.SchemaField(
+                            {
+                                uuid: new foundry.data.fields.StringField({
+                                    required: true,
+                                    nullable: false,
+                                    blank: false,
+                                }),
+                                id: new foundry.data.fields.StringField({
+                                    required: true,
+                                    nullable: false,
+                                    blank: false,
+                                }),
+                                label: new foundry.data.fields.StringField({
+                                    required: true,
+                                    nullable: false,
+                                    blank: false,
+                                }),
+                            },
+                            {
+                                nullable: true,
+                                initial: null,
+                                label: 'COSMERE.Item.Talent.Prerequisite.Ancestry.Label',
+                            },
+                        ),
+
+                        // Culture
+                        culture: new foundry.data.fields.SchemaField(
+                            {
+                                uuid: new foundry.data.fields.StringField({
+                                    required: true,
+                                    nullable: false,
+                                    blank: false,
+                                }),
+                                id: new foundry.data.fields.StringField({
+                                    required: true,
+                                    nullable: false,
+                                    blank: false,
+                                }),
+                                label: new foundry.data.fields.StringField({
+                                    required: true,
+                                    nullable: false,
+                                    blank: false,
+                                }),
+                            },
+                            {
+                                nullable: true,
+                                initial: null,
+                                label: 'COSMERE.Item.Talent.Prerequisite.Culture.Label',
+                            },
+                        ),
                     }),
                     {
                         nullable: true,

--- a/src/system/types/item/talent-tree.ts
+++ b/src/system/types/item/talent-tree.ts
@@ -35,6 +35,8 @@ export namespace Node {
             Skill = 'skill',
             Connection = 'connection',
             Level = 'level',
+            Ancestry = 'ancestry',
+            Culture = 'culture',
         }
 
         export const enum Mode {
@@ -42,22 +44,24 @@ export namespace Node {
             AllOf = 'all-of',
         }
 
-        export interface TalentRef {
+        export interface ItemRef {
             /**
-             * UUID of the Talent item this prerequisite refers to.
+             * UUID of the item this prerequisite refers to.
              */
             uuid: string;
 
             /**
-             * The id of the talent
+             * The id of the item
              */
             id: string;
 
             /**
-             * The name of the talent
+             * The name of the item
              */
             label: string;
         }
+
+        export type TalentRef = ItemRef;
     }
 
     interface BasePrerequisite<Type extends Prerequisite.Type> {
@@ -98,12 +102,24 @@ export namespace Node {
         level: number;
     }
 
+    export interface AncestryPrerequisite
+        extends BasePrerequisite<Prerequisite.Type.Ancestry> {
+        ancestry: Prerequisite.ItemRef;
+    }
+
+    export interface CulturePrerequisite
+        extends BasePrerequisite<Prerequisite.Type.Culture> {
+        culture: Prerequisite.ItemRef;
+    }
+
     export type Prerequisite =
         | ConnectionPrerequisite
         | AttributePrerequisite
         | SkillPrerequisite
         | TalentPrerequisite
-        | LevelPrerequisite;
+        | LevelPrerequisite
+        | AncestryPrerequisite
+        | CulturePrerequisite;
 }
 
 export interface BaseNode<Type extends Node.Type = Node.Type> {

--- a/src/system/utils/talent-tree.ts
+++ b/src/system/utils/talent-tree.ts
@@ -250,6 +250,12 @@ export function characterMeetsPrerequisiteRule(
             return actor.system.skills[prereq.skill].rank >= prereq.rank;
         case TalentTree.Node.Prerequisite.Type.Level:
             return actor.system.level >= prereq.level;
+        case TalentTree.Node.Prerequisite.Type.Ancestry:
+            return actor.ancestry?.id === prereq.ancestry.id;
+        case TalentTree.Node.Prerequisite.Type.Culture:
+            return actor.cultures.some(
+                (culture) => culture.id === prereq.culture.id,
+            );
         case TalentTree.Node.Prerequisite.Type.Connection:
             return true; // No way to check connections
         default:

--- a/src/templates/item/talent-tree/components/prerequisites.hbs
+++ b/src/templates/item/talent-tree/components/prerequisites.hbs
@@ -46,6 +46,10 @@
                     <span>{{rule.description}}</span>
                 {{else if (eq rule.type "level")}}
                     <span>{{rule.level}}+</span>
+                {{else if (eq rule.type "ancestry")}}
+                    {{{rule.ancestry.link}}}
+                {{else if (eq rule.type "culture")}}
+                    {{{rule.culture.link}}}
                 {{/if}}
             </div>
             <div class="controls icon faded flexrow">

--- a/src/templates/item/talent-tree/dialogs/edit-prerequisite.hbs
+++ b/src/templates/item/talent-tree/dialogs/edit-prerequisite.hbs
@@ -93,6 +93,28 @@
     }}
     {{/if}}
 
+    {{!-- Ancestry --}}
+    {{#if (eq type "ancestry")}}
+        {{app-document-reference-input
+            name="ancestry"
+            label=(localize schema.fields.ancestry.label)
+            value=ancestry
+            type="Item"
+            subtype="ancestry"
+        }}
+    {{/if}}
+
+    {{!-- Culture --}}
+    {{#if (eq type "culture")}}
+        {{app-document-reference-input
+            name="culture"
+            label=(localize schema.fields.culture.label)
+            value=culture
+            type="Item"
+            subtype="culture"
+        }}
+    {{/if}}
+
     {{!-- Submit --}}
     <br>
     <div class="form-group">

--- a/src/templates/item/talent-tree/partials/talent-tree-node-tooltip.hbs
+++ b/src/templates/item/talent-tree/partials/talent-tree-node-tooltip.hbs
@@ -32,6 +32,14 @@
                     {{else if (eq prereq.type "connection")}}
                         <i class="fa-solid fa-users"></i>
                         <span>{{prereq.description}}</span>
+                    {{else if (eq prereq.type "ancestry")}}
+                        <i class="fa-solid fa-people-arrows"></i>
+                        <span>{{prereq.ancestry.label}}</span>
+                        <span>{{localize "GENERIC.Ancestry"}}</span>
+                    {{else if (eq prereq.type "culture")}}
+                        <i class="fa-solid fa-globe"></i>
+                        <span>{{prereq.culture.label}}</span>
+                        <span>{{localize "GENERIC.Culture"}}</span>
                     {{/if}}
                 </div>
             {{/each}}


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR adds the ancestry and culture prerequisite type options. 

**Related Issue**  
Closes #433 

**How Has This Been Tested?**  
1. Open talent tree
2. Select talent
3. Add prerequisite
4. Set type to ancestry
5. Drag ancestry onto drop input
6. Click update
7. Hover over talent, Ensure prerequisite renders properly
8. Add talent tree to an ancestry
9. Add the ancestry to a character
10. Open the ancestry
11. Hover over the first talent
12. Ensure the prerequisite shows as being met
13. Edit the talent tree
14. Edit the prerequisite
15. Set type to culture
16. Drag culture item onto drop input
17. Click update
18. Add the culture to the character
19. Hover over the first talent in the ancestry
20. Ensure the prerequisite shows as being met

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/1d105a8c-692b-48dc-a0e5-696f69f21f2b)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343