### PR TITLE
fix(item event system): improve event loop detection

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1027,8 +1027,9 @@
                         }
                     }
                 },
-                "Notifications": {
-                    "LoopError": "Too many events fired in a short time. Aborting execution to prevent infinite loop."
+                "Notification": {
+                    "ExceededMaxDepth": "Exceeded maximum event chain depth. Aborting event execution.",
+                    "RecentEventsExceeded": "Exceeded maximum number of \"{eventType}\" events in a short period of time. Aborting event execution."
                 }
             },
             "Sheet": {

--- a/src/system/hooks/item-event-system/handlers/grant-expertises.ts
+++ b/src/system/hooks/item-event-system/handlers/grant-expertises.ts
@@ -45,15 +45,18 @@ export function register() {
             );
 
             // Grant the expertises
-            await actor.update({
-                'system.expertises': expertises.reduce(
-                    (acc, expertise) => ({
-                        ...acc,
-                        [expertise.key]: expertise.toObject(),
-                    }),
-                    {},
-                ),
-            });
+            await actor.update(
+                {
+                    'system.expertises': expertises.reduce(
+                        (acc, expertise) => ({
+                            ...acc,
+                            [expertise.key]: expertise.toObject(),
+                        }),
+                        {},
+                    ),
+                },
+                event.op,
+            );
         },
     });
 }

--- a/src/system/hooks/item-event-system/handlers/grant-items.ts
+++ b/src/system/hooks/item-event-system/handlers/grant-items.ts
@@ -142,8 +142,16 @@ export function register() {
 
             // Grant the items to the actor
             await Promise.all([
-                actor.updateEmbeddedDocuments('Item', documentUpdates),
-                actor.createEmbeddedDocuments('Item', documentsToCreate),
+                actor.updateEmbeddedDocuments(
+                    'Item',
+                    documentUpdates,
+                    event.op,
+                ),
+                actor.createEmbeddedDocuments(
+                    'Item',
+                    documentsToCreate,
+                    event.op,
+                ),
             ]);
         },
     });

--- a/src/system/hooks/item-event-system/handlers/modify-attribute.ts
+++ b/src/system/hooks/item-event-system/handlers/modify-attribute.ts
@@ -74,14 +74,17 @@ export function register() {
             const actor = event.item.actor;
 
             // Modify the attribute
-            await actor.update({
-                [`system.attributes.${this.attribute}`]: {
-                    [this.bonus ? 'bonus' : 'value']:
-                        actor.system.attributes[this.attribute][
-                            this.bonus ? 'bonus' : 'value'
-                        ] + this.amount,
+            await actor.update(
+                {
+                    [`system.attributes.${this.attribute}`]: {
+                        [this.bonus ? 'bonus' : 'value']:
+                            actor.system.attributes[this.attribute][
+                                this.bonus ? 'bonus' : 'value'
+                            ] + this.amount,
+                    },
                 },
-            });
+                event.op,
+            );
         },
     });
 }

--- a/src/system/hooks/item-event-system/handlers/modify-skill-rank.ts
+++ b/src/system/hooks/item-event-system/handlers/modify-skill-rank.ts
@@ -62,10 +62,13 @@ export function register() {
             const actor = event.item.actor;
 
             // Modify the skill rank
-            await actor.update({
-                [`system.skills.${this.skill}.rank`]:
-                    actor.system.skills[this.skill].rank + this.amount,
-            });
+            await actor.update(
+                {
+                    [`system.skills.${this.skill}.rank`]:
+                        actor.system.skills[this.skill].rank + this.amount,
+                },
+                event.op,
+            );
         },
     });
 }

--- a/src/system/hooks/item-event-system/handlers/remove-expertises.ts
+++ b/src/system/hooks/item-event-system/handlers/remove-expertises.ts
@@ -45,15 +45,18 @@ export function register() {
             );
 
             // Remove the expertises
-            await actor.update({
-                'system.expertises': expertises.reduce(
-                    (acc, expertise) => ({
-                        ...acc,
-                        [`-=${expertise.key}`]: expertise.toObject(),
-                    }),
-                    {},
-                ),
-            });
+            await actor.update(
+                {
+                    'system.expertises': expertises.reduce(
+                        (acc, expertise) => ({
+                            ...acc,
+                            [`-=${expertise.key}`]: expertise.toObject(),
+                        }),
+                        {},
+                    ),
+                },
+                event.op,
+            );
         },
     });
 }

