### PR TITLE
fix(event system): fix an issue causing certain sequential event combinations to break

### DIFF
--- a/src/system/hooks/item-event-system/index.ts
+++ b/src/system/hooks/item-event-system/index.ts
@@ -305,7 +305,9 @@ async function fireEvent(event: Event) {
 
             try {
                 // Execute the rule
-                return await rule.handler.execute(event);
+                return await rule.handler.execute(
+                    foundry.utils.deepClone(event),
+                );
             } catch (e) {
                 console.error(
                     `[${SYSTEM_ID}] Error executing event rule ${rule.id} for item ${item.name} ${item.uuid}`,


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue where the operations object passed to updates/creates/etc. retains info from previous events thus causing invalid states with certain combinations.

Closes #486 

**How Has This Been Tested?**  
1. Create actor
2. Create item
3. Add event, trigger: `added to actor`, handler: `grant items` -> set at least one item
4. Add a second event, trigger: `added to actor`, handler: `update actor` -> set any actor property
5. Drag the item onto the actor

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343