### PR TITLE
fix: errors on closing locked actors

### DIFF
--- a/src/system/applications/actor/components/adversary/skills.ts
+++ b/src/system/applications/actor/components/adversary/skills.ts
@@ -126,25 +126,21 @@ export class AdversarySkillsComponent extends HandlebarsApplicationComponent<
             .on('click', (event) => this.onClickCollapsible(event));
     }
 
-    protected _onDestroy(): void {
-        // Setting a flag causes a document update and therefore a re-render.
-        // We don't want to re-render every time we collapse a section because it breaks transitions.
-        // This flag is therefore only stored once at the end when closing the document so that
-        // it is available in the correct state when we next open the document and reinitialize this component.
-        void this.application.actor.setFlag(
-            SYSTEM_ID,
-            'sheet.skillsCollapsed',
-            this.sectionCollapsed,
-        );
-
-        super._onDestroy();
-    }
-
     /* --- Event handlers --- */
     private onClickCollapsible(event: JQuery.ClickEvent) {
         const target = event.currentTarget as HTMLElement;
         target?.parentElement?.classList.toggle('expanded');
         this.sectionCollapsed = !this.sectionCollapsed;
+
+        if (!this.application.isEditable) return;
+
+        void this.application.actor.update(
+            {
+                'flags.cosmere-rpg.sheet.skillsCollapsed':
+                    this.sectionCollapsed,
+            },
+            { render: false },
+        );
     }
 }
 

--- a/src/system/applications/actor/components/immunities.ts
+++ b/src/system/applications/actor/components/immunities.ts
@@ -97,26 +97,22 @@ export class ActorImmunitiesComponent extends HandlebarsApplicationComponent<
             .on('click', (event) => this.onClickCollapsible(event));
     }
 
-    protected _onDestroy(): void {
-        // Setting a flag causes a document update and therefore a re-render.
-        // We don't want to re-render every time we collapse a section because it breaks transitions.
-        // This flag is therefore only stored once at the end when closing the document so that
-        // it is available in the correct state when we next open the document and get the flag in prepareContext.
-        void this.application.actor.setFlag(
-            SYSTEM_ID,
-            'sheet.immunitiesCollapsed',
-            this.sectionCollapsed,
-        );
-
-        super._onDestroy();
-    }
-
     /* --- Event handlers --- */
 
     private onClickCollapsible(event: JQuery.ClickEvent) {
         const target = event.currentTarget as HTMLElement;
         target?.parentElement?.classList.toggle('expanded');
         this.sectionCollapsed = !this.sectionCollapsed;
+
+        if (!this.application.isEditable) return;
+
+        void this.application.actor.update(
+            {
+                'flags.cosmere-rpg.sheet.immunitiesCollapsed':
+                    this.sectionCollapsed,
+            },
+            { render: false },
+        );
     }
 }
 

--- a/src/system/applications/components/expertises-list.ts
+++ b/src/system/applications/components/expertises-list.ts
@@ -160,28 +160,24 @@ export class ExpertisesListComponent extends HandlebarsApplicationComponent<
         }
     }
 
-    protected override _onDestroy(): void {
-        // Setting a flag causes a document update and therefore a re-render.
-        // We don't want to re-render every time we collapse a section because it breaks CSS transitions.
-        // This flag is therefore only stored once at the end when closing the document so that
-        // it is available in the correct state when we next open the document and get the flag in prepareContext.
-        if (this.application instanceof BaseActorSheet) {
-            void this.application.actor.setFlag(
-                SYSTEM_ID,
-                'sheet.expertisesCollapsed',
-                this._collapsed,
-            );
-        }
-
-        super._onDestroy();
-    }
-
     /* --- Event handlers --- */
 
     private onClickCollapsible(event: JQuery.ClickEvent) {
         const target = event.currentTarget as HTMLElement;
         target?.parentElement?.classList.toggle('expanded');
         this._collapsed = !this._collapsed;
+
+        if (this.application instanceof BaseActorSheet) {
+            if (!this.application.isEditable) return;
+
+            void this.application.actor.update(
+                {
+                    'flags.cosmere-rpg.sheet.expertisesCollapsed':
+                        this._collapsed,
+                },
+                { render: false },
+            );
+        }
     }
 
     /* --- Context --- */

--- a/src/templates/actors/adversary/components/skills.hbs
+++ b/src/templates/actors/adversary/components/skills.hbs
@@ -6,6 +6,7 @@
             <span>{{localize "COSMERE.Actor.Skill.label_p"}}</span>
         </div>
         <div class="controls">
+            {{#if editable}}
             <a role="button"
                 data-action="toggle-hide-unranked"
                 data-tooltip="COSMERE.Actor.Sheet.{{#if hideUnranked}}ToggleShowSkills{{else}}ToggleCollapseSkills{{/if}}"
@@ -16,6 +17,7 @@
                 <i class="fas fa-eye-slash"></i>
                 {{/if}}
             </a>
+            {{/if}}
             {{#if isEditMode}}
             <a role="button"
                 data-action="configure-skills"


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue where skills, expertises, and immunities section would attempt to update an actor flag on destroy, which would throw errors when doing so for locked actors.

**Related Issue**  
Closes #490.

**How Has This Been Tested?**  
Tested locked actors to see that no errors are thrown on close. Tested also that non-locked actors still have full functionality as normal.

**Screenshots (if applicable)**  
_Add screenshots or GIFs that help illustrate the changes, especially if they affect the UI or user-facing aspects of the system._

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: 12.343.
