### PR TITLE
Fix: Adjust Roll Data Override to be Less Aggressive

### DIFF
--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -1212,7 +1212,12 @@ export class CosmereActor<
             string,
             any
         >;
-        return this.deepMergeData(data, registeredData);
+        return foundry.utils.mergeObject(data, registeredData, {
+            insertKeys: true,
+            insertValues: true,
+            overwrite: true,
+            recursive: true,
+        });
     }
 
     public getEnricherData() {
@@ -1265,36 +1270,6 @@ export class CosmereActor<
 
         // Default to the first (assumed lowest) formula
         return scale[0].formula;
-    }
-
-    /**
-     * Utility Function to deep merge two sets of roll data.
-     */
-
-    public deepMergeData(
-        dataA: Record<string, any>,
-        dataB: Record<string, any>,
-    ): CosmereActorRollData<SystemType> {
-        const result = { ...dataA };
-
-        for (const key in dataB) {
-            if (Object.hasOwn(dataB, key)) {
-                if (
-                    dataB[key] instanceof Object &&
-                    dataA[key] instanceof Object
-                ) {
-                    result[key] = this.deepMergeData(dataA[key], dataB[key]);
-                } else {
-                    result[key] = dataB[key] as
-                        | object
-                        | string
-                        | number
-                        | undefined;
-                }
-            }
-        }
-
-        return result as CosmereActorRollData<SystemType>;
     }
 
     /**


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Other (please describe):

**Description**  
This simplifies the way that the roll data config handles overrides, existing keys, etc. It also reduces the likelihood of erroneously and aggressively overriding existing roll data for no reason. Finally, it adds a simple deepMerge util for combining existing roll-data and module-defined roll-data more thoroughly.

**Related Issue**  
Fixes #551 

**How Has This Been Tested?**  
Define some roll data in a module, using various options and formula. Check actor.getRollData() in console from foundry app.

**Screenshots (if applicable)**  
N/A

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343.

**Additional context**  
N/A
