### PR TITLE
fix(0.3-1.0 migration): fix issue where some grant rules would fail to migrate

### DIFF
--- a/src/system/utils/migration/migrations/0.3-1.0.ts
+++ b/src/system/utils/migration/migrations/0.3-1.0.ts
@@ -169,10 +169,15 @@ function migrateItemData(item: RawDocumentData<any>, changes: object) {
     if (item.type === 'talent') {
         if ('grantRules' in item.system) {
             // Migrate grant rules to event system
-            const grantRules = item.system.grantRules as Record<
-                string,
-                AnyObject
-            >;
+            let grantRules = item.system.grantRules as
+                | Record<string, AnyObject>
+                | AnyObject[];
+
+            if (Array.isArray(grantRules)) {
+                grantRules = Object.fromEntries(
+                    grantRules.map((rule) => [rule._id, rule]),
+                ) as Record<string, AnyObject>;
+            }
 
             // Prepare the events object
             const events: AnyMutableObject = {};


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue where the migration of grant rules would fail because the stored data was an object in same cases and an array in others. 

**Related Issue**  
—

**How Has This Been Tested?**  
Ran migration against an older compendium

**Checklist:**  
- [ ] I have commented on my code, particularly in hard-to-understand areas. **N/A**
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343