### PR TITLE
feat(attributes component): update input to use source value when editing and add effect indicator

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -300,6 +300,9 @@
                 "Skills": {
                     "AdjustTooltip": "Left Click to increase {skill}'s Rank.<br>Right Click to decrease {skill}'s Rank.",
                     "SetTooltip": "Left Click to adjust {skill}'s Rank.<br>Right Click to clear {skill}'s Rank."
+                },
+                "Attributes": {
+                    "IsModifiedTooltip": "This attribute is being modified by an effect."
                 }
             }
         },

--- a/src/style.scss
+++ b/src/style.scss
@@ -85,6 +85,7 @@
             --cosmere-color-faded: #857d6a;
             --cosmere-color-sheet: #081127;
             --cosmere-color-neutral: var(--cosmere-color-dark-1);
+            --cosmere-color-highlight: var(--cosmere-color-opportunity-text);
 
             --cosmere-color-base-1: #1d2945;
             --cosmere-color-base-2: #0d172f;
@@ -108,6 +109,7 @@
             --cosmere-color-faded: #9c876e;
             --cosmere-color-sheet: #d9cdbf;
             --cosmere-color-neutral: var(--cosmere-color-light-2);
+            --cosmere-color-highlight: #ad6f41;
 
             --cosmere-color-base-1: #c6b094;
             --cosmere-color-base-2: #eadfd2;

--- a/src/style/sheets/actor/module.scss
+++ b/src/style/sheets/actor/module.scss
@@ -696,6 +696,13 @@
                             color: var(--cosmere-color-text-sub);                            
                             z-index: 1;                            
                             position: relative;
+
+                            > i {
+                                position: absolute;
+                                font-size: .75em;
+                                top: 0.1em;
+                                right: -1.05em;
+                            }
                         }
         
                         .value {                        
@@ -703,6 +710,10 @@
                             text-align: center;
                             height: 1.25rem;
                             padding-top: 0.25rem;
+
+                            &.modified:not(:focus) {
+                                color: var(--cosmere-color-highlight);
+                            }
                         }
                     }
 

--- a/src/system/applications/actor/components/attributes.ts
+++ b/src/system/applications/actor/components/attributes.ts
@@ -62,11 +62,11 @@ export class ActorAttributesComponent extends HandlebarsApplicationComponent<
                 $(event.target).trigger('select');
             })
             .on('blur', (event) => {
-                // Get the value
-                const value = $(event.target).data('value') as number;
+                // Get the total
+                const total = $(event.target).data('total') as number;
 
-                // Set the value to the input
-                $(event.target).val(value);
+                // Set the value to the total
+                $(event.target).val(total);
             });
     }
 
@@ -104,18 +104,27 @@ export class ActorAttributesComponent extends HandlebarsApplicationComponent<
         const attrConfig = CONFIG.COSMERE.attributes[attrId];
 
         const attr = this.application.actor.system.attributes[attrId];
-        const sourceValue = (
+        const source = (
             this.application.actor._source as {
-                system: { attributes: Record<Attribute, { value: number }> };
+                system: {
+                    attributes: Record<
+                        Attribute,
+                        { value: number; bonus: number }
+                    >;
+                };
             }
-        ).system.attributes[attrId].value;
+        ).system.attributes[attrId];
+
+        const total = attr.value + attr.bonus;
+        const sourceTotal = source.value + source.bonus;
 
         return {
             id: attrId,
             config: attrConfig,
             ...attr,
-            source: sourceValue,
-            modified: attr.value !== sourceValue,
+            total,
+            source: source,
+            modified: total !== sourceTotal,
         };
     }
 }

--- a/src/templates/actors/components/attributes.hbs
+++ b/src/templates/actors/components/attributes.hbs
@@ -13,18 +13,21 @@
                 <div class="container left">
                     <div class="background"></div>
                     <div class="border"></div>
-                    <span class="title">
+                    <span class="title" {{#if attribute.modified}}data-tooltip="COSMERE.Actor.Sheet.Attributes.IsModifiedTooltip"{{/if}}>
                         {{ localize attribute.config.labelShort }}
+                        {{#if attribute.modified}}
+                            <i class="fa-solid fa-bolt"></i>
+                        {{/if}}
                     </span>
                     {{#if (not @root.isEditMode)}}
-                    <input class="value" type="number"
-                        value="{{bonus attribute}}"
-                        readonly
-                    >
+                        <input class="value {{#if attribute.modified}}modified{{/if}}" type="number"
+                            value="{{bonus attribute}}"
+                            readonly
+                        >
                     {{else}}
-                    <input class="value" type="number" min="0" max="10" step="1"
-                        name="system.attributes.{{attribute.config.key}}.value" value="{{attribute.value}}" 
-                    />
+                        <input class="value {{#if attribute.modified}}modified{{/if}}" type="number" min="0" max="10" step="1"
+                            name="system.attributes.{{attribute.config.key}}.value" value="{{attribute.value}}" data-value="{{attribute.value}}" data-source-value="{{attribute.source}}" 
+                        />
                     {{/if}}
                 </div>
             </div>
@@ -53,17 +56,20 @@
                 <div class="container right">
                     <div class="background"></div>
                     <div class="border"></div>
-                    <span class="title">
+                    <span class="title" {{#if attribute.modified}}data-tooltip="COSMERE.Actor.Sheet.Attributes.IsModifiedTooltip"{{/if}}>
                         {{ localize attribute.config.labelShort }}
+                        {{#if attribute.modified}}
+                            <i class="fa-solid fa-bolt"></i>
+                        {{/if}}
                     </span>
                     {{#if (not @root.isEditMode)}}
-                    <input class="value" type="number"
+                    <input class="value {{#if attribute.modified}}modified{{/if}}" type="number"
                         value="{{bonus attribute}}"
                         readonly
                     >
                     {{else}}
-                    <input class="value" type="number" min="0" max="10" step="1"
-                        name="system.attributes.{{attribute.config.key}}.value" value="{{attribute.value}}" 
+                    <input class="value {{#if attribute.modified}}modified{{/if}}" type="number" min="0" max="10" step="1"
+                        name="system.attributes.{{attribute.config.key}}.value" value="{{attribute.value}}" data-value="{{attribute.value}}" data-source-value="{{attribute.source}}"
                     />
                     {{/if}}
                 </div>                    

--- a/src/templates/actors/components/attributes.hbs
+++ b/src/templates/actors/components/attributes.hbs
@@ -21,12 +21,12 @@
                     </span>
                     {{#if (not @root.isEditMode)}}
                         <input class="value {{#if attribute.modified}}modified{{/if}}" type="number"
-                            value="{{bonus attribute}}"
+                            value="{{total}}"
                             readonly
                         >
                     {{else}}
                         <input class="value {{#if attribute.modified}}modified{{/if}}" type="number" min="0" max="10" step="1"
-                            name="system.attributes.{{attribute.config.key}}.value" value="{{attribute.value}}" data-value="{{attribute.value}}" data-source-value="{{attribute.source}}" 
+                            name="system.attributes.{{attribute.config.key}}.value" value="{{total}}" data-total="{{total}}" data-source-value="{{attribute.source.value}}" 
                         />
                     {{/if}}
                 </div>
@@ -64,12 +64,12 @@
                     </span>
                     {{#if (not @root.isEditMode)}}
                     <input class="value {{#if attribute.modified}}modified{{/if}}" type="number"
-                        value="{{bonus attribute}}"
+                        value="{{total}}"
                         readonly
                     >
                     {{else}}
                     <input class="value {{#if attribute.modified}}modified{{/if}}" type="number" min="0" max="10" step="1"
-                        name="system.attributes.{{attribute.config.key}}.value" value="{{attribute.value}}" data-value="{{attribute.value}}" data-source-value="{{attribute.source}}"
+                        name="system.attributes.{{attribute.config.key}}.value" value="{{total}}" data-total="{{total}}" data-source-value="{{attribute.source.value}}"
                     />
                     {{/if}}
                 </div>                    


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR changes the attributes component to set the attribute input value to the source value (unmodified by effects) when focussed. Also adds an indicator that the attribute is being modified by an effect. Also consolidates raw and bonus value so they are both properly reflected in edit mode (bonus no longer only visible in view mode)

**Related Issue**  
Closes #429 

**How Has This Been Tested?**  
1. Create a character
2. Add an item
3. Add an effect to that item, set attribute key to `system.attributes.str.value`, mode to `add`, and effect value to `2`
4. Ensure strength is now 2
5. Click on the strength attribute input to edit it
6. Ensure value changes to 0
7. Edit value to 2
8. Unfocus input
9. Ensure value changes to 4
10. Change effect attribute key to `system.attributes.str.bonus`
11. Ensure value is still 4
12. Click on the strength attribute input to edit it
13. Ensure value changes to 2
14. Edit value to 0
15. Unfocus input
16. Ensure value changes to 2

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/172c7e80-c5c7-4bd1-886f-9a5bb65615e5)

![image](https://github.com/user-attachments/assets/41c91e35-e0ff-4ba7-97a1-7d8b71eb27cb)

![image](https://github.com/user-attachments/assets/7b592e36-2584-431a-8ae3-dc386a7e6631)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343