### PR TITLE
feat(hooks): add hook to set default sorting mode for compendiums

### DIFF
--- a/src/system/hooks/compendium.ts
+++ b/src/system/hooks/compendium.ts
@@ -1,0 +1,43 @@
+// Types
+import { AnyObject } from '@system/types/utils';
+
+// Constants
+import { SYSTEM_ID } from '@system/constants';
+
+interface Metadata extends CompendiumCollection.Metadata {
+    flags?: AnyObject;
+}
+
+Hooks.on('renderCompendium', async (compendium: Compendium<Metadata>) => {
+    if (
+        !foundry.utils.hasProperty(
+            compendium.collection.metadata.flags ?? {},
+            `${SYSTEM_ID}.defaultSortingMode`,
+        )
+    )
+        return;
+
+    const sortingModes = game.settings!.get(
+        'core',
+        'collectionSortingModes',
+    ) as Record<string, string>;
+    if (sortingModes[compendium.metadata.id]) return;
+
+    // Get the default sorting mode from the compendium metadata
+    const defaultSortingMode = foundry.utils.getProperty(
+        compendium.collection.metadata.flags!,
+        `${SYSTEM_ID}.defaultSortingMode`,
+    ) as string;
+
+    // Set the sorting mode for the compendium
+    await game.settings!.set('core', 'collectionSortingModes', {
+        ...sortingModes,
+        [compendium.metadata.id]: defaultSortingMode,
+    });
+
+    // Initialize the compendium collection tree
+    compendium.collection.initializeTree();
+
+    // Re-render
+    compendium.render();
+});

--- a/src/system/hooks/index.ts
+++ b/src/system/hooks/index.ts
@@ -4,5 +4,6 @@ import './actor';
 import './item';
 import './enrichers';
 import './journal';
+import './compendium';
 
 export { register as registerItemEventSystem } from './item-event-system';


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Adds a hook to set the default sorting mode (picked up from flags) on compendiums. Sorting mode is only set if no sorting mode is configured in the settings for the given compendium (i.e. only the first time).

**Related Issue**  
Closes #440

**How Has This Been Tested?**  
1. Add default sorting mode flag to a compendium in its module.json (the compendium must be sorted)
```json
"flags": {
    "cosmere-rpg": {
        "defaultSortingMode": "m"
    }
}
```
2. Open the compendium 

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343