### PR TITLE
fix(chat message): make damage card section title not default to healing

### DIFF
--- a/src/system/documents/chat-message.ts
+++ b/src/system/documents/chat-message.ts
@@ -360,12 +360,10 @@ export class CosmereChatMessage extends ChatMessage {
               })
             : undefined;
 
-        const isHealing = !types.some(
-            (type) =>
-                !CONFIG.COSMERE.damageTypes[DamageType.Healing].label.includes(
-                    type[0],
-                ),
+        const isHealing = this.damageRolls.some(
+            (r) => r.damageType === DamageType.Healing,
         );
+
         const sectionHTML = await renderSystemTemplate(
             TEMPLATES.CHAT_CARD_SECTION,
             {


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes the issue where the chat card would show damage rolls without a damage type as healing instead of damage.

**Related Issue**  
Closes #443 

**How Has This Been Tested?**  
1. Create character
2. Create new weapon
3. Set damage formula (but not type)
4. Add weapon to character
5. Equip weapon
6. Use weapon

**Screenshots (if applicable)**  
<img width="421" height="350" alt="image" src="https://github.com/user-attachments/assets/a61569ee-49ac-4da9-8c3f-2257d28e4382" />

**Checklist:**  
- [ ] I have commented on my code, particularly in hard-to-understand areas. — N/A
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343