### PR TITLE
Feat: Add Goal Prerequisite to Talent Trees

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -533,7 +533,8 @@
                         "connection": "Connection",
                         "level": "Level",
                         "ancestry": "Ancestry",
-                        "culture": "Culture"
+                        "culture": "Culture",
+                        "goal": "Goal"
                     },
                     "Mode": {
                         "AnyOf": "Any of",
@@ -1155,7 +1156,8 @@
                         "Connection": "Connection",
                         "ConnectionDescription": "Description",
                         "ConnectionDescriptionPlaceholder": "Connection Description",
-                        "DropTalents": "Drop Talents here to add them to the list."
+                        "DropTalents": "Drop Talents here to add them to the list.",
+                        "DropGoals": "Drop Goals here to add them to the list."
                     },
                     "GrantRules": {
                         "Description": "Description",
@@ -1541,6 +1543,7 @@
         "Type": "Type",
         "Description": "Description",
         "Talent": "Talent",
+        "Goal": "Goal",
         "Button": {
             "Roll": "Roll",
             "Continue": "Continue",

--- a/src/system/applications/item/components/talent-tree/index.ts
+++ b/src/system/applications/item/components/talent-tree/index.ts
@@ -2,3 +2,4 @@ import './talent-tree-view';
 import './talent-tree-editor';
 import './node-prerequisites';
 import './node-prerequisite-talent-list';
+import './node-prerequisite-goal-list';

--- a/src/system/applications/item/components/talent-tree/node-prerequisite-goal-list.ts
+++ b/src/system/applications/item/components/talent-tree/node-prerequisite-goal-list.ts
@@ -1,0 +1,155 @@
+import { TalentTree } from '@system/types/item';
+import { CosmereItem, GoalItem } from '@system/documents/item';
+import { ConstructorOf } from '@system/types/utils';
+
+// Component imports
+import { HandlebarsApplicationComponent } from '@system/applications/component-system';
+import { EditNodePrerequisiteDialog } from '../../dialogs/talent-tree/edit-node-prerequisite';
+
+// Mixins
+import { DragDropComponentMixin } from '@system/applications/mixins/drag-drop';
+
+// NOTE: Must use type here instead of interface as an interface doesn't match AnyObject type
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type Params = {
+    node: TalentTree.TalentNode;
+    goals: Collection<TalentTree.Node.Prerequisite.GoalRef>;
+};
+
+export class NodePrerequisiteGoalListComponent extends DragDropComponentMixin(
+    HandlebarsApplicationComponent<
+        ConstructorOf<EditNodePrerequisiteDialog>,
+        Params
+    >,
+) {
+    static readonly TEMPLATE =
+        'systems/cosmere-rpg/templates/item/talent-tree/components/prerequisite-goal-list.hbs';
+
+    /**
+     * NOTE: Unbound methods is the standard for defining actions
+     * within ApplicationV2
+     */
+    /* eslint-disable @typescript-eslint/unbound-method */
+    static ACTIONS = {
+        'remove-goal': this.onRemoveGoal,
+    };
+    /* eslint-enable @typescript-eslint/unbound-method */
+
+    static DRAG_DROP = [
+        {
+            dropSelector: '*',
+        },
+    ];
+
+    /* --- Accessors --- */
+
+    public get node() {
+        return this.params!.node;
+    }
+
+    public get goals() {
+        return this.params!.goals;
+    }
+
+    /* --- Actions --- */
+
+    private static onRemoveGoal(
+        this: NodePrerequisiteGoalListComponent,
+        event: Event,
+    ) {
+        // Get goal element
+        const el = $(event.currentTarget!).closest('.goal');
+
+        // Get id
+        const id = el.data('id') as string;
+
+        // Remove goal
+        this.goals.delete(id);
+
+        // Dispatch change event
+        this.element!.dispatchEvent(new Event('change'));
+
+        // Re-render
+        void this.render();
+    }
+
+    /* --- Drag drop --- */
+
+    protected override _canDragDrop() {
+        return true;
+    }
+
+    protected override async _onDrop(event: DragEvent) {
+        const data = TextEditor.getDragEventData(event) as unknown as {
+            type: string;
+            uuid: string;
+        };
+        if (data.type !== 'Item') return;
+
+        // Get document
+        const item = (await fromUuid(data.uuid))! as unknown as CosmereItem;
+
+        // Check if document is a goal
+        if (!item.isGoal()) return;
+
+        // Check if a goal with the same ID is already in the list
+        const duplicateRef = this.goals.find(
+            (ref) => ref.id === item.system.id,
+        );
+        if (duplicateRef) {
+            // Retrieve duplicate goal
+            const duplicate = (await fromUuid(
+                duplicateRef.uuid,
+            ))! as unknown as GoalItem;
+
+            // Show a warning
+            return ui.notifications.warn(
+                game.i18n!.format(
+                    'GENERIC.Warning.DuplicatePrerequisiteGoalRef',
+                    {
+                        goalId: duplicate.system.id,
+                        goalName: duplicate.name,
+                    },
+                ),
+            );
+        }
+
+        // Add goal to the list
+        this.goals.set(item.system.id, {
+            id: item.system.id,
+            uuid: item.uuid,
+            label: item.name,
+        });
+
+        // Dispatch change event
+        this.element!.dispatchEvent(new Event('change'));
+
+        // Re-render
+        void this.render();
+    }
+
+    /* --- Context --- */
+
+    public async _prepareContext(params: Params, context: never) {
+        // Construct content links
+        const contentLinks = this.goals.map(
+            (ref) => `@UUID[${ref.uuid}]{${ref.label}}`,
+        );
+
+        // Enrich links
+        const enrichedLinks = await Promise.all(
+            contentLinks.map((link) => TextEditor.enrichHTML(link)),
+        );
+
+        return {
+            ...params,
+            goals: this.goals.map(({ id }, index) => ({
+                id,
+                link: enrichedLinks[index],
+            })),
+        };
+    }
+}
+
+// Register the component
+NodePrerequisiteGoalListComponent.register('app-node-prerequisite-goal-list');

--- a/src/system/applications/item/components/talent-tree/node-prerequisites.ts
+++ b/src/system/applications/item/components/talent-tree/node-prerequisites.ts
@@ -165,6 +165,14 @@ export class NodePrerequisitesComponent extends HandlebarsApplicationComponent<
                   }
                 : {}),
 
+            ...(rule.type === TalentTree.Node.Prerequisite.Type.Goal
+                ? {
+                      goals: await Promise.all(
+                          rule.goals.map(this.prepareRefContext.bind(this)),
+                      ),
+                  }
+                : {}),
+
             ...(rule.type === TalentTree.Node.Prerequisite.Type.Ancestry
                 ? {
                       ancestry: await this.prepareRefContext(rule.ancestry),

--- a/src/system/applications/item/components/talent-tree/talent-tree-view.ts
+++ b/src/system/applications/item/components/talent-tree/talent-tree-view.ts
@@ -590,6 +590,25 @@ export class TalentTreeViewComponent<
                                   })),
                               }
                             : undefined),
+                        ...(prereq.type ===
+                        TalentTree.Node.Prerequisite.Type.Goal
+                            ? {
+                                  goals: prereq.goals.map((ref) => ({
+                                      id: ref.id,
+                                      label:
+                                          (
+                                              fromUuidSync(ref.uuid) as
+                                                  | Pick<CosmereItem, 'name'>
+                                                  | undefined
+                                          )?.name ?? ref.label,
+                                      uuid: ref.uuid,
+                                      completed:
+                                          this.contextActor?.hasCompletedGoal(
+                                              ref.id,
+                                          ) ?? false,
+                                  })),
+                              }
+                            : undefined),
                     };
                 }),
                 description: await TextEditor.enrichHTML(

--- a/src/system/applications/item/dialogs/talent-tree/edit-node-prerequisite.ts
+++ b/src/system/applications/item/dialogs/talent-tree/edit-node-prerequisite.ts
@@ -79,6 +79,8 @@ export class EditNodePrerequisiteDialog extends ComponentHandlebarsApplicationMi
             data.talents = new RecordCollection(
                 Array.from(data.talents.entries()),
             );
+        } else if (data.type === TalentTree.Node.Prerequisite.Type.Goal) {
+            data.goals = new RecordCollection(Array.from(data.goals.entries()));
         }
 
         const dialog = new this(tree, node, data);
@@ -117,6 +119,40 @@ export class EditNodePrerequisiteDialog extends ComponentHandlebarsApplicationMi
                     (acc, id) => ({
                         ...acc,
                         [`system.nodes.${this.node.id}.prerequisites.${this.data.id}.talents.-=${id}`]:
+                            {},
+                    }),
+                    {},
+                ),
+            });
+        } else if (this.data.type === TalentTree.Node.Prerequisite.Type.Goal) {
+            // Get the old prerequisite state
+            const old = this.node.prerequisites.get(this.data.id);
+
+            // Get previous goals
+            const prevGoals =
+                old?.type === TalentTree.Node.Prerequisite.Type.Goal
+                    ? Array.from(old.goals.keys())
+                    : [];
+
+            // Figure out which goals have been removed
+            const removedGoals = prevGoals.filter(
+                (id) =>
+                    !(this.data as TalentTree.Node.GoalPrerequisite).goals.has(
+                        id,
+                    ),
+            );
+
+            void this.tree.update({
+                [`system.nodes.${this.node.id}.prerequisites.${this.data.id}`]:
+                    this.data,
+                [`system.nodes.${this.node.id}.prerequisites.${this.data.id}.goals`]:
+                    this.data.goals.toJSON(),
+
+                // Add removals
+                ...removedGoals.reduce(
+                    (acc, id) => ({
+                        ...acc,
+                        [`system.nodes.${this.node.id}.prerequisites.${this.data.id}.goals.-=${id}`]:
                             {},
                     }),
                     {},
@@ -171,6 +207,8 @@ export class EditNodePrerequisiteDialog extends ComponentHandlebarsApplicationMi
             this.data.type === TalentTree.Node.Prerequisite.Type.Talent
         ) {
             this.data.talents ??= new RecordCollection();
+        } else if (this.data.type === TalentTree.Node.Prerequisite.Type.Goal) {
+            this.data.goals ??= new RecordCollection();
         } else if (
             this.data.type === TalentTree.Node.Prerequisite.Type.Connection
         ) {

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -868,6 +868,8 @@ const COSMERE: CosmereRPGConfig = {
                             'COSMERE.Item.Talent.Prerequisite.Type.ancestry',
                         [TalentTree.Node.Prerequisite.Type.Culture]:
                             'COSMERE.Item.Talent.Prerequisite.Type.culture',
+                        [TalentTree.Node.Prerequisite.Type.Goal]:
+                            'COSMERE.Item.Talent.Prerequisite.Type.goal',
                     },
                 },
             },

--- a/src/system/data/item/fields/talent-tree-node-collection.ts
+++ b/src/system/data/item/fields/talent-tree-node-collection.ts
@@ -255,6 +255,30 @@ class TalentTreeNodeField extends foundry.data.fields.SchemaField {
                                 label: 'COSMERE.Item.Talent.Prerequisite.Culture.Label',
                             },
                         ),
+
+                        // Goal
+                        goals: new CollectionField(
+                            new foundry.data.fields.SchemaField({
+                                uuid: new foundry.data.fields.StringField({
+                                    required: true,
+                                    nullable: false,
+                                    blank: false,
+                                }),
+                                id: new foundry.data.fields.StringField({
+                                    required: true,
+                                    nullable: false,
+                                    blank: false,
+                                }),
+                                label: new foundry.data.fields.StringField({
+                                    required: true,
+                                    nullable: false,
+                                    blank: false,
+                                }),
+                            }),
+                            {
+                                nullable: true,
+                            },
+                        ),
                     }),
                     {
                         nullable: true,

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -1350,6 +1350,22 @@ export class CosmereActor<
         return characterMeetsTalentPrerequisites(this, prerequisites);
     }
 
