### PR TITLE
fix(event system): change default event host to source

### DIFF
--- a/src/system/api/item.ts
+++ b/src/system/api/item.ts
@@ -465,7 +465,7 @@ export function registerItemEventType(data: ItemEventTypeConfigData) {
         label: data.label,
         description: data.description,
         hook: data.hook,
-        host: data.host ?? ItemEventSystem.Event.ExecutionHost.Owner,
+        host: data.host ?? ItemEventSystem.Event.ExecutionHost.Source,
         filter: data.filter,
         condition: data.condition,
         transform: data.transform,


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR changes the default host for events from `owner` to `user`, which was causing certain events to only fire for the original GM user.

**Related Issue**  
Closes #447 

**How Has This Been Tested?**  
1. Connect with original GM user
2. Connect with second user
3. Add an event rule to any non-weapon activatable item (action, talent, etc.)
4. Set trigger to "Used"
5. Set handler type to "Use item"
6. Set target to "Equipped Weapon"
7. Set damage Bonus to "2d4"
8. Click update
9. Ensure a weapon is equipped
10. Use the item from the second user

**Checklist:**  
- [ ] I have commented on my code, particularly in hard-to-understand areas. N/A
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343