### PR TITLE
fix: chat card links

### DIFF
--- a/src/system/documents/chat-message.ts
+++ b/src/system/documents/chat-message.ts
@@ -1050,6 +1050,15 @@ export class CosmereChatMessage extends ChatMessage {
      * @param {JQuery.ClickEvent} event  The triggering event.
      */
     private onClickCollapsible(event: JQuery.ClickEvent) {
+        const directTarget = event.target as HTMLElement;
+
+        if (
+            directTarget.hasAttribute('data-link') ||
+            directTarget.classList.contains('inline-roll')
+        ) {
+            return;
+        }
+
         event.stopPropagation();
         const target = event.currentTarget as HTMLElement;
         target?.classList.toggle('expanded');


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue where UUID links and inline rolls in chat card descriptions would not work, as their click event would be picked up instead by the collapsible behaviour and block further propagation. Links and inline rolls should now appropriately be detected by the collapsible listener and behave correctly.

**Related Issue**  
Closes #442.

**How Has This Been Tested?**  
Tested with UUID links, journal references, and inline rolls within chat cards to make sure all 3 work appropriately. Also ensured collapsible behaviour still works if clicking anywhere in the description that isn't one of those links. Checked enrichers for regression.

**Screenshots (if applicable)**  
_Add screenshots or GIFs that help illustrate the changes, especially if they affect the UI or user-facing aspects of the system._

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: 12.343.