+    /**
+     * Utility function to determine if an actor has a given goal
+     */
+    public hasGoal(id: string): boolean {
+        return this.goals.some((goal) => goal.system.id === id);
+    }
+
+    /**
+     * Utility function to determine if an actor has completed a given goal
+     */
+    public hasCompletedGoal(id: string): boolean {
+        return this.goals.some(
+            (goal) => goal.system.id === id && goal.system.level === 3,
+        );
+    }
+
     /* --- Helpers --- */
 
     /**

--- a/src/system/types/item/talent-tree.ts
+++ b/src/system/types/item/talent-tree.ts
@@ -37,6 +37,7 @@ export namespace Node {
             Level = 'level',
             Ancestry = 'ancestry',
             Culture = 'culture',
+            Goal = 'goal',
         }
 
         export const enum Mode {
@@ -62,6 +63,8 @@ export namespace Node {
         }
 
         export type TalentRef = ItemRef;
+
+        export type GoalRef = ItemRef;
     }
 
     interface BasePrerequisite<Type extends Prerequisite.Type> {
@@ -97,6 +100,11 @@ export namespace Node {
         talents: Collection<Prerequisite.TalentRef>;
     }
 
+    export interface GoalPrerequisite
+        extends BasePrerequisite<Prerequisite.Type.Goal> {
+        goals: Collection<Prerequisite.GoalRef>;
+    }
+
     export interface LevelPrerequisite
         extends BasePrerequisite<Prerequisite.Type.Level> {
         level: number;
@@ -119,7 +127,8 @@ export namespace Node {
         | TalentPrerequisite
         | LevelPrerequisite
         | AncestryPrerequisite
-        | CulturePrerequisite;
+        | CulturePrerequisite
+        | GoalPrerequisite;
 }
 
 export interface BaseNode<Type extends Node.Type = Node.Type> {

--- a/src/system/utils/talent-tree.ts
+++ b/src/system/utils/talent-tree.ts
@@ -256,6 +256,10 @@ export function characterMeetsPrerequisiteRule(
             return actor.cultures.some(
                 (culture) => culture.system.id === prereq.culture.id,
             );
+        case TalentTree.Node.Prerequisite.Type.Goal:
+            return Array.from(prereq.goals).some((ref) =>
+                actor.hasCompletedGoal(ref.id),
+            );
         case TalentTree.Node.Prerequisite.Type.Connection:
             return true; // No way to check connections
         default:

--- a/src/templates/item/talent-tree/components/prerequisite-goal-list.hbs
+++ b/src/templates/item/talent-tree/components/prerequisite-goal-list.hbs
@@ -1,0 +1,21 @@
+<ul>
+    <li>test</li>
+    {{#each goals as |goal|}}
+    <li class="goal" data-id="{{goal.id}}">
+        <div class="col link">
+            {{{goal.link}}}
+        </div>
+        <div class="col controls">
+            <a data-action="remove-goal"
+                data-tooltip="GENERIC.Button.Remove"
+            >
+                <i class="fa-solid fa-trash"></i>
+            </a>
+        </div>
+    </li>
+    {{/each}}
+</ul>
+<p>
+    sdfjas;lkdjfl;asj
+    {{localize "COSMERE.Item.Sheet.Talent.Prerequisites.DropGoals"}}
+</p>

--- a/src/templates/item/talent-tree/components/prerequisite-goal-list.hbs
+++ b/src/templates/item/talent-tree/components/prerequisite-goal-list.hbs
@@ -1,5 +1,4 @@
 <ul>
-    <li>test</li>
     {{#each goals as |goal|}}
     <li class="goal" data-id="{{goal.id}}">
         <div class="col link">
@@ -16,6 +15,5 @@
     {{/each}}
 </ul>
 <p>
-    sdfjas;lkdjfl;asj
     {{localize "COSMERE.Item.Sheet.Talent.Prerequisites.DropGoals"}}
 </p>

--- a/src/templates/item/talent-tree/components/prerequisites.hbs
+++ b/src/templates/item/talent-tree/components/prerequisites.hbs
@@ -36,6 +36,13 @@
                             <span>,</span>
                         {{/if}}
                     {{/each}}
+                {{else if (eq rule.type "goal")}}
+                    {{#each rule.goals as |ref|}}
+                        {{{ref.link}}}
+                        {{#if (not @last)}}
+                            <span>,</span>
+                        {{/if}}
+                    {{/each}}
                 {{else if (eq rule.type "attribute")}}
                     <span>{{localize (concat "COSMERE.Attribute." rule.attribute)}}</span>
                     <span>{{rule.value}}+</span>

--- a/src/templates/item/talent-tree/dialogs/edit-prerequisite.hbs
+++ b/src/templates/item/talent-tree/dialogs/edit-prerequisite.hbs
@@ -19,6 +19,16 @@
         </div>
     {{/if}}
 
+    {{!-- Goal --}}
+    {{#if (eq type "goal")}}
+        <div class="form-group">
+            {{app-node-prerequisite-goal-list
+                node=node
+                goals=goals
+            }}
+        </div>
+    {{/if}}
+
     {{!-- Attribute --}}
     {{#if (eq type "attribute")}}
     <div class="form-group">
@@ -32,9 +42,9 @@
     <div class="form-group">
         <label>{{localize "COSMERE.Item.Sheet.Talent.Prerequisites.AttributeValue"}}</label>
         <div class="form-fields">
-            <input 
-                type="number" 
-                name="value" 
+            <input
+                type="number"
+                name="value"
                 value="{{value}}"
                 min="0"
                 step="1"
@@ -57,9 +67,9 @@
     <div class="form-group">
         <label>{{localize "COSMERE.Item.Sheet.Talent.Prerequisites.SkillRank"}}</label>
         <div class="form-fields">
-            <input 
-                type="number" 
-                name="rank" 
+            <input
+                type="number"
+                name="rank"
                 value="{{rank}}"
                 min="0"
                 step="1"
@@ -74,9 +84,9 @@
     <div class="form-group">
         <label>{{localize "COSMERE.Item.Sheet.Talent.Prerequisites.ConnectionDescription"}}</label>
         <div class="form-fields">
-            <input 
-                type="text" 
-                name="description" 
+            <input
+                type="text"
+                name="description"
                 value="{{description}}"
                 placeholder="{{localize "COSMERE.Item.Sheet.Talent.Prerequisites.ConnectionDescriptionPlaceholder"}}"
             >

--- a/src/templates/item/talent-tree/partials/talent-tree-node-tooltip.hbs
+++ b/src/templates/item/talent-tree/partials/talent-tree-node-tooltip.hbs
@@ -21,7 +21,9 @@
                         <i class="fa-solid fa-list-check"></i>
                         {{#each prereq.goals as |goal|}}
                             <span>{{goal.label}}</span>
-                            <span>{{lower (localize "GENERIC.Goal")}}</span>
+                            {{#if (not @last)}}
+                                <span>or</span>
+                            {{/if}}
                         {{/each}}
                     {{else if (eq prereq.type "attribute")}}
                         <i class="fa-solid fa-chart-column"></i>

--- a/src/templates/item/talent-tree/partials/talent-tree-node-tooltip.hbs
+++ b/src/templates/item/talent-tree/partials/talent-tree-node-tooltip.hbs
@@ -17,6 +17,12 @@
                                 <span>or</span>
                             {{/if}}
                         {{/each}}
+                    {{else if (eq prereq.type "goal")}}
+                        <i class="fa-solid fa-list-check"></i>
+                        {{#each prereq.goals as |goal|}}
+                            <span>{{goal.label}}</span>
+                            <span>{{lower (localize "GENERIC.Goal")}}</span>
+                        {{/each}}
                     {{else if (eq prereq.type "attribute")}}
                         <i class="fa-solid fa-chart-column"></i>
                         <span>{{localize (concat "COSMERE.Attribute." prereq.attribute)}}</span>


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
A specific completed goal can now be required by a talent node in a tree in order to take it. For example, Second Idea (Windrunner) can now require the "Speak the First Ideal" goal be completed, rather than just requiring the First Ideal (Windrunner) talent.

**Related Issue**  
Closes #461 

**How Has This Been Tested?**  
- Create a talent tree
- Add a talent node
- Click the node and add a prerequisite
- Select 'goal' from the dropdown
- Drag and drop any number of goals
- Click confirm on the prereq and disable edit mode
- Confirm the goal(s) appear as a prerequisite in the hover tooltip for the talent node
- Try to add the talent to a sheet that does not have the goal(s) (should fail)
- Try to add the talent to a sheet that has the goal(s) not completed (should fail)
- Try to add the talent to a sheet that has the goal(s) completed (should succeed)

**Screenshots (if applicable)**  
_Add screenshots or GIFs that help illustrate the changes, especially if they affect the UI or user-facing aspects of the system._

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: [insert version here].

**Additional context**  
It is a known bug outside the scope of this PR that the prerequisites list does not update/rerender on closing the prereq menu—you have to either toggle edit mode off and back on or close and reopen the sheet.