### PR TITLE
fix(hooks): fix issue causing cosmere-rpg.modeDeactivateItem hook to not fire

### DIFF
--- a/src/system/hooks/actor.ts
+++ b/src/system/hooks/actor.ts
@@ -66,6 +66,13 @@ Hooks.on(
                         return false;
                     }
                 }
+
+                // Store the current mode in flags for later use
+                foundry.utils.setProperty(
+                    update,
+                    `flags.${SYSTEM_ID}.meta.update.mode.${modality}`,
+                    currentMode,
+                );
             }
         }
     },
@@ -81,8 +88,11 @@ Hooks.on(
             ) as Record<string, string>;
 
             for (const [modality, newMode] of Object.entries(modalityChanges)) {
-                // Get current mode
-                const currentMode = actor.getMode(modality);
+                // Get previous mode
+                const prevMode = actor.getFlag(
+                    SYSTEM_ID,
+                    `meta.update.mode.${modality}`,
+                );
 
                 // Get modality item for the current mode
                 const currentModalityItem = actor.items.find(
@@ -90,7 +100,7 @@ Hooks.on(
                         item.hasId() &&
                         item.hasModality() &&
                         item.system.modality === modality &&
-                        item.system.id === currentMode,
+                        item.system.id === prevMode,
                 );
 
                 if (currentModalityItem) {


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes the issue of the `cosmere-rpg.modeDeactivateItem` hook not firing. Was caused by checking against the current state of the modality not the previous (pre-update) state. Changed it so we now store the state on the actor flags so we can check against it for this hook.

**Related Issue**  
Closes #435 

**How Has This Been Tested?**  
1. Create character
2. Add new action and edit it
3. Set identifier to "mode1"
4. Enable "Has Modality"
5. Set modality identifier to "modality"
6. Add another new action and edit it
7. Set identifier to "mode2"
8. Enable "Has Modality"
9. Set modality identifier to "modality"
10. Set `CONFIG.debug.hook` to true
11. Use the first action
12. Use the second action

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343