### PR TITLE
fix(api): fix issue causing duplicate registrations to not get detected properly

### DIFF
--- a/src/system/api/general.ts
+++ b/src/system/api/general.ts
@@ -6,6 +6,9 @@ import {
 } from '@system/types/config';
 import { RegistrationHelper } from './helper';
 
+// Utils
+import { objectsEqual } from './utils';
+
 export function getCurrentRegistrations() {
     return RegistrationHelper.COMPLETED;
 }
@@ -79,10 +82,9 @@ export function registerCurrency(data: CurrencyConfigData) {
     if (data.id in CONFIG.COSMERE.currencies) {
         // If the same object is already registered, we ignore the registration and mark it succesful.
         if (
-            foundry.utils.objectsEqual(
-                toRegister,
-                CONFIG.COSMERE.currencies[data.id],
-            )
+            objectsEqual(toRegister, CONFIG.COSMERE.currencies[data.id], [
+                'icon',
+            ])
         ) {
             return true;
         }

--- a/src/system/api/sheet.ts
+++ b/src/system/api/sheet.ts
@@ -5,6 +5,9 @@ import {
 import { RegistrationConfig } from '../types/config';
 import { RegistrationHelper } from './helper';
 
+// Utils
+import { objectsEqual } from './utils';
+
 /**
  * Registers a new static section for the actor's actions list.
  */
@@ -42,11 +45,12 @@ export function registerActionListSection(
     ) {
         // If the same object is already registered, we ignore the registration and mark it succesful.
         if (
-            foundry.utils.objectsEqual(
+            objectsEqual(
                 toRegister,
                 CONFIG.COSMERE.sheet.actor.components.actions.sections.static[
                     data.id
                 ],
+                ['filter', 'new'],
             )
         ) {
             return true;

--- a/src/system/api/utils.ts
+++ b/src/system/api/utils.ts
@@ -1,0 +1,21 @@
+export function objectsEqual<A extends object, B extends A>(
+    a: A,
+    b: B,
+    ignoreKeys: (keyof A | keyof B)[] = [],
+): a is B {
+    if (a === b) return true;
+
+    // Make a copy of the object without ignored keys
+    const filteredA = Object.fromEntries(
+        Object.entries(a).filter(
+            ([key]) => !ignoreKeys.includes(key as keyof A),
+        ),
+    );
+    const filteredB = Object.fromEntries(
+        Object.entries(b).filter(
+            ([key]) => !ignoreKeys.includes(key as keyof B),
+        ),
+    );
+
+    return foundry.utils.objectsEqual(filteredA, filteredB);
+}


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes the issue causing the api to display an error when multiple modules register the same currencies/inventory sections. 

**Related Issue**  
Closes #489 

**How Has This Been Tested?**  
1. Load up a world with multiple modules that register the same currencies and/or inventory sections

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343