### PR TITLE
Prevent application deregistration from attempting to re-destroy components

### DIFF
--- a/src/system/applications/component-system/system.ts
+++ b/src/system/applications/component-system/system.ts
@@ -288,11 +288,21 @@ export function deregisterApplicationInstance(
     console.log('Deregistering application instance:', application.id);
 
     // Destroy all components that belonged to this application
-    Object.keys(componentRegistry).forEach((componentRef) => {
+    //
+    // Because we're deleting child references recursively, the remaining
+    // registry keys are NOT stable, and may have changed during the root call
+    // to destroyComponent.
+    // We need to check again whenever we've destroyed a potential parent component.
+    for (
+        let componentsToDestroy = Object.keys(componentRegistry);
+        componentsToDestroy.length > 0;
+        componentsToDestroy = Object.keys(componentRegistry)
+    ) {
+        const componentRef = componentsToDestroy[0];
         if (componentRef.startsWith(application.id)) {
             destroyComponent(componentRef);
         }
-    });
+    }
 
     // Remove application instance
     delete applicationInstances[application.id];


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
The existing control flow for application instance deregistration failed to account for components still persisting in the local copy of the `componentRegistry`'s keys, despite having been recursively deleted while processing a previous registry entry. This PR updates the control flow to check the _new_ state of the registry entries after each loop, to ensure that any child components are no longer present in the list of components to destroy.

**Related Issue**  
Closes #533

**How Has This Been Tested?**  
1. Open a Character sheet
2. Close the Character sheet
3. Regression: Confirm that any instance of that application is gone (i.e. `foundry.applications.instances` is empty, if the character sheet was the only open document)
4. Issue resolution: Observe that the previous error message is now gone

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343.
