### PR TITLE
Changed deregisterApplicationInstance function

### DIFF
--- a/src/system/applications/component-system/system.ts
+++ b/src/system/applications/component-system/system.ts
@@ -288,11 +288,12 @@ export function deregisterApplicationInstance(
     console.log('Deregistering application instance:', application.id);
 
     // Destroy all components that belonged to this application
-    Object.keys(componentRegistry).forEach((componentRef) => {
-        if (componentRef.startsWith(application.id)) {
-            destroyComponent(componentRef);
-        }
-    });
+    Object.keys(componentRegistry)
+        .filter((componentRef) => 
+            componentRef.startsWith(application.id) && 
+            !componentRegistry[componentRef]?.parentRef // no parent, only top level components
+        )
+        .forEach((componentRef) => destroyComponent(componentRef));
 
     // Remove application instance
     delete applicationInstances[application.id];


### PR DESCRIPTION
It should fix the error that appears after each closing window. The main idea of the fix is destroy only top level components. It should destroy others components without errors in console.

<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ x ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
There is an error in console when you close each window 

**Related Issue**  
Sorry, i didn't find Issue with this. But i asked about it in discord channel, and got answer that you are aware about this problem.

**How Has This Been Tested?**  
Start new fully blank world and try to close windows of characters, items etc. And no errors have appeared.

**Screenshots (if applicable)**  
Before

https://github.com/user-attachments/assets/5a445aba-bf21-4001-aafb-b8946b3c58bd


After

https://github.com/user-attachments/assets/931b6afb-4a4f-4d2b-a79c-0e05d7901021



**Checklist:**  
- [ x ] I have commented on my code, particularly in hard-to-understand areas.
- [x ] My changes do not introduce any new warnings or errors.
- [ x ] My PR does not contain any copyrighted works that I do not have permission to use.
- [ x ] I have tested my changes on Foundry VTT version: 12.343.


