### PR TITLE
fix(effects): Fixed incorrect lookup of effect parent description

### DIFF
--- a/src/templates/actors/components/effects-list.hbs
+++ b/src/templates/actors/components/effects-list.hbs
@@ -142,7 +142,6 @@
             {{else}}
                 {{#with (lookup @root.itemState effect.id) as |state|}}
                 {{#with (lookup @root.itemData effect.id) as |data|}}
-                {{#with (lookup @root.itemData effect.parent.id) as |parentData|}}
 
 
                 <li class="item effect collapsible {{#if effect.active}}active{{/if}}" data-item-id="{{effect.id}}"
@@ -195,12 +194,11 @@
                     </section>
                     <section class="description collapsible-content">
                         <div class="wrapper">
-                            {{{default data.descriptionHTML (default parentData.descriptionHTML '<p>—</p>')}}}
+                            {{{default data.descriptionHTML '<p>—</p>'}}}
                         </div>
                     </section>
                 </li>
 
-                {{/with}}
                 {{/with}}
                 {{/with}}
             {{/if}}


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Removes the description lookup in Effects list from "parent" items which don't exist when an item is the only thing on the list

**Related Issue**  
Closes #935

**How Has This Been Tested?**  
Create two effects on one item, enable one while the other is disabled, and confirm that they both appear in the correct sections of the effects tab

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.
