### PR TITLE
Chore: Clear Unused Goal Item Type Imports

### DIFF
--- a/src/system/data/item/goal.ts
+++ b/src/system/data/item/goal.ts
@@ -1,4 +1,3 @@
-import { Goal } from '@system/types/item';
 import { CosmereItem } from '@system/documents';
 
 import { CollectionField } from '@system/data/fields';

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -10,7 +10,6 @@ import {
     ArmorTraitId,
     ActionCostType,
 } from '@system/types/cosmere';
-import { Goal } from '@system/types/item';
 import { CosmereHooks } from '@system/types/hooks';
 import { DeepPartial, Nullable } from '@system/types/utils';
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Other (please describe): simple build warning fix

**Description**  
Some attempts to import the 'Goal' item from the item types directory were left after the recent migration of goal rewards to the events system

**How Has This Been Tested?**  
Build warning is gone.

**Checklist:**  
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes do not introduce any new warnings or errors.
- [ ] My PR does not contain any copyrighted works that I do not have permission to use.
- [ ] I have tested my changes on Foundry VTT version: [insert version here].

**Additional context**  
N/A
