### PR TITLE
fix(effects): Removed incorrect parent lookup from effects list

### DIFF
--- a/src/templates/actors/components/effects-list.hbs
+++ b/src/templates/actors/components/effects-list.hbs
@@ -142,7 +142,6 @@
             {{else}}
                 {{#with (lookup @root.itemState effect.id) as |state|}}
                 {{#with (lookup @root.itemData effect.id) as |data|}}
-                {{#with (lookup @root.itemData effect.parent.id) as |parentData|}}
 
 
                 <li class="item effect collapsible {{#if effect.active}}active{{/if}}" data-item-id="{{effect.id}}"
@@ -195,12 +194,11 @@
                     </section>
                     <section class="description collapsible-content">
                         <div class="wrapper">
-                            {{{default data.descriptionHTML (default parentData.descriptionHTML '<p>—</p>')}}}
+                            {{{default data.descriptionHTML '<p>—</p>'}}}
                         </div>
                     </section>
                 </li>
 
-                {{/with}}
                 {{/with}}
                 {{/with}}
             {{/if}}


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix

**Description**  
Removed a lookup of nonexistent parent data from effects which have parents but are the only effect in their sublist (active/passive/inactive)

**Related Issue**  
Closes #935 

**How Has This Been Tested?**  
Created new item with two effects, verified they display as sub-elements under the parent effect, toggled one of them, verified that both effects still appear in the list

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.