### PR TITLE
feat(item embeds): make heading configurable

### DIFF
--- a/src/style/sheets/journal.scss
+++ b/src/style/sheets/journal.scss
@@ -6,6 +6,23 @@
                 font-size: 10pt;
             }
         }
+
+        > a.embed-label {
+            position: relative;
+            padding-right: 1ch;
+
+            span {
+                font-weight: bold;
+                color: var(--cosmere-color-opportunity);
+            }
+
+            > i.icon {
+                position: absolute;
+                font-size: .5em;
+                top: 2px;
+                right: .9ch;
+            } 
+        }
     }
 
     section.item-embed.talent-tree {

--- a/src/system/utils/embed/item/generic.ts
+++ b/src/system/utils/embed/item/generic.ts
@@ -37,6 +37,11 @@ export async function buildEmbedHTML(
             },
         );
 
+    config.heading ??= true;
+    config.prependLabel = config.heading
+        ? false
+        : (config.prependLabel ?? true);
+
     const headingTag =
         config.values?.find((v) => HEADING_TAGS.includes(v)) ??
         DEFAULT_HEADING_TAG;

--- a/src/templates/item/action/embed.hbs
+++ b/src/templates/item/action/embed.hbs
@@ -1,13 +1,29 @@
-<{{{headingTag}}}>
-    <span>{{default config.label item.name}}</span>
-    {{#if item.system.activation.cost.type}}
-        <span>
-            (<em class="cosmere-icon">{{#if (eq item.system.activation.cost.type "act")}}{{item.system.activation.cost.value}}{{else}}{{cosmereDingbat item.system.activation.cost.type}}{{/if}}</em>)
-        </span>
-    {{/if}}
-    <a {{{linkDataStr}}}>
-        <i class="fa-solid fa-up-right-from-square"></i>
-    </a>
-</{{{headingTag}}}>
+{{#if config.heading}}
+    <{{{headingTag}}}>
+        <span>{{default config.label item.name}}</span>
+        {{#if item.system.activation.cost.type}}
+            <span>
+                (<em class="cosmere-icon">{{#if (eq item.system.activation.cost.type "act")}}{{item.system.activation.cost.value}}{{else}}{{cosmereDingbat item.system.activation.cost.type}}{{/if}}</em>)
+            </span>
+        {{/if}}
+        <a {{{linkDataStr}}}>
+            <i class="fa-solid fa-up-right-from-square"></i>
+        </a>
+    </{{{headingTag}}}>
+{{/if}}
 
-{{{description}}}
+{{#if config.prependLabel}}
+    <a class="embed-label" {{{linkDataStr}}}>
+        {{#if item.system.activation.cost.type}}
+            <span>
+                (<em class="cosmere-icon">{{#if (eq item.system.activation.cost.type "act")}}{{item.system.activation.cost.value}}{{else}}{{cosmereDingbat item.system.activation.cost.type}}{{/if}}</em>)
+            </span>
+        {{/if}}
+        <span>{{default config.label item.name}}.</span>
+        <i class="icon fa-solid fa-link"></i>
+    </a>
+{{/if}}
+
+<div {{#if config.prependLabel}}style="display: inline-block;"{{/if}}>
+    {{{description}}}
+</div>

--- a/src/templates/item/generic/embed.hbs
+++ b/src/templates/item/generic/embed.hbs
@@ -1,8 +1,19 @@
-<{{{headingTag}}}>
-    <span>{{default config.label item.name}}</span>
-    <a {{{linkDataStr}}}>
-        <i class="fa-solid fa-up-right-from-square"></i>
-    </a>
-</{{{headingTag}}}>
+{{#if config.heading}}
+    <{{{headingTag}}}>
+        <span>{{default config.label item.name}}</span>
+        <a {{{linkDataStr}}}>
+            <i class="fa-solid fa-up-right-from-square"></i>
+        </a>
+    </{{{headingTag}}}>
+{{/if}}
 
-{{{description}}}
+{{#if config.prependLabel}}
+    <a class="embed-label" {{{linkDataStr}}}>
+        <span>{{default config.label item.name}}.</span>
+        <i class="icon fa-solid fa-link"></i>
+    </a>
+{{/if}}
+
+<div {{#if config.prependLabel}}style="display: inline-block;"{{/if}}>
+    {{{description}}}
+</div>


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR adds the ability to configure the heading for item embeds.

**Related Issue**  
Closes #555 

**How Has This Been Tested?**  
1. Create journal and add page
2. Drag item (e.g. action) onto page
3. Replace `@UUID` with `@Embed`, set `inline`
4. Save the page
5. Ensure embed shows WITH heading
6. Edit the page, update embed: set `heading=false`
7. Save the page
8. Ensure embed shows no heading and has the label (item name) prepended to the description
9. Edit the page, update embed: set `prependLabel=false`
10. Save the page
11. Ensure embed shows only the description

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343