### PR TITLE
fix(talent tree): prevent adding same talent multiple times when double clicking 

### DIFF
--- a/src/system/applications/item/components/talent-tree/talent-tree-view.ts
+++ b/src/system/applications/item/components/talent-tree/talent-tree-view.ts
@@ -12,7 +12,7 @@ import { NodeConnection } from './types';
 import * as TalentTreeUtils from '@system/utils/talent-tree';
 import { AppContextMenu } from '@system/applications/utils/context-menu';
 import { renderSystemTemplate, TEMPLATES } from '@system/utils/templates';
-import { htmlStringHasContent } from '@system/utils/generic';
+import { htmlStringHasContent, debounce } from '@system/utils/generic';
 
 // Component imports
 import { HandlebarsApplicationComponent } from '@system/applications/component-system';
@@ -252,7 +252,10 @@ export class TalentTreeViewComponent<
         );
 
         // Add listeners
-        this.app.world.on('click-node', this.onClickNode.bind(this));
+        this.app.world.on(
+            'click-node',
+            debounce(this.onClickNode.bind(this), 300, true),
+        );
 
         this.app.world.on(
             'rightclick-node',
@@ -360,11 +363,11 @@ export class TalentTreeViewComponent<
 
         this.app.world.on(
             'mouseover-node',
-            foundry.utils.debounce(this.onMouseOverNode.bind(this), 300),
+            debounce(this.onMouseOverNode.bind(this), 300, true),
         );
         this.app.world.on(
             'mouseout-node',
-            foundry.utils.debounce(this.onMouseOutNode.bind(this), 300),
+            debounce(this.onMouseOutNode.bind(this), 300, true),
         );
 
         this.viewport.on('mousedown', () => {

--- a/src/system/utils/generic.ts
+++ b/src/system/utils/generic.ts
@@ -318,3 +318,31 @@ export function getTargetDescriptors() {
 
     return Array.from(targets.values());
 }
+
+/**
+ * Wrap callbacks in debounce mechanism.
+ * Prevents multiple invocations of the same callback within a given delay.
+ * If the `immediate` flag is set, the callback will be invoked immediately on the first call and then debounced for subsequent calls.
+ * Otherwise, it will wait for the delay before invoking the callback.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function debounce<T extends (...args: any[]) => void>(
+    callback: T,
+    delay: number,
+    immediate = false,
+): T {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    return function (this: unknown, ...args: Parameters<T>): void {
+        const later = () => {
+            timeoutId = null;
+            if (!immediate) callback.apply(this, args);
+        };
+
+        const callNow = immediate && !timeoutId;
+        clearTimeout(timeoutId!);
+        timeoutId = setTimeout(later, delay);
+
+        if (callNow) callback.apply(this, args);
+    } as T;
+}


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes the issue that users over a slow connection could end up adding the same talent multiple times when double clicking a talent in the talent tree.

**Related Issue**  
Closes #441 

**How Has This Been Tested?**  
—

**Checklist:**  
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes do not introduce any new warnings or errors.
- [ ] My PR does not contain any copyrighted works that I do not have permission to use.
- [ ] I have tested my changes on Foundry VTT version: [insert version here].

**Additional context**  
_Add any other context or information here that would be useful for reviewers._
