### PR TITLE
fix: sheet edit mode toggle breaking bug

### DIFF
--- a/src/system/applications/actor/base.ts
+++ b/src/system/applications/actor/base.ts
@@ -197,19 +197,17 @@ export class BaseActorSheet<
         if (!(event.target instanceof HTMLInputElement)) return;
 
         // Stop event propagation
+        event.preventDefault();
         event.stopPropagation();
 
-        // Update the actor
+        // Update the actor and re-render
         await this.actor.update(
             {
                 'flags.cosmere-rpg.sheet.mode':
                     this.mode === 'view' ? 'edit' : 'view',
             },
-            { render: false },
+            { render: true },
         );
-
-        // Render the sheet
-        void this.render(true);
 
         // Get toggle
         const toggle = $(this.element).find('#mode-toggle');
@@ -388,6 +386,10 @@ export class BaseActorSheet<
         }
 
         $(this.element)
+            .find('#mode-toggle')
+            .on('dblclick', (event) => this.onDoubleClickModeToggle(event));
+
+        $(this.element)
             .find('.collapsible .header')
             .on('click', (event) => this.onClickCollapsible(event));
     }
@@ -397,6 +399,12 @@ export class BaseActorSheet<
     protected onClickCollapsible(event: JQuery.ClickEvent) {
         const target = event.currentTarget as HTMLElement;
         target?.parentElement?.classList.toggle('expanded');
+    }
+
+    protected onDoubleClickModeToggle(event: JQuery.DoubleClickEvent) {
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
     }
 
     protected onActionsSearchChange(event: SearchBarInputEvent) {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue where rapidly toggling the edit mode slider would completely break the sheet due to an attempt by the renderer to minimise and toggle on/off edit at the same time. This was being caused by a race condition between listeners, and event.stopPropogation on the edit toggle did nothing because the header listener listens for a different click event (dbl click). Since the dbl click to minimise is default behaviour, the only way to block it is to add our own dblclick listener on the edit slider that stops propogation if the slider is double clicked.

**Related Issue**  
Closes #417 

**How Has This Been Tested?**  
Tested by rapidly clicking the edit moddle toggle with a mouse click macro (5ms between clicks) and see that the edit slider behaves correctly and no longer breaks. Also ensured minimising still works by double clicking anywhere EXCEPT the edit mode toggle.

**Screenshots (if applicable)**  
_Add screenshots or GIFs that help illustrate the changes, especially if they affect the UI or user-facing aspects of the system._

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: 12.343.
