### PR TITLE
fix: currency and weight rounding errors 437

### DIFF
--- a/src/style/sheets/item/module.scss
+++ b/src/style/sheets/item/module.scss
@@ -264,6 +264,7 @@
         display: flex;
         flex-direction: row;
         margin-bottom: 0.25rem;
+        gap: 0.25rem;
 
         .separator {
             font-size: var(--font-size-10);

--- a/src/system/data/actor/common.ts
+++ b/src/system/data/actor/common.ts
@@ -629,7 +629,11 @@ export class CommonActorDataModel<
             money.forEach((item) => {
                 if (item.system.price.currency !== currency) return;
 
-                total += item.system.price.baseValue * item.system.quantity;
+                total += parseFloat(
+                    (
+                        item.system.price.baseValue * item.system.quantity
+                    ).toFixed(2),
+                );
             });
 
             // Update derived total

--- a/src/system/utils/handlebars/index.ts
+++ b/src/system/utils/handlebars/index.ts
@@ -232,9 +232,11 @@ Handlebars.registerHelper(
                 context.weight = {
                     value: item.system.weight.value,
                     unit: item.system.weight.unit,
-                    total:
-                        (item.system.quantity ?? 0) *
-                        (item.system.weight.value ?? 0),
+                    total: parseFloat(
+                        (
+                            item.system.quantity * item.system.weight.value
+                        ).toFixed(2),
+                    ),
                 };
                 context.price = {
                     value: item.system.price.value,


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->


**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue where multiplying decimals for currency totals and item weight totals would occasionally result in very long floating points that break the UI.

**Related Issue**  
Closes #437 

**How Has This Been Tested?**  
Tested for both currency total fields and for item weight totals to ensure that items with value or weight of 0.x do not cause more than 2 decimal points to ever appear in the UI.

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/a469de95-4de2-4ef9-910d-5f7c1f14f497)
![image](https://github.com/user-attachments/assets/f8962749-7b68-47b3-8d0d-800c093ac33c)

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: 12.343.
