### PR TITLE
Feat: Add Roll Data Registration to API

### DIFF
--- a/src/system/api/actor.ts
+++ b/src/system/api/actor.ts
@@ -2,6 +2,7 @@ import { Skill } from '@system/types/cosmere';
 import { SkillConfig } from '@system/types/config';
 import { CommonRegistrationData } from './types';
 import { RegistrationHelper } from './helper';
+import { RollDataConfig } from '../types/config';
 
 interface SkillConfigData
     extends Omit<SkillConfig, 'key'>,
@@ -42,6 +43,55 @@ export function registerSkill(data: SkillConfigData) {
             hiddenUntilAcquired: data.hiddenUntilAcquired,
         };
         CONFIG.COSMERE.attributes[data.attribute].skills.push(data.id as Skill);
+        return true;
+    };
+
+    return RegistrationHelper.tryRegisterConfig({
+        key,
+        data,
+        register,
+    });
+}
+
+/**
+ * Registers roll data for sheets of specific types.
+ */
+interface RollDataConfigData
+    extends Omit<RollDataConfig, 'label'>,
+        CommonRegistrationData {
+    /**
+     * Unique id for the roll data.
+     */
+    id: string;
+}
+
+export function registerRollData(data: RollDataConfigData) {
+    if (!CONFIG.COSMERE) {
+        throw new Error(
+            'Cannot access the API until after the system is initialized.',
+        );
+    }
+
+    // Clean data, remove fields that are not part of the config
+    data = {
+        id: data.id,
+        override: data.override,
+        types: data.types,
+        data: data.data,
+        source: data.source,
+        priority: data.priority,
+        strict: data.strict,
+    };
+
+    const key = `rollData.${data.id}`;
+
+    const register = () => {
+        CONFIG.COSMERE.rollData[data.id] = {
+            label: data.id,
+            override: data.override,
+            types: data.types,
+            data: data.data,
+        };
         return true;
     };
 

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -1147,6 +1147,8 @@ const COSMERE: CosmereRPGConfig = {
         },
     },
 
+    rollData: {},
+
     sheet: {
         actor: {
             components: {

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -1292,7 +1292,7 @@ export class CosmereActor<
                             this,
                             data,
                         ) as number;
-                        if (property && typeof property === 'number') {
+                        if (typeof property === 'number') {
                             val = property;
                         }
                     }

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -1131,7 +1131,7 @@ export class CosmereActor<
 
     public getRollData(): CosmereActorRollData<SystemType> {
         const tokens = this.getActiveTokens();
-        return {
+        const data = {
             ...(super.getRollData() as SystemType),
 
             name: this.name,
@@ -1208,6 +1208,11 @@ export class CosmereActor<
             // Hook data
             source: this,
         };
+        const registeredData = this.getRegisteredRollData(data) as Record<
+            string,
+            any
+        >;
+        return { ...data, ...registeredData };
     }
 
     public getEnricherData() {
@@ -1260,6 +1265,58 @@ export class CosmereActor<
 
         // Default to the first (assumed lowest) formula
         return scale[0].formula;
+    }
+
+    /**
+     * Utility Function to determine a formula value based on a scalar plot of an attribute value
+     */
+    public getRegisteredRollData(
+        initialRollData: CosmereActorRollData<SystemType>,
+    ): any {
+        const registeredData: Record<string, any> = {};
+        for (const key in CONFIG.COSMERE.rollData) {
+            const rollData = CONFIG.COSMERE.rollData[key];
+            if (!rollData.types.includes(this.type)) {
+                continue;
+            }
+            let value = 0;
+            rollData.data.forEach((data) => {
+                if (typeof data === 'string') {
+                    const property = foundry.utils.getProperty(
+                        this,
+                        data,
+                    ) as number;
+                    if (property && typeof property === 'number') {
+                        value += property;
+                    }
+                } else {
+                    value += data;
+                }
+            });
+            if (key.includes('.')) {
+                const splitKey = key.split('.');
+                if (
+                    !rollData.override &&
+                    Object.keys(initialRollData).includes(splitKey[0])
+                ) {
+                    continue;
+                }
+                const current = registeredData;
+                splitKey.forEach((propertyKey) => {
+                    current[propertyKey] = {} as Record<string, any>;
+                });
+                foundry.utils.setProperty(registeredData, key, value);
+            } else {
+                if (
+                    !rollData.override &&
+                    Object.keys(initialRollData).includes(key)
+                ) {
+                    continue;
+                }
+                registeredData[key] = value;
+            }
+        }
+        return registeredData;
     }
 
     /**

--- a/src/system/types/config.ts
+++ b/src/system/types/config.ts
@@ -33,6 +33,7 @@ import {
     Theme,
     MovementType,
     ImmunityType,
+    ActorType,
 } from './cosmere';
 import { AdvantageMode } from './roll';
 
@@ -374,6 +375,28 @@ export interface ItemEventHandlerTypeConfig {
     documentClass: ItemEventSystem.HandlerCls;
 }
 
+export interface RollDataConfig {
+    /**
+     * A label which functions as an identifier and property path for the roll data.
+     */
+    label: string;
+
+    /**
+     * Whether or not it should override existing roll data properties.
+     */
+    override?: boolean;
+
+    /**
+     * The types of document the data applies to.
+     */
+    types: ActorType[];
+
+    /**
+     * The data to provide, in the form of raw values to add or document.system variables to pull from.
+     */
+    data: (string | number)[];
+}
+
 export interface CosmereRPGConfig {
     themes: Record<Theme, string>;
     sizes: Record<Size, SizeConfig>;
@@ -503,6 +526,8 @@ export interface CosmereRPGConfig {
             };
         };
     };
+
+    rollData: Record<string, RollDataConfig>;
 
     sheet: {
         actor: {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This adds the ability to dynamically register 'roll data' in the config via the API, which is then resolved in the getRollData() function for the actor sheets. It allows an arbitrary amount of data, can include nested keys, acquire data from the actor using nested keys, and specify the subtype of actor it should be applied to. It also supports mathematical operators in the list, defaulting to addition and keeping the last operator set for future operations.

**Related Issue**  
Resolves #548 

**How Has This Been Tested?**  
I registered the following values via a module and checked they appeared in the actor roll data and resolved appropriately:
```js
export const ROLL_DATA: CosmereAPI.RollDataConfigData[] = [
	{
		id: "test.embedded",
		types: [ActorType.Character],
		data: [5, '-', 3],
	},
	{
		id: "workbenchA",
		types: [ActorType.Character],
		data: [3, 6, '*', 'system.deflect.value'],
	},
	{
		id: "scalar.damage.unarmed",
		types: [ActorType.Character, ActorType.Adversary],
		data: [4, '*', 'system.tier'],
		override: true,
	},
];
```

**Screenshots (if applicable)**  
<img width="666" height="933" alt="image" src="https://github.com/user-attachments/assets/625beb05-ef44-4947-937d-7d814e68516f" />

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: [insert version here].

**Additional context**  
N/A