--- a/src/system/hooks/item-event-system/handlers/remove-items.ts
+++ b/src/system/hooks/item-event-system/handlers/remove-items.ts
@@ -127,8 +127,8 @@ export function register() {
 
             // Remove the items from the actor
             await Promise.all([
-                actor.deleteEmbeddedDocuments('Item', itemRemovals),
-                actor.updateEmbeddedDocuments('Item', itemUpdates),
+                actor.deleteEmbeddedDocuments('Item', itemRemovals, event.op),
+                actor.updateEmbeddedDocuments('Item', itemUpdates, event.op),
             ]);
         },
     });

--- a/src/system/hooks/item-event-system/handlers/set-attribute.ts
+++ b/src/system/hooks/item-event-system/handlers/set-attribute.ts
@@ -73,11 +73,14 @@ export function register() {
             const actor = event.item.actor;
 
             // Modify the attribute
-            await actor.update({
-                [`system.attributes.${this.attribute}`]: {
-                    [this.bonus ? 'bonus' : 'value']: this.value,
+            await actor.update(
+                {
+                    [`system.attributes.${this.attribute}`]: {
+                        [this.bonus ? 'bonus' : 'value']: this.value,
+                    },
                 },
-            });
+                event.op,
+            );
         },
     });
 }

--- a/src/system/hooks/item-event-system/handlers/set-skill-rank.ts
+++ b/src/system/hooks/item-event-system/handlers/set-skill-rank.ts
@@ -62,9 +62,12 @@ export function register() {
             const actor = event.item.actor;
 
             // Set the skill rank
-            await actor.update({
-                [`system.skills.${this.skill}.rank`]: this.value,
-            });
+            await actor.update(
+                {
+                    [`system.skills.${this.skill}.rank`]: this.value,
+                },
+                event.op,
+            );
         },
     });
 }

--- a/src/system/hooks/item-event-system/handlers/update-actor.ts
+++ b/src/system/hooks/item-event-system/handlers/update-actor.ts
@@ -95,7 +95,7 @@ export function register() {
             );
 
             // Update the actor
-            await actor.update(changes);
+            await actor.update(changes, event.op);
         },
     });
 }

--- a/src/system/hooks/item-event-system/handlers/update-item.ts
+++ b/src/system/hooks/item-event-system/handlers/update-item.ts
@@ -121,7 +121,7 @@ export function register() {
                     );
 
                     // Update the item
-                    await item.update(changes);
+                    await item.update(changes, event.op);
                 }),
             );
         },

--- a/src/system/hooks/item-event-system/handlers/use-item.ts
+++ b/src/system/hooks/item-event-system/handlers/use-item.ts
@@ -154,6 +154,8 @@ export function register() {
                                   },
                               }
                             : {}),
+
+                        ...event.op,
                     }),
                 ),
             );

--- a/src/system/types/config.ts
+++ b/src/system/types/config.ts
@@ -385,7 +385,7 @@ export interface ItemEventTypeConfig {
      */
     transform?: (...args: any[]) => {
         document: foundry.abstract.Document;
-        options?: AnyObject;
+        options?: AnyObject & { _eti?: string; _d?: number };
         userId?: string;
     };
     /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/src/system/types/item/event-system/event.ts
+++ b/src/system/types/item/event-system/event.ts
@@ -16,6 +16,11 @@ export type Event<
      */
     item: CosmereItem;
 
+    /**
+     * The event operation. Must be passed down to document operations.
+     */
+    op: AnyObject;
+
     options?: TOptions;
 } & EventData;
 


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes the issue of the event system loop detection triggering when importing large quantities of items by improving the detection mechanism. Before the system was simply checking if a certain number (50) of events was fired in quick succession (within 200ms of each other). The new system tracks event chain depth and triggers whenever any individual chain of events exceeds 10, or whenever an extremely large amount of events (1000) of the same type gets fired in quick succession. This last check is still necessary as we can't track event chain depth through the `execute-macro` handler (or potentially custom handlers).

**Related Issue**  
Closes #403 

**How Has This Been Tested?**  
1. Create actor
2. Create item
3. Add event to item
4. Set trigger to "Added to actor"
5. Set handler to "Grant items"
6. Enable "Allow Duplicates"
7. Drag the created item into the item drop area (so the item grants itself when added to actor)
8. Drag the created item onto the actor
9. Ensure the loop detection kicks in and prevents infinite looping
10. Find a compendium with a large number of item (> 50) or create one
11. Right click on the compendium and select "Import All Content"
12. Ensure loop detection hasn't kicked in

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343