### PR TITLE
fix(dialog): Made "pick" dialog default to having first element selec…

### DIFF
--- a/src/templates/general/dialogs/pick.hbs
+++ b/src/templates/general/dialogs/pick.hbs
@@ -1,8 +1,8 @@
 <form>
-    <div class="form-group-stacked"></div>
+    <div class="form-group-stacked">
         {{#each options as |option|}}
             <div class="form-field">
-                <input type="radio" name="choice" value="{{option.id}}" id="{{option.id}}">
+                <input type="radio" name="choice" value="{{option.id}}" id="{{option.id}}" {{#if @first}}checked{{/if}}>
                 <label for="{{option.id}}">
                     {{#if @root.localize}}
                         {{localize option.label}}


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Made the "pick" dialog auto-select the first radio button so that all radio buttons appear at dialog open

**Related Issue**  

**How Has This Been Tested?**  

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.