### PR TITLE
fix(actor): pierce properly ignores deflect #934

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,104 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+    testDir: './src/system/tests/playwright',
+    /* Run tests in files in parallel */
+    fullyParallel: false,
+    /* Fail the build on CI if you accidentally left test.only in the source code. */
+    forbidOnly: !!process.env.CI,
+    /* Retry on CI only */
+    retries: process.env.CI ? 2 : 0,
+    /* For Foundry safety to start, disable all parallelism. */
+    workers: 1,
+    /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+    reporter: 'html',
+    /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+    use: {
+        /* Base URL to use in actions like `await page.goto('')`. */
+        baseURL: 'http://localhost:30000',
+        storageState: './playwright/.auth/state.json',
+        viewport: { width: 1920, height: 1080 },
+
+        /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+        trace: 'on-first-retry',
+    },
+    globalSetup: './src/system/tests/playwright/global-setup.ts',
+    globalTeardown: './src/system/tests/playwright/global-teardown.ts',
+
+    // Timeout config
+    timeout: 60_000, // Full test timeout: 60 seconds
+    expect: {
+        timeout: 10_000, // Assertions: 10 seconds
+    },
+
+    /* Configure projects for major browsers */
+    projects: [
+        {
+            name: 'chromium',
+            use: {
+                ...devices['Desktop Chrome'],
+                launchOptions: {
+                    args: process.env.CI
+                        ? []
+                        : ['--use-gl=angle', '--use-angle=gl'],
+                },
+                viewport: { width: 1920, height: 1080 },
+            },
+        },
+
+        // Disabled for minimum test time
+        // {
+        //     name: 'firefox',
+        //     use: {
+        //         ...devices['Desktop Firefox'],
+        //         viewport: { width: 1920, height: 1080 },
+        //     },
+        // },
+
+        // {
+        //     name: 'webkit',
+        //     use: {
+        //         ...devices['Desktop Safari'],
+        //         viewport: { width: 1920, height: 1080 },
+        //     },
+        // },
+
+        /* Test against mobile viewports. */
+        // {
+        //   name: 'Mobile Chrome',
+        //   use: { ...devices['Pixel 5'] },
+        // },
+        // {
+        //   name: 'Mobile Safari',
+        //   use: { ...devices['iPhone 12'] },
+        // },
+
+        /* Test against branded browsers. */
+        // {
+        //   name: 'Microsoft Edge',
+        //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+        // },
+        // {
+        //   name: 'Google Chrome',
+        //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+        // },
+    ],
+
+    /* Run your local dev server before starting the tests */
+    // webServer: {
+    //   command: 'npm run start',
+    //   url: 'http://localhost:3000',
+    //   reuseExistingServer: !process.env.CI,
+    // },
+});

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1630,19 +1630,76 @@
                 }
             }
         },
-        "Macro": {
-            "Talents": {
-                "Erudition": {
-                    "Dialog": {
-                        "Title": "{actor}: Erudition",
-                        "Skills": "Skills",
-                        "Expertises": "Expertises",
-                        "Expertise": "Expertise",
-                        "Warn": {
-                            "UniqueSkills": "Cannot select the same skill multiple times.",
-                            "UniqueExpertises": "Cannot select the same expertise multiple times."
-                        },
-                        "Confirm": "Confirm"
+        "Objects": {
+            "Generic": {
+                "Ancestry": {
+                    "Human": "Human"
+                }
+            },
+            "Stormlight": {
+                "Weapon": {
+                    "Axe": "Axe",
+                    "Hammer": "Hammer",
+                    "Knife": "Knife",
+                    "Longsword": "Longsword",
+                    "Longspear": "Longspear",
+                    "Mace": "Mace",
+                    "Shield": "Shield",
+                    "Shortbow": "Shortbow",
+                    "Shortspear": "Shortspear",
+                    "Sidesword": "Sidesword",
+                    "Staff": "Staff"
+                },
+                "Armor": {
+                    "Breastplate": "Breastplate",
+                    "Chain": "Chain",
+                    "FullPlate": "Full Plate",
+                    "HalfPlate": "Half Plate",
+                    "Leather": "Leather",
+                    "Uniform": "Uniform"
+                },
+                "Culture": {
+                    "Alethi": "Alethi",
+                    "Azish": "Azish",
+                    "Herdazian": "Herdazian",
+                    "Thaylen": "Thaylen",
+                    "Unkalaki": "Unkalaki",
+                    "Veden": "Veden"
+                },
+                "Currency": {
+                    "Spheres": "Spheres",
+                    "Mark": "Mark",
+                    "Chip": "Chip",
+                    "Broam": "Broam",
+                    "Diamond": "Diamond",
+                    "Garnet": "Garnet",
+                    "Heliodor": "Heliodor",
+                    "Topaz": "Topaz",
+                    "Ruby": "Ruby",
+                    "Smokestone": "Smokestone",
+                    "Zircon": "Zircon",
+                    "Amethyst": "Amethyst",
+                    "Sapphire": "Sapphire",
+                    "Emerald": "Emerald"
+                },
+                "Macro": {
+                    "StartingPath": {
+                        "Set": "Set starting path {path} for {actor}. Set starting skill: {skill}.",
+                        "Replaced": "Replaced starting path {oldPath} with {newPath} for {actor}. Set starting skill: {skill}.",
+                        "Unset": "Cleared starting path for {actor}. Removed starting skill: {skill}."
+                    },
+                    "Erudition": {
+                        "Dialog": {
+                            "Title": "{actor}: Erudition",
+                            "Skills": "Skills",
+                            "Expertises": "Expertises",
+                            "Expertise": "Expertise",
+                            "Warn": {
+                                "UniqueSkills": "Cannot select the same skill multiple times.",
+                                "UniqueExpertises": "Cannot select the same expertise multiple times."
+                            },
+                            "Confirm": "Confirm"
+                        }
                     }
                 }
             }
@@ -1831,6 +1888,10 @@
         "Cost": "Cost",
         "Configure": "Configure",
         "DistanceUnit": "ft.",
+        "WeightUnit": {
+            "Imperial": "lbs",
+            "Metric": "kg"
+        },
         "ViewDetails": "View Details",
         "HideDetails": "Hide Details",
         "Bonus": "Bonus",
@@ -2010,6 +2071,14 @@
         "systemTheme": {
             "name": "Preferred System Theme",
             "hint": "Specify the themed set of colours to use for system documents and interface elements. The selected theme will respect the preferred Dark/Light mode selected in the core settings."
+        },
+        "measurementUnitSystem": {
+            "name": "Unit System",
+            "hint": "Determines whether distances and weights are displayed in Imperial (ft, lbs) or Metric (m, kg) units throughout the system.",
+            "choices": {
+                "Imperial": "Imperial (ft, lbs)",
+                "Metric": "Metric (m, kg)"
+            }
         }
     },
     "KEYBINDINGS": {
@@ -2020,17 +2089,5 @@
         "changeQuantity5": "Increase/Decrease Quantity by 5",
         "changeQuantity10": "Increase/Decrease Quantity by 10",
         "changeQuantity50": "Increase/Decrease Quantity by 50"
-    },
-    "STORMLIGHT": {
-        "Currency": {
-            "Spheres": "Spheres"
-        },
-        "Macro": {
-            "StartingPath": {
-                "Set": "Set starting path {path} for {actor}. Set starting skill: {skill}.",
-                "Replaced": "Replaced starting path {oldPath} with {newPath} for {actor}. Set starting skill: {skill}.",
-                "Unset": "Cleared starting path for {actor}. Removed starting skill: {skill}."
-            }
-        }
     }
 }

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
     "id": "cosmere-rpg",
     "title": "Cosmere Roleplaying Game",
     "description": "A community-developed system for playing the Cosmere Roleplaying Game, by Dragonsteel Entertainment and Brotherwise Games.",
-    "version": "3.0.2",
+    "version": "3.1.0",
     "compatibility": {
         "minimum": "13.346",
         "verified": "13.351",
@@ -171,5 +171,5 @@
     "background": "systems/cosmere-rpg/assets/art/foundry_setup_Cosmere_RPG.webp",
     "url": "https://github.com/the-metalworks/cosmere-rpg",
     "manifest": "https://raw.githubusercontent.com/the-metalworks/cosmere-rpg/main/src/system.json",
-    "download": "https://github.com/the-metalworks/cosmere-rpg/releases/download/release-3.0.2/cosmere-rpg-release-3.0.2.zip"
+    "download": "https://github.com/the-metalworks/cosmere-rpg/releases/download/release-3.1.0/cosmere-rpg-release-3.1.0.zip"
 }

--- a/src/system/applications/actor/components/details.ts
+++ b/src/system/applications/actor/components/details.ts
@@ -3,6 +3,7 @@ import { MovementTypeConfig } from '@system/types/config';
 import { ConstructorOf } from '@system/types/utils';
 import { SYSTEM_ID } from '@src/system/constants';
 import { TEMPLATES } from '@src/system/utils/templates';
+import { getUnitLabel } from '@system/settings';
 
 // Fields
 import { Derived } from '@system/data/fields';
@@ -170,7 +171,7 @@ any> {
                 ({ rate, label }) => `
                 <div>
                     <span><b>${label}:</b></span>
-                    <span>${rate} ft.</span>
+                    <span>${rate} ${getUnitLabel('distance')}</span>
                 </div>
             `,
             );

--- a/src/system/data/actor/common.ts
+++ b/src/system/data/actor/common.ts
@@ -11,9 +11,11 @@ import {
     DamageType,
     Status,
     ActorType,
+    UnitSystem,
 } from '@system/types/cosmere';
 import { CosmereActor } from '@system/documents/actor';
 import { ArmorItem, LootItem } from '@system/documents';
+import { getSystemSetting, SETTINGS } from '@system/settings';
 
 import {
     CosmereDocument,
@@ -752,34 +754,54 @@ export class CommonActorDataModel<
     }
 }
 
-const SENSES_RANGES = [5, 10, 20, 50, 100, Number.MAX_SAFE_INTEGER];
+const SENSES_RANGES_FT = [5, 10, 20, 50, 100, Number.MAX_SAFE_INTEGER];
+const SENSES_RANGES_M = [1.5, 3, 6, 15, 30, Number.MAX_SAFE_INTEGER];
+
 function awarenessToSensesRange(attr: AttributeData) {
     const awareness = attr.value + attr.bonus;
-    return SENSES_RANGES[
-        Math.min(Math.ceil(awareness / 2), SENSES_RANGES.length - 1)
-    ];
+    const ranges =
+        getSystemSetting(SETTINGS.MEASUREMENT_UNIT_SYSTEM) ===
+        UnitSystem.Metric
+            ? SENSES_RANGES_M
+            : SENSES_RANGES_FT;
+    return ranges[Math.min(Math.ceil(awareness / 2), ranges.length - 1)];
 }
 
-const MOVEMENT_RATES = [20, 25, 30, 40, 60, 80];
+const MOVEMENT_RATES_FT = [20, 25, 30, 40, 60, 80];
+const MOVEMENT_RATES_M = [6, 7.5, 9, 12, 18, 24];
+
 function speedToMovementRate(attr: AttributeData) {
     const speed = attr.value + attr.bonus;
-    return MOVEMENT_RATES[
-        Math.min(Math.ceil(speed / 2), MOVEMENT_RATES.length - 1)
-    ];
+    const rates =
+        getSystemSetting(SETTINGS.MEASUREMENT_UNIT_SYSTEM) ===
+        UnitSystem.Metric
+            ? MOVEMENT_RATES_M
+            : MOVEMENT_RATES_FT;
+    return rates[Math.min(Math.ceil(speed / 2), rates.length - 1)];
 }
 
-const LIFTING_CAPACITIES = [100, 200, 500, 1000, 5000, 10000];
+const LIFTING_CAPACITIES_LB = [100, 200, 500, 1000, 5000, 10000];
+const LIFTING_CAPACITIES_KG = [45, 90, 225, 450, 2250, 4500];
+
 function strengthToLiftingCapacity(attr: AttributeData) {
     const strength = attr.value + attr.bonus;
-    return LIFTING_CAPACITIES[
-        Math.min(Math.ceil(strength / 2), LIFTING_CAPACITIES.length - 1)
-    ];
+    const capacities =
+        getSystemSetting(SETTINGS.MEASUREMENT_UNIT_SYSTEM) ===
+        UnitSystem.Metric
+            ? LIFTING_CAPACITIES_KG
+            : LIFTING_CAPACITIES_LB;
+    return capacities[Math.min(Math.ceil(strength / 2), capacities.length - 1)];
 }
 
-const CARRYING_CAPACITIES = [50, 100, 250, 500, 2500, 5000];
+const CARRYING_CAPACITIES_LB = [50, 100, 250, 500, 2500, 5000];
+const CARRYING_CAPACITIES_KG = [22.5, 45, 112.5, 225, 1125, 2250];
+
 function strengthToCarryingCapacity(attr: AttributeData) {
     const strength = attr.value + attr.bonus;
-    return CARRYING_CAPACITIES[
-        Math.min(Math.ceil(strength / 2), CARRYING_CAPACITIES.length - 1)
-    ];
+    const capacities =
+        getSystemSetting(SETTINGS.MEASUREMENT_UNIT_SYSTEM) ===
+        UnitSystem.Metric
+            ? CARRYING_CAPACITIES_KG
+            : CARRYING_CAPACITIES_LB;
+    return capacities[Math.min(Math.ceil(strength / 2), capacities.length - 1)];
 }

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -25,6 +25,7 @@ import {
     TalentTreeItem,
     ActionItem,
     EffectsContainerItem,
+    WeaponItem,
 } from '@system/documents/item';
 import { CosmereActiveEffect } from '@system/documents/active-effect';
 
@@ -851,9 +852,13 @@ export class CosmereActor<
                 ? CONFIG.COSMERE.damageTypes[instance.type]
                 : { ignoreDeflect: false };
 
+            const originatingItem = options.originatingItem as ActionItem;
+            const originatingItemParent = originatingItem?.parent as WeaponItem;
+
             const pierce =
-                options.originatingItem?.isWeapon() &&
-                (options.originatingItem?.system?.traits?.pierce?.active ??
+                originatingItem?.isStrikeAction &&
+                originatingItemParent?.isWeapon() &&
+                (originatingItemParent?.system?.traits?.pierce?.active ??
                     false);
 
             // Checks if damage should be deflected or not

--- a/src/system/documents/chat-message.ts
+++ b/src/system/documents/chat-message.ts
@@ -60,11 +60,9 @@ export class CosmereChatMessage<
     }
 
     public get itemSource(): CosmereItem | null {
-        return this.actorSource
-            ? (this.actorSource.items.get(
-                  this.getFlag(SYSTEM_ID, 'message.item'),
-              ) ?? null)
-            : null;
+        const id = this.getFlag(SYSTEM_ID, 'message.item');
+        if (!id) return null;
+        return this.actorSource?.getEmbeddedDocumentFromUuid(id) as CosmereItem;
     }
 
     public get d20Rolls(): D20Roll[] {

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -516,7 +516,7 @@ export class CosmereItem<
             !(this.parent instanceof CosmereItem)
         )
             return false;
-        return this.defaultAction?.id === this.id;
+        return this.parent.defaultAction?.id === this.id;
     }
 
     /**

--- a/src/system/hooks/starter-rules/ancestries.ts
+++ b/src/system/hooks/starter-rules/ancestries.ts
@@ -3,7 +3,7 @@ import { SYSTEM_ID } from '@system/constants';
 export const ANCESTRIES = [
     {
         id: 'human',
-        label: 'Human',
+        label: 'COSMERE.Objects.Generic.Ancestry.Human',
         reference: 'Compendium.cosmere-rpg.ancestries.Item.q7t6vnxXBXDvsfhc',
     },
 ];

--- a/src/system/hooks/starter-rules/cultures.ts
+++ b/src/system/hooks/starter-rules/cultures.ts
@@ -3,32 +3,32 @@ import { SYSTEM_ID } from '@system/constants';
 const CULTURES = [
     {
         id: 'alethi',
-        label: 'Alethi',
+        label: 'COSMERE.Objects.Stormlight.Culture.Alethi',
         reference: 'Compendium.cosmere-rpg.cultures.Item.oWJSlmauhHG57LrO',
     },
     {
         id: 'azish',
-        label: 'Azish',
+        label: 'COSMERE.Objects.Stormlight.Culture.Azish',
         reference: 'Compendium.cosmere-rpg.cultures.Item.PbkgODW2av4tBPdW',
     },
     {
         id: 'herdazian',
-        label: 'Herdazian',
+        label: 'COSMERE.Objects.Stormlight.Culture.Herdazian',
         reference: 'Compendium.cosmere-rpg.cultures.Item.nIOHtV8KoTdKH4FQ',
     },
     {
         id: 'thaylen',
-        label: 'Thaylen',
+        label: 'COSMERE.Objects.Stormlight.Culture.Thaylen',
         reference: 'Compendium.cosmere-rpg.cultures.Item.yuZdO7YSfydUAdhu',
     },
     {
         id: 'unkalaki',
-        label: 'Unkalaki',
+        label: 'COSMERE.Objects.Stormlight.Culture.Unkalaki',
         reference: 'Compendium.cosmere-rpg.cultures.Item.RDD4CJzcnb2mjXXC',
     },
     {
         id: 'veden',
-        label: 'Veden',
+        label: 'COSMERE.Objects.Stormlight.Culture.Veden',
         reference: 'Compendium.cosmere-rpg.cultures.Item.ZVXjqw4l30mNjAdq',
     },
 ];

--- a/src/system/hooks/starter-rules/currency.ts
+++ b/src/system/hooks/starter-rules/currency.ts
@@ -4,53 +4,53 @@ export function register() {
     const secondary = [
         {
             id: 'diamond',
-            label: 'Diamond',
+            label: 'COSMERE.Objects.Stormlight.Currency.Diamond',
             conversionRate: 1,
             base: true,
         },
         {
             id: 'garnet',
-            label: 'Garnet',
+            label: 'COSMERE.Objects.Stormlight.Currency.Garnet',
             conversionRate: 5,
         },
         {
             id: 'heliodor',
-            label: 'Heliodor',
+            label: 'COSMERE.Objects.Stormlight.Currency.Heliodor',
             conversionRate: 5,
         },
         {
             id: 'topaz',
-            label: 'Topaz',
+            label: 'COSMERE.Objects.Stormlight.Currency.Topaz',
             conversionRate: 5,
         },
         {
             id: 'ruby',
-            label: 'Ruby',
+            label: 'COSMERE.Objects.Stormlight.Currency.Ruby',
             conversionRate: 10,
         },
         {
             id: 'smokestone',
-            label: 'Smokestone',
+            label: 'COSMERE.Objects.Stormlight.Currency.Smokestone',
             conversionRate: 10,
         },
         {
             id: 'zircon',
-            label: 'Zircon',
+            label: 'COSMERE.Objects.Stormlight.Currency.Zircon',
             conversionRate: 10,
         },
         {
             id: 'amethyst',
-            label: 'Amethyst',
+            label: 'COSMERE.Objects.Stormlight.Currency.Amethyst',
             conversionRate: 25,
         },
         {
             id: 'sapphire',
-            label: 'Sapphire',
+            label: 'COSMERE.Objects.Stormlight.Currency.Sapphire',
             conversionRate: 25,
         },
         {
             id: 'emerald',
-            label: 'Emerald',
+            label: 'COSMERE.Objects.Stormlight.Currency.Emerald',
             conversionRate: 50,
         },
     ];
@@ -58,25 +58,25 @@ export function register() {
     cosmereRPG.api.registerCurrency({
         source: SYSTEM_ID,
         id: 'spheres',
-        label: 'STORMLIGHT.Currency.Spheres',
+        label: 'COSMERE.Objects.Stormlight.Currency.Spheres',
         icon: 'systems/cosmere-rpg/assets/icons/stormlight/currency/spheres_infused.webp',
         denominations: {
             primary: [
                 {
                     id: 'mark',
-                    label: 'Mark',
+                    label: 'COSMERE.Objects.Stormlight.Currency.Mark',
                     unit: 'mk ●',
                     conversionRate: 1,
                     base: true,
                 },
                 {
                     id: 'chip',
-                    label: 'Chip',
+                    label: 'COSMERE.Objects.Stormlight.Currency.Chip',
                     conversionRate: 0.2,
                 },
                 {
                     id: 'broam',
-                    label: 'Broam',
+                    label: 'COSMERE.Objects.Stormlight.Currency.Broam',
                     conversionRate: 4,
                 },
             ],

--- a/src/system/hooks/starter-rules/items/armor.ts
+++ b/src/system/hooks/starter-rules/items/armor.ts
@@ -3,32 +3,32 @@ import { SYSTEM_ID } from '@system/constants';
 const ARMOR = [
     {
         id: 'breastplate',
-        label: 'Breastplate',
+        label: 'COSMERE.Objects.Stormlight.Armor.Breastplate',
         reference: 'Compendium.cosmere-rpg.items.Item.xLer8raOT6EkLfWN',
     },
     {
         id: 'chain',
-        label: 'Chain',
+        label: 'COSMERE.Objects.Stormlight.Armor.Chain',
         reference: 'Compendium.cosmere-rpg.items.Item.6y5hONLMQa4O2wnU',
     },
     {
         id: 'full-plate',
-        label: 'Full Plate',
+        label: 'COSMERE.Objects.Stormlight.Armor.FullPlate',
         reference: 'Compendium.cosmere-rpg.items.Item.t97DN6FAh7BMNvcP',
     },
     {
         id: 'half-plate',
-        label: 'Half Plate',
+        label: 'COSMERE.Objects.Stormlight.Armor.HalfPlate',
         reference: 'Compendium.cosmere-rpg.items.Item.GlrRu1goky9ifKCl',
     },
     {
         id: 'leather',
-        label: 'Leather',
+        label: 'COSMERE.Objects.Stormlight.Armor.Leather',
         reference: 'Compendium.cosmere-rpg.items.Item.dxty96So3kGZVhv5',
     },
     {
         id: 'uniform',
-        label: 'Uniform',
+        label: 'COSMERE.Objects.Stormlight.Armor.Uniform',
         reference: 'Compendium.cosmere-rpg.items.Item.SRLLAWCE7rwS40Pv',
     },
 ];

--- a/src/system/hooks/starter-rules/items/weapons.ts
+++ b/src/system/hooks/starter-rules/items/weapons.ts
@@ -3,57 +3,57 @@ import { SYSTEM_ID } from '@system/constants';
 const WEAPONS = [
     {
         id: 'axe',
-        label: 'Axe',
+        label: 'COSMERE.Objects.Stormlight.Weapon.Axe',
         reference: 'Compendium.cosmere-rpg.items.Item.C4o8jIXuVulD9qS9',
     },
     {
         id: 'hammer',
-        label: 'Hammer',
+        label: 'COSMERE.Objects.Stormlight.Weapon.Hammer',
         reference: 'Compendium.cosmere-rpg.items.Item.OBPoBfwLrZg0Unz6',
     },
     {
         id: 'knife',
-        label: 'Knife',
+        label: 'COSMERE.Objects.Stormlight.Weapon.Knife',
         reference: 'Compendium.cosmere-rpg.items.Item.k0aKCdFJU0m2lZbv',
     },
     {
         id: 'longsword',
-        label: 'Longsword',
+        label: 'COSMERE.Objects.Stormlight.Weapon.Longsword',
         reference: 'Compendium.cosmere-rpg.items.Item.yzR4gLjOV6njxdde',
     },
     {
         id: 'longspear',
-        label: 'Longspear',
+        label: 'COSMERE.Objects.Stormlight.Weapon.Longspear',
         reference: 'Compendium.cosmere-rpg.items.Item.ex4dg2bXFpC5HTv6',
     },
     {
         id: 'mace',
-        label: 'Mace',
+        label: 'COSMERE.Objects.Stormlight.Weapon.Mace',
         reference: 'Compendium.cosmere-rpg.items.Item.5sH5poLPx75U008u',
     },
     {
         id: 'shield',
-        label: 'Shield',
+        label: 'COSMERE.Objects.Stormlight.Weapon.Shield',
         reference: 'Compendium.cosmere-rpg.items.Item.fV3Adif5imyAc5m5',
     },
     {
         id: 'shortbow',
-        label: 'Shortbow',
+        label: 'COSMERE.Objects.Stormlight.Weapon.Shortbow',
         reference: 'Compendium.cosmere-rpg.items.Item.VuNjyCtkobEQKdOx',
     },
     {
         id: 'shortspear',
-        label: 'Shortspear',
+        label: 'COSMERE.Objects.Stormlight.Weapon.Shortspear',
         reference: 'Compendium.cosmere-rpg.items.Item.5CvSwkwuSRArPTM2',
     },
     {
         id: 'sidesword',
-        label: 'Sidesword',
+        label: 'COSMERE.Objects.Stormlight.Weapon.Sidesword',
         reference: 'Compendium.cosmere-rpg.items.Item.0mE1SpjOuNtgR0eq',
     },
     {
         id: 'staff',
-        label: 'Staff',
+        label: 'COSMERE.Objects.Stormlight.Weapon.Staff',
         reference: 'Compendium.cosmere-rpg.items.Item.zyDACVYDa0N9N31r',
     },
 ];

--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -1,5 +1,5 @@
 import { SYSTEM_ID } from './constants';
-import { Resource, Theme } from './types/cosmere';
+import { Resource, Theme, UnitSystem } from './types/cosmere';
 import { setTheme } from './utils/templates';
 import { ResourceConfig } from './types/config';
 
@@ -24,6 +24,7 @@ export const SETTINGS = {
     TOKEN_DEFAULT_BAR_1_VAL: 'defaultTokenBar1Value',
     TOKEN_DEFAULT_BAR_2_VAL: 'defaultTokenBar2Value',
     SYSTEM_THEME: 'systemTheme',
+    MEASUREMENT_UNIT_SYSTEM: 'measurementUnitSystem',
 } as const;
 
 type SystemSettingsConfig = {
@@ -62,7 +63,11 @@ type SystemSettingsConfig = {
     [key in `${typeof SYSTEM_ID}.${typeof SETTINGS.TOKEN_DEFAULT_BAR_2_VAL}`]:
         | `resources.${Resource}`
         | 'none';
-} & { [key in `${typeof SYSTEM_ID}.${typeof SETTINGS.SYSTEM_THEME}`]: Theme };
+} & {
+    [key in `${typeof SYSTEM_ID}.${typeof SETTINGS.SYSTEM_THEME}`]: Theme;
+} & {
+    [key in `${typeof SYSTEM_ID}.${typeof SETTINGS.MEASUREMENT_UNIT_SYSTEM}`]: UnitSystem;
+};
 
 type SystemSettingKey = (typeof SETTINGS)[keyof typeof SETTINGS];
 
@@ -285,6 +290,29 @@ export function registerDeferredSettings() {
     });
 
     setTheme(document.body, getSystemSetting(SETTINGS.SYSTEM_THEME));
+
+    // UNIT SYSTEM SETTING
+    game.settings.register(SYSTEM_ID, SETTINGS.MEASUREMENT_UNIT_SYSTEM, {
+        name: game.i18n.localize(
+            `SETTINGS.${SETTINGS.MEASUREMENT_UNIT_SYSTEM}.name`,
+        ),
+        hint: game.i18n.localize(
+            `SETTINGS.${SETTINGS.MEASUREMENT_UNIT_SYSTEM}.hint`,
+        ),
+        scope: 'client',
+        config: true,
+        type: String,
+        default: UnitSystem.Imperial,
+        requiresReload: true,
+        choices: {
+            [UnitSystem.Imperial]: game.i18n.localize(
+                `SETTINGS.${SETTINGS.MEASUREMENT_UNIT_SYSTEM}.choices.Imperial`,
+            ),
+            [UnitSystem.Metric]: game.i18n.localize(
+                `SETTINGS.${SETTINGS.MEASUREMENT_UNIT_SYSTEM}.choices.Metric`,
+            ),
+        },
+    });
 }
 
 /**
@@ -351,6 +379,20 @@ export function registerSystemKeybindings() {
             editable: keybind.editable,
         });
     });
+}
+
+/**
+ * Retrieves the localized unit label (distance or weight) matching the
+ * user's currently selected `MEASUREMENT_UNIT_SYSTEM` setting.
+ * @param kind Which kind of unit label to retrieve.
+ */
+export function getUnitLabel(kind: 'distance' | 'weight'): string {
+    const isMetric =
+        getSystemSetting(SETTINGS.MEASUREMENT_UNIT_SYSTEM) ===
+        UnitSystem.Metric;
+    const key =
+        kind === 'distance' ? 'GENERIC.DistanceUnit' : 'GENERIC.WeightUnit';
+    return game.i18n.localize(`${key}.${isMetric ? 'Metric' : 'Imperial'}`);
 }
 
 /**

--- a/src/system/tests/playwright/actor-sheet/adversary-sheet-actions.spec.ts
+++ b/src/system/tests/playwright/actor-sheet/adversary-sheet-actions.spec.ts
@@ -1,0 +1,177 @@
+import {
+    ActorType,
+    Attribute,
+    AttributeGroup,
+} from '@src/system/types/cosmere';
+import { test, expect } from '../fixtures';
+import { html5DragAndDrop } from '../helpers/drag-drop';
+
+test('Resources/Attribute/Defenses', async ({
+    authenticatedPage: page,
+    createActor,
+}) => {
+    const testAdversary = await createActor(
+        'Test Adversary',
+        ActorType.Adversary,
+    );
+
+    await page.pause();
+    await testAdversary.checkResource('Health', 0, 0);
+    await testAdversary.checkResource('Focus', 0, 0);
+    await testAdversary.checkResource('Investiture', 0, 0);
+    await testAdversary.checkAttribute(Attribute.Strength, 0);
+    await testAdversary.checkAttribute(Attribute.Speed, 0);
+    await testAdversary.checkAttribute(Attribute.Intellect, 0);
+    await testAdversary.checkAttribute(Attribute.Willpower, 0);
+    await testAdversary.checkAttribute(Attribute.Awareness, 0);
+    await testAdversary.checkAttribute(Attribute.Presence, 0);
+    await testAdversary.checkDefense(AttributeGroup.Physical, 10);
+    await testAdversary.checkDefense(AttributeGroup.Cognitive, 10);
+    await testAdversary.checkDefense(AttributeGroup.Spiritual, 10);
+
+    // Update strength, check new values
+    await testAdversary.updateAttribute(Attribute.Strength, 1);
+    await testAdversary.checkResource('Health', 0, 0);
+    await testAdversary.checkResource('Focus', 0, 0);
+    await testAdversary.checkAttribute(Attribute.Strength, 1);
+    await testAdversary.checkAttribute(Attribute.Speed, 0);
+    await testAdversary.checkDefense(AttributeGroup.Physical, 11);
+    await testAdversary.checkDefense(AttributeGroup.Cognitive, 10);
+
+    // Update speed, check new values
+    await testAdversary.updateAttribute(Attribute.Speed, 2);
+    await testAdversary.checkResource('Health', 0, 0);
+    await testAdversary.checkResource('Focus', 0, 0);
+    await testAdversary.checkAttribute(Attribute.Strength, 1);
+    await testAdversary.checkAttribute(Attribute.Speed, 2);
+    await testAdversary.checkDefense(AttributeGroup.Physical, 13);
+    await testAdversary.checkDefense(AttributeGroup.Cognitive, 10);
+
+    // // Update health to less than max
+    // await testCharacter.updateResource('Health', 5);
+    // await testCharacter.checkResource('Health', 5, 11);
+
+    // // Update health to more than max
+    // await testCharacter.updateResource('Health', 100);
+    // await testCharacter.checkResource('Health', 11, 11);
+});
+
+test('Edit mode', async ({ authenticatedPage: page, createActor }) => {
+    const testAdversary = await createActor(
+        'Test Character',
+        ActorType.Adversary,
+    );
+    const testAdversarySheet = testAdversary.locator;
+
+    await expect(
+        testAdversarySheet
+            .getByRole('listitem')
+            .filter({ hasText: 'Features Action Cost Resources' }),
+    ).toBeVisible();
+    await expect(
+        testAdversarySheet
+            .getByRole('listitem')
+            .filter({ hasText: 'Weapons Action Cost Resources' }),
+    ).toBeVisible();
+    await expect(
+        testAdversarySheet
+            .getByRole('listitem')
+            .filter({ hasText: 'Actions Action Cost Resources' }),
+    ).toBeVisible();
+    await expect(
+        testAdversarySheet
+            .locator('ul:nth-child(1) > .item > .details > .controls > a')
+            .first(),
+    ).toBeVisible();
+    await expect(
+        testAdversarySheet
+            .locator('ul:nth-child(2) > .item > .details > .controls > a')
+            .first(),
+    ).not.toBeVisible();
+    await expect(
+        testAdversarySheet
+            .locator('ul:nth-child(3) > .item > .details > .controls > a')
+            .first(),
+    ).toBeVisible();
+    await expect(
+        testAdversarySheet.locator('select[name="system.role"]'),
+    ).toBeVisible();
+    await expect(
+        testAdversarySheet.locator('select[name="system.size"]'),
+    ).toBeVisible();
+    await expect(testAdversarySheet.locator('.type > a')).toBeVisible();
+    await expect(
+        testAdversarySheet.locator('div').filter({ hasText: 'Skills' }).nth(3),
+    ).toBeVisible();
+    await expect(
+        testAdversarySheet
+            .locator('div')
+            .filter({ hasText: 'Expertises' })
+            .nth(3),
+    ).toBeVisible();
+    await expect(
+        testAdversarySheet
+            .locator('div')
+            .filter({ hasText: 'Immunities' })
+            .nth(3),
+    ).toBeVisible();
+
+    // Toggle edit mode off
+    await testAdversarySheet.locator('.fa-solid.fa-pen').click();
+    await expect(
+        testAdversarySheet.getByText('Minion o Medium Humanoid'),
+    ).toBeVisible();
+
+    await expect(
+        testAdversarySheet
+            .getByRole('listitem')
+            .filter({ hasText: 'Features Action Cost Resources' }),
+    ).not.toBeVisible();
+    await expect(
+        testAdversarySheet
+            .getByRole('listitem')
+            .filter({ hasText: 'Weapons Action Cost Resources' }),
+    ).not.toBeVisible();
+    await expect(
+        testAdversarySheet
+            .getByRole('listitem')
+            .filter({ hasText: 'Actions Action Cost Resources' }),
+    ).not.toBeVisible();
+    await expect(
+        testAdversarySheet
+            .locator('ul:nth-child(1) > .item > .details > .controls > a')
+            .first(),
+    ).not.toBeVisible();
+    await expect(
+        testAdversarySheet
+            .locator('ul:nth-child(2) > .item > .details > .controls > a')
+            .first(),
+    ).not.toBeVisible();
+    await expect(
+        testAdversarySheet
+            .locator('ul:nth-child(3) > .item > .details > .controls > a')
+            .first(),
+    ).not.toBeVisible();
+    await expect(
+        testAdversarySheet.locator('select[name="system.role"]'),
+    ).not.toBeVisible();
+    await expect(
+        testAdversarySheet.locator('select[name="system.size"]'),
+    ).not.toBeVisible();
+    await expect(testAdversarySheet.locator('.type > a')).not.toBeVisible();
+    await expect(
+        testAdversarySheet.locator('div').filter({ hasText: 'Skills' }).nth(3),
+    ).not.toBeVisible();
+    await expect(
+        testAdversarySheet
+            .locator('div')
+            .filter({ hasText: 'Expertises' })
+            .nth(3),
+    ).not.toBeVisible();
+    await expect(
+        testAdversarySheet
+            .locator('div')
+            .filter({ hasText: 'Immunities' })
+            .nth(3),
+    ).not.toBeVisible();
+});

--- a/src/system/tests/playwright/actor-sheet/character-sheet-actions.spec.ts
+++ b/src/system/tests/playwright/actor-sheet/character-sheet-actions.spec.ts
@@ -1,0 +1,355 @@
+import {
+    ActorType,
+    Attribute,
+    AttributeGroup,
+} from '@src/system/types/cosmere';
+import { test, expect } from '../fixtures';
+import { mostRecentChatMessage } from '../helpers/chat';
+import { html5DragAndDrop } from '../helpers/drag-drop';
+import { clearNotifications } from '../helpers/notifications';
+import { getLocatorForNextWindowToOpen } from '../helpers/hooks';
+
+test('Add all basic actions, use them all', async ({
+    authenticatedPage: page,
+    createActor,
+}) => {
+    const testCharacter = await createActor(
+        'Test Character',
+        ActorType.Character,
+    );
+    const testCharacterSheet = testCharacter.locator;
+    await page.getByRole('tab', { name: 'Compendium Packs' }).click();
+    await page
+        .locator('span')
+        .filter({ hasText: 'Stormlight Starter Rules' })
+        .click();
+    await page.locator('a').filter({ hasText: 'Actions' }).click();
+    await html5DragAndDrop(
+        page,
+        page.getByText('Basic Actions Pack'),
+        testCharacterSheet,
+    );
+
+    await testCharacter.switchToActionsTab();
+
+    // Expect all basic actions to appear on character sheet
+    await testCharacter.checkHasAction('Aid', 'r', '1 Focus');
+    await testCharacter.checkHasAction('Avoid Danger', 'r');
+    await testCharacter.checkHasAction('Banter', '0');
+    await testCharacter.checkHasAction('Brace', '1');
+    await testCharacter.checkHasAction('Disengage', '1');
+    await testCharacter.checkHasAction('Dodge', 'r', '1 Focus');
+    await testCharacter.checkHasAction('Drop', '0');
+    await testCharacter.checkHasAction('Gain Advantage', '1');
+    await testCharacter.checkHasAction('Grapple', '2');
+    await testCharacter.checkHasAction('Interact', '1');
+    await testCharacter.checkHasAction('Move', '1');
+    await testCharacter.checkHasAction('Reactive Strike', 'r', '1 Focus');
+    await testCharacter.checkHasAction('Ready', '1');
+    await testCharacter.checkHasAction(
+        'Recover',
+        '2',
+        '1 Use from 1 / 1',
+        '1 / 1 Per scene',
+    );
+    await testCharacter.checkHasAction('Shove', '2');
+    await testCharacter.checkHasAction('Strike', '1');
+    await testCharacter.checkHasAction('Unarmed Attack', '1');
+    await testCharacter.checkHasAction('Use A Skill', '1');
+    await clearNotifications(page);
+
+    // Update focus to max and test using the "Aid" action
+    await testCharacter.updateResource('Focus', 2);
+    await testCharacter.checkResource('Focus', 2, 2);
+    const aidLocator = await testCharacter.actionLocator('Aid');
+    await aidLocator.locator('.img').click();
+    await expect(
+        page.getByRole('heading', { name: 'Consume Resource' }),
+    ).toBeVisible();
+    await expect(page.getByText('Test Character Consume 1')).toBeVisible();
+    await page.getByRole('button', { name: 'Continue' }).click();
+    await testCharacter.checkResource('Focus', 1, 2);
+    await page.getByRole('tab', { name: 'Chat Messages' }).click();
+    await expect(mostRecentChatMessage(page)).toContainText('Aid');
+
+    const avoidDangerLocator =
+        await testCharacter.actionLocator('Avoid Danger');
+    await avoidDangerLocator.locator('.img').click();
+    await expect(
+        page.getByRole('heading', { name: 'Avoid Danger (Custom Skill)' }),
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Roll', exact: true }).click();
+    await expect(mostRecentChatMessage(page)).toContainText('Avoid Danger');
+
+    const banterLocator = await testCharacter.actionLocator('Banter');
+    await banterLocator.locator('.img').click();
+    await expect(mostRecentChatMessage(page)).toContainText('Banter');
+
+    const braceLocator = await testCharacter.actionLocator('Brace');
+    await braceLocator.locator('.img').click();
+    await expect(mostRecentChatMessage(page)).toContainText('Brace');
+
+    const disengageLocator = await testCharacter.actionLocator('Disengage');
+    await disengageLocator.locator('.img').click();
+    await expect(mostRecentChatMessage(page)).toContainText('Disengage');
+
+    const dodgeLocator = await testCharacter.actionLocator('Dodge');
+    await dodgeLocator.locator('.img').click();
+    await expect(
+        page.getByRole('heading', { name: 'Consume Resource' }),
+    ).toBeVisible();
+    await expect(page.getByText('Test Character Consume 1')).toBeVisible();
+    await page.getByRole('button', { name: 'Continue' }).click();
+    await testCharacter.checkResource('Focus', 0, 2);
+    await expect(mostRecentChatMessage(page)).toContainText('Dodge');
+
+    const dropLocator = await testCharacter.actionLocator('Drop');
+    await dropLocator.locator('.img').click();
+    await expect(mostRecentChatMessage(page)).toContainText('Drop');
+
+    const gainAdvantageLocator =
+        await testCharacter.actionLocator('Gain Advantage');
+    await gainAdvantageLocator.locator('.img').click();
+    await expect(mostRecentChatMessage(page)).toContainText('Gain Advantage');
+
+    const grappleLocator = await testCharacter.actionLocator('Grapple');
+    await grappleLocator.locator('.img').click();
+    await expect(
+        page.getByRole('heading', { name: 'Grapple (Custom Skill)' }),
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Roll', exact: true }).click();
+    await expect(mostRecentChatMessage(page)).toContainText('Grapple');
+
+    const interactLocator = await testCharacter.actionLocator('Interact');
+    await interactLocator.locator('.img').click();
+    await expect(mostRecentChatMessage(page)).toContainText('Interact');
+
+    const moveLocator = await testCharacter.actionLocator('Move');
+    await moveLocator.locator('.img').click();
+    await expect(mostRecentChatMessage(page)).toContainText('Move');
+
+    const reactiveStrikeLocator =
+        await testCharacter.actionLocator('Reactive Strike');
+    await reactiveStrikeLocator.locator('.img').click();
+    await expect(
+        page.getByRole('heading', { name: 'Consume Resource' }),
+    ).toBeVisible();
+    await expect(page.getByText('Test Character Consume 1')).toBeVisible();
+    await page.getByRole('button', { name: 'Continue' }).click();
+    await testCharacter.checkResource('Focus', 0, 2);
+    await expect(mostRecentChatMessage(page)).toContainText('Move');
+
+    const readyLocator = await testCharacter.actionLocator('Ready');
+    await readyLocator.locator('.img').click();
+    await expect(mostRecentChatMessage(page)).toContainText('Ready');
+
+    const recoverLocator = await testCharacter.actionLocator('Recover');
+    await recoverLocator.locator('.img').click();
+    await expect(page.getByText('Recover Consume 1 Use?')).toBeVisible();
+    await page.getByRole('button', { name: 'Continue' }).click();
+    await expect(recoverLocator).toContainText(
+        'Recover 2 1 Use from 0 / 1 0 / 1 Per scene',
+    );
+    await expect(mostRecentChatMessage(page)).toContainText('Recover');
+
+    const shoveLocator = await testCharacter.actionLocator('Shove');
+    await shoveLocator.locator('.img').click();
+    await expect(
+        page.getByRole('heading', { name: 'Shove (Custom Skill)' }),
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Roll', exact: true }).click();
+    await expect(mostRecentChatMessage(page)).toContainText('Shove');
+
+    // const strikeLocator = await testCharacter.actionLocator('Strike');
+    // await strikeLocator.locator('.img').click();
+
+    const unarmedAttackLocator =
+        await testCharacter.actionLocator('Unarmed Attack');
+    await unarmedAttackLocator.locator('.img').click();
+    await expect(
+        page.getByRole('heading', { name: 'Unarmed Attack (Athletics)' }),
+    ).toBeVisible();
+    await page.getByRole('button', { name: 'Roll', exact: true }).click();
+    await expect(mostRecentChatMessage(page)).toContainText('Unarmed Attack');
+
+    const useASkillLocator = await testCharacter.actionLocator('Use A Skill');
+    await useASkillLocator.locator('.img').click();
+    await expect(mostRecentChatMessage(page)).toContainText('Use A Skill');
+});
+
+test('Add weapon, validate strike action details', async ({
+    authenticatedPage: page,
+    createActor,
+}) => {
+    const testCharacter = await createActor(
+        'Test Character',
+        ActorType.Character,
+    );
+    const testCharacterSheet = testCharacter.locator;
+    await page.getByRole('tab', { name: 'Compendium Packs' }).click();
+    await page
+        .locator('span')
+        .filter({ hasText: 'Stormlight Starter Rules' })
+        .click();
+    await page.locator('a').filter({ hasText: 'Items' }).click();
+    await page
+        .locator('#compendium-cosmere-rpg_items')
+        .getByText('Weapons')
+        .click();
+    await html5DragAndDrop(page, page.getByText('Axe'), testCharacterSheet);
+    await testCharacterSheet.locator('a').filter({ hasText: '3' }).click();
+    // Validate that since the Axe isn't equipped, the "Strike" action is not visible
+    await expect(
+        testCharacterSheet.getByText('Strike: Axe 1 — —'),
+    ).not.toBeVisible();
+
+    // Equip the axe
+    await testCharacterSheet
+        .locator('.sheet-navigation > a:nth-child(4)')
+        .click();
+    await testCharacterSheet.locator('div.detail.slim.equip > a').click();
+
+    //Validate that the Axe strike action is now visible
+    await testCharacterSheet.locator('a').filter({ hasText: '3' }).click();
+    await expect(
+        testCharacterSheet.getByText('Strike: Axe 1 — —'),
+    ).toBeVisible();
+    await testCharacterSheet.getByText('Strike: Axe').click();
+    await expect(
+        testCharacterSheet.locator('app-actor-actions-list-entry'),
+    ).toContainText(
+        'Damage 1d6 keen; Range Melee; Traits Thrown [20/60]; Expert Traits Offhand;Type Heavy Weapon; Weapons Skill Heavy; Price 20 mk; Weight 2 lb.;',
+    );
+    await testCharacterSheet
+        .locator('.controls.icon > a:nth-child(2)')
+        .first()
+        .click();
+    await expect(
+        testCharacterSheet.getByRole('button', { name: ' View' }),
+    ).toBeVisible();
+    const axeStrikeActionSheetPromise = getLocatorForNextWindowToOpen(page);
+    await testCharacterSheet.getByRole('button', { name: ' View' }).click();
+    const axeStrikeActionSheet = await axeStrikeActionSheetPromise;
+    await expect(
+        axeStrikeActionSheet
+            .locator('section')
+            .filter({ hasText: 'Action Description Details' })
+            .first(),
+    ).toBeVisible();
+    await axeStrikeActionSheet
+        .getByRole('button', { name: 'Close Window' })
+        .click();
+
+    // Test the Loaded automations
+    await testCharacterSheet
+        .locator('.sheet-navigation > a:nth-child(4)')
+        .click();
+    await testCharacterSheet
+        .locator('div:nth-child(7) > a:nth-child(2)')
+        .click();
+    const axeSheetPromise = getLocatorForNextWindowToOpen(page);
+    await testCharacterSheet.getByRole('button', { name: ' Edit' }).click();
+    const axeSheet = await axeSheetPromise;
+    await axeSheet.getByText('Details', { exact: true }).click();
+    await axeSheet.getByText('Traits Thrown', { exact: true }).click();
+    await axeSheet
+        .locator('input[name="system.traits.loaded.defaultActive"]')
+        .check();
+    await axeSheet
+        .locator('input[name="system.traits.loaded.defaultValue"]')
+        .click();
+    await axeSheet
+        .locator('input[name="system.traits.loaded.defaultValue"]')
+        .fill('3');
+    await axeSheet.getByText('Traits Loaded, Thrown').click();
+    await expect(axeSheet.locator('app-item-details-resources')).toContainText(
+        'Primary ResourceAmmo',
+    );
+    await axeSheet.getByText('Actions', { exact: true }).click();
+    await expect(axeSheet.locator('app-item-actions-list')).toContainText(
+        'Strike: Axe 1 1 Ammo from —',
+    );
+    await expect(axeSheet.locator('app-item-actions-list')).toContainText(
+        'Reload: Axe 1 — —',
+    );
+    await axeSheet.getByRole('button', { name: 'Close Window' }).click();
+    await expect(
+        testCharacterSheet.locator('app-actor-equipment-list'),
+    ).toContainText('Axe Melee, One Handed, Loaded [3], Thrown 1 2 3 / 3');
+    await testCharacterSheet
+        .locator('a')
+        .filter({ hasText: '3' })
+        .first()
+        .click();
+    await expect(
+        testCharacterSheet.locator('app-actor-actions-list'),
+    ).toContainText('Axe 3 / 3');
+    await testCharacterSheet.getByText('Strike: Axe 1 1 Ammo from 3').click();
+    await expect(
+        testCharacterSheet.locator('app-actor-actions-list'),
+    ).toContainText('Strike: Axe 1 1 Ammo from 3 / 3 —');
+    await expect(
+        testCharacterSheet.locator('app-actor-actions-list'),
+    ).toContainText('Reload: Axe 1 — —');
+});
+
+test('Edit mode', async ({ authenticatedPage: page, createActor }) => {
+    const testCharacter = await createActor(
+        'Test Character',
+        ActorType.Character,
+    );
+    const testCharacterSheet = testCharacter.locator;
+    await testCharacter.switchToActionsTab();
+
+    await page.getByRole('tab', { name: 'Compendium Packs' }).click();
+    await page
+        .locator('span')
+        .filter({ hasText: 'Stormlight Starter Rules' })
+        .click();
+    await page.locator('a').filter({ hasText: 'Heroic Paths' }).click();
+    await page.locator('span').filter({ hasText: 'Envoy' }).click();
+    const envoyPathElement = page.locator('a').filter({ hasText: /^Envoy$/ });
+    await html5DragAndDrop(page, envoyPathElement, testCharacterSheet);
+    await clearNotifications(page);
+    await expect(
+        testCharacterSheet
+            .getByRole('listitem')
+            .filter({ hasText: 'Envoy Actions Action Cost' }),
+    ).toBeVisible();
+    await expect(
+        testCharacterSheet
+            .getByRole('listitem')
+            .filter({ hasText: 'Basic Actions Action Cost' }),
+    ).toBeVisible();
+    await expect(
+        testCharacterSheet.locator(
+            'app-actor-actions-list > .item-list.collapsible > .item.header > .details > .controls > a',
+        ),
+    ).toBeVisible();
+    await expect(
+        testCharacterSheet
+            .locator('.item-list.empty > .item > .details > .controls > a')
+            .first(),
+    ).toBeVisible();
+
+    // Toggle edit mode off
+    await page.locator('.fa-solid.fa-pen').click();
+    await expect(
+        testCharacterSheet
+            .getByRole('listitem')
+            .filter({ hasText: 'Envoy Actions Action Cost' }),
+    ).toBeVisible();
+    await expect(
+        testCharacterSheet.locator(
+            'app-actor-actions-list > .item-list.collapsible > .item.header > .details > .controls > a',
+        ),
+    ).toBeVisible();
+    await expect(
+        testCharacterSheet.getByText('Rousing Presence 1 — —'),
+    ).toBeVisible();
+    await expect(
+        testCharacterSheet
+            .getByRole('listitem')
+            .filter({ hasText: 'Basic Actions Action Cost' }),
+    ).not.toBeVisible();
+});

--- a/src/system/tests/playwright/actor-sheet/character-sheet-details.spec.ts
+++ b/src/system/tests/playwright/actor-sheet/character-sheet-details.spec.ts
@@ -1,0 +1,264 @@
+import {
+    ActorType,
+    Attribute,
+    AttributeGroup,
+} from '@src/system/types/cosmere';
+import { test, expect } from '../fixtures';
+import { html5DragAndDrop } from '../helpers/drag-drop';
+
+test('Resources/Attribute/Defenses', async ({
+    authenticatedPage: page,
+    createActor,
+}) => {
+    const testCharacter = await createActor(
+        'Test Character',
+        ActorType.Character,
+    );
+    await testCharacter.checkResource('Health', 0, 10);
+    await testCharacter.checkResource('Focus', 0, 2);
+    await testCharacter.checkResource('Investiture', 0, 0);
+    await testCharacter.checkAttribute(Attribute.Strength, 0);
+    await testCharacter.checkAttribute(Attribute.Speed, 0);
+    await testCharacter.checkAttribute(Attribute.Intellect, 0);
+    await testCharacter.checkAttribute(Attribute.Willpower, 0);
+    await testCharacter.checkAttribute(Attribute.Awareness, 0);
+    await testCharacter.checkAttribute(Attribute.Presence, 0);
+    await testCharacter.checkDefense(AttributeGroup.Physical, 10);
+    await testCharacter.checkDefense(AttributeGroup.Cognitive, 10);
+    await testCharacter.checkDefense(AttributeGroup.Spiritual, 10);
+
+    // Update strength, check new values
+    await testCharacter.updateAttribute(Attribute.Strength, 1);
+    await testCharacter.checkResource('Health', 1, 11);
+    await testCharacter.checkResource('Focus', 0, 2);
+    await testCharacter.checkAttribute(Attribute.Strength, 1);
+    await testCharacter.checkAttribute(Attribute.Speed, 0);
+    await testCharacter.checkDefense(AttributeGroup.Physical, 11);
+    await testCharacter.checkDefense(AttributeGroup.Cognitive, 10);
+
+    // Update speed, check new values
+    await testCharacter.updateAttribute(Attribute.Speed, 2);
+    await testCharacter.checkResource('Health', 1, 11);
+    await testCharacter.checkResource('Focus', 0, 2);
+    await testCharacter.checkAttribute(Attribute.Strength, 1);
+    await testCharacter.checkAttribute(Attribute.Speed, 2);
+    await testCharacter.checkDefense(AttributeGroup.Physical, 13);
+    await testCharacter.checkDefense(AttributeGroup.Cognitive, 10);
+
+    // Update health to less than max
+    await testCharacter.updateResource('Health', 5);
+    await testCharacter.checkResource('Health', 5, 11);
+
+    // Update health to more than max
+    await testCharacter.updateResource('Health', 100);
+    await testCharacter.checkResource('Health', 11, 11);
+});
+
+test('Ancestry/Culture/Path Drag and Drop', async ({
+    authenticatedPage: page,
+    createActor,
+}) => {
+    const testCharacter = await createActor(
+        'Test Character',
+        ActorType.Character,
+    );
+    const testCharacterSheet = testCharacter.locator;
+    await testCharacter.checkResource('Health', 0, 10);
+    await testCharacter.checkResource('Focus', 0, 2);
+    await testCharacter.checkResource('Investiture', 0, 0);
+    await testCharacter.checkAttribute(Attribute.Strength, 0);
+    await testCharacter.checkAttribute(Attribute.Speed, 0);
+    await testCharacter.checkAttribute(Attribute.Intellect, 0);
+    await testCharacter.checkAttribute(Attribute.Willpower, 0);
+    await testCharacter.checkAttribute(Attribute.Awareness, 0);
+    await testCharacter.checkAttribute(Attribute.Presence, 0);
+    await testCharacter.checkDefense(AttributeGroup.Physical, 10);
+    await testCharacter.checkDefense(AttributeGroup.Cognitive, 10);
+    await testCharacter.checkDefense(AttributeGroup.Spiritual, 10);
+    await page.getByRole('tab', { name: 'Compendium Packs' }).click();
+    await page
+        .locator('span')
+        .filter({ hasText: 'Stormlight Starter Rules' })
+        .click();
+
+    // Add Human ancestry
+    await page.locator('a').filter({ hasText: 'Ancestries' }).click();
+    const humanAncestryElement = page.getByText('Human');
+    await html5DragAndDrop(page, humanAncestryElement, testCharacterSheet);
+    await expect(
+        testCharacterSheet.locator('app-character-ancestry'),
+    ).toContainText('Human Ancestry');
+    await page
+        .locator('#compendium-cosmere-rpg_ancestries')
+        .getByRole('button', { name: 'Close Window' })
+        .click();
+
+    // Add Herdazian Culture
+    await page.locator('a').filter({ hasText: 'Cultures' }).click();
+    const herdazianCultureElement = page.getByText('Herdazian');
+    await html5DragAndDrop(page, herdazianCultureElement, testCharacterSheet);
+    await expect(
+        testCharacterSheet.locator('app-character-culture'),
+    ).toContainText('Herdazian Culture');
+    await page
+        .locator('#compendium-cosmere-rpg_cultures')
+        .getByRole('button', { name: 'Close Window' })
+        .click();
+
+    // Add Agent path
+
+    await page.locator('a').filter({ hasText: 'Heroic Paths' }).click();
+    await page.locator('span').filter({ hasText: 'Agent' }).click();
+    const agentPathElement = page.locator('a').filter({ hasText: /^Agent$/ });
+    await html5DragAndDrop(page, agentPathElement, testCharacterSheet);
+    await expect(
+        testCharacterSheet
+            .locator('app-actor-skill')
+            .filter({ hasText: 'Insight' }),
+    ).toContainText('+ 1 Insight AWA');
+    await page.locator('a').filter({ hasText: '3' }).click();
+    await page.locator('.sheet-navigation > a:nth-child(2)').click();
+    await expect(page.locator('app-character-talents-list')).toContainText(
+        'Agent Talents',
+    );
+    await expect(page.locator('app-character-talents-list')).toContainText(
+        'Opportunist',
+    );
+});
+
+test('Edit mode', async ({ authenticatedPage: page, createActor }) => {
+    const testCharacter = await createActor(
+        'Test Character',
+        ActorType.Character,
+    );
+    const testCharacterSheet = testCharacter.locator;
+
+    await expect(
+        testCharacterSheet.locator(
+            'div:nth-child(1) > .attributes > .sheet-stack.defense > .container > .config-icon',
+        ),
+    ).toBeVisible();
+    await expect(
+        testCharacterSheet.locator(
+            'div:nth-child(2) > .attributes > .sheet-stack.defense > .container > .config-icon',
+        ),
+    ).toBeVisible();
+    await expect(
+        testCharacterSheet.locator(
+            'div:nth-child(3) > .attributes > .sheet-stack.defense > .container > .config-icon',
+        ),
+    ).toBeVisible();
+    await expect(
+        testCharacterSheet.locator('.label > a').first(),
+    ).toBeVisible();
+    await expect(
+        testCharacterSheet.locator(
+            '.sheet-stack.derived-stat.movement > .label > a',
+        ),
+    ).toBeVisible();
+    await expect(
+        testCharacterSheet.locator(
+            '.sheet-stack.derived-stat.recovery > .label > a',
+        ),
+    ).toBeVisible();
+    await expect(
+        testCharacterSheet.locator(
+            '.sheet-stack.derived-stat.senses > .label > a',
+        ),
+    ).toBeVisible();
+    await expect(
+        testCharacterSheet.locator(
+            '.sheet-stack.derived-stat.lift > .label > a',
+        ),
+    ).toBeVisible();
+    await expect(
+        testCharacterSheet.locator('.controls > a:nth-child(2)').first(),
+    ).toBeVisible();
+    await expect(
+        testCharacterSheet.locator(
+            '.resource.foc > .sidebar-header > .controls > a',
+        ),
+    ).toBeVisible();
+    await expect(
+        testCharacterSheet.locator(
+            '.resource.inv > .sidebar-header > .controls > a',
+        ),
+    ).toBeVisible();
+    await expect(
+        testCharacterSheet
+            .locator('div')
+            .filter({ hasText: 'Expertises' })
+            .nth(3),
+    ).toBeVisible();
+    await expect(
+        testCharacterSheet
+            .locator('div')
+            .filter({ hasText: 'Immunities' })
+            .nth(3),
+    ).toBeVisible();
+    // Toggle edit mode off
+    await testCharacterSheet.locator('.slider').click();
+    await expect(
+        testCharacterSheet.locator(
+            'div:nth-child(1) > .attributes > .sheet-stack.defense > .container > .config-icon',
+        ),
+    ).not.toBeVisible();
+    await expect(
+        testCharacterSheet.locator(
+            'div:nth-child(2) > .attributes > .sheet-stack.defense > .container > .config-icon',
+        ),
+    ).not.toBeVisible();
+    await expect(
+        testCharacterSheet.locator(
+            'div:nth-child(3) > .attributes > .sheet-stack.defense > .container > .config-icon',
+        ),
+    ).not.toBeVisible();
+    await expect(
+        testCharacterSheet.locator('.label > a').first(),
+    ).not.toBeVisible();
+    await expect(
+        testCharacterSheet.locator(
+            '.sheet-stack.derived-stat.movement > .label > a',
+        ),
+    ).not.toBeVisible();
+    await expect(
+        testCharacterSheet.locator(
+            '.sheet-stack.derived-stat.recovery > .label > a',
+        ),
+    ).not.toBeVisible();
+    await expect(
+        testCharacterSheet.locator(
+            '.sheet-stack.derived-stat.senses > .label > a',
+        ),
+    ).not.toBeVisible();
+    await expect(
+        testCharacterSheet.locator(
+            '.sheet-stack.derived-stat.lift > .label > a',
+        ),
+    ).not.toBeVisible();
+    await expect(
+        testCharacterSheet.locator('.controls > a:nth-child(2)').first(),
+    ).not.toBeVisible();
+    await expect(
+        testCharacterSheet.locator(
+            '.resource.foc > .sidebar-header > .controls > a',
+        ),
+    ).not.toBeVisible();
+    await expect(
+        testCharacterSheet.locator(
+            '.resource.inv > .sidebar-header > .controls > a',
+        ),
+    ).not.toBeVisible();
+    await expect(
+        testCharacterSheet
+            .locator('div')
+            .filter({ hasText: 'Expertises' })
+            .nth(3),
+    ).not.toBeVisible();
+    await expect(
+        testCharacterSheet
+            .locator('div')
+            .filter({ hasText: 'Immunities' })
+            .nth(3),
+    ).not.toBeVisible();
+});

--- a/src/system/tests/playwright/embedded-actions/embedded-actions.spec.ts
+++ b/src/system/tests/playwright/embedded-actions/embedded-actions.spec.ts
@@ -1,0 +1,87 @@
+import { ItemType } from '@src/system/types/cosmere';
+import { test, expect } from '../fixtures';
+
+test('Create talent with embedded action', async ({
+    authenticatedPage: page,
+    createItem,
+}) => {
+    await expect(page).toHaveTitle('Foundry Virtual Tabletop');
+    const testTalent = await createItem('Test Talent', ItemType.Talent);
+    const testTalentSheet = testTalent.locator;
+    await expect(testTalentSheet.locator('.item-header')).toBeVisible();
+    await expect(testTalentSheet.locator('app-item-header'))
+        .toMatchAriaSnapshot(`
+      - img
+      - textbox: Test Talent
+      `);
+    await testTalentSheet.getByText('Actions').click();
+    const embeddedAction = await testTalent.createEmbeddedItem();
+    const embeddedActionSheet = embeddedAction.locator;
+
+    await expect(
+        testTalentSheet.getByRole('listitem').filter({ hasText: 'New Action' }),
+    ).toBeVisible();
+    await embeddedActionSheet.getByText('Details').click();
+    await expect(
+        testTalentSheet
+            .getByRole('listitem')
+            .filter({ hasText: 'New Action — —' }),
+    ).toBeVisible();
+    await embeddedActionSheet
+        .locator('select[name="system.activation.type"]')
+        .selectOption('utility');
+    await embeddedActionSheet
+        .locator('select[name="system.activation.cost.type"]')
+        .selectOption('act');
+    await embeddedActionSheet.getByRole('spinbutton').click();
+    await embeddedActionSheet.getByRole('spinbutton').fill('2');
+    await embeddedActionSheet.getByText('Details').click();
+    await expect(
+        testTalentSheet.locator('app-item-actions-list'),
+    ).toContainText('2');
+    await embeddedActionSheet
+        .locator('app-item-resource-consumption-list > .controls > a')
+        .click();
+    await expect(
+        embeddedActionSheet.locator('app-item-resource-consumption-list'),
+    ).toContainText('1 Focus from Ancestor of type Actor');
+    await expect(
+        testTalentSheet.locator('app-item-actions-list'),
+    ).toContainText('New Action 2 1 Focus —');
+
+    await page.locator('select[name="resource"]').selectOption('inv');
+    await expect(
+        embeddedActionSheet.locator('app-item-resource-consumption-list'),
+    ).toContainText('1 Investiture from Ancestor of type Actor');
+    await expect(
+        testTalentSheet.locator('app-item-actions-list'),
+    ).toContainText('New Action 2 1 Investiture —');
+
+    await page.locator('input[name="value"]').fill('1+');
+    await page.locator('#board').click({
+        position: {
+            x: 0,
+            y: 0,
+        },
+    });
+    await expect(
+        embeddedActionSheet.locator('app-item-resource-consumption-list'),
+    ).toContainText('1+ Investiture from Ancestor of type Actor');
+    await expect(
+        testTalentSheet.locator('app-item-actions-list'),
+    ).toContainText('New Action 2 1+ Investiture —');
+
+    await page.locator('input[name="value"]').fill('0-2');
+    await page.locator('#board').click({
+        position: {
+            x: 0,
+            y: 0,
+        },
+    });
+    await expect(
+        embeddedActionSheet.locator('app-item-resource-consumption-list'),
+    ).toContainText('0-2 Investiture from Ancestor of type Actor');
+    await expect(
+        testTalentSheet.locator('app-item-actions-list'),
+    ).toContainText('New Action 2 1 - 2 Investiture (Optional) —');
+});

--- a/src/system/tests/playwright/fixtures.ts
+++ b/src/system/tests/playwright/fixtures.ts
@@ -1,0 +1,75 @@
+import { test as base, expect } from '@playwright/test';
+import { Page } from '@playwright/test';
+import { ActorType, ItemType } from '@src/system/types/cosmere';
+import { ItemSheetRef } from './helpers/item';
+import { ActorSheetRef } from './helpers/actor';
+
+// Declare the types for your custom fixtures
+interface MyFixtures {
+    authenticatedPage: Page;
+    createItem: (name: string, type: ItemType) => Promise<ItemSheetRef>;
+    createActor: (name: string, type: ActorType) => Promise<ActorSheetRef>;
+}
+
+export const test = base.extend<MyFixtures>({
+    authenticatedPage: async ({ page }, use) => {
+        await page.goto('/game');
+        await page.waitForFunction(
+            () => typeof game !== 'undefined' && game.ready === true,
+            { timeout: 120_000 },
+        );
+
+        const hardwareAccelerationWarning = page
+            .locator('.notification.warning.permanent')
+            .filter({
+                hasText:
+                    /Hardware Acceleration Disabled|does not have hardware acceleration enabled/i,
+            });
+
+        if (await hardwareAccelerationWarning.isVisible()) {
+            await hardwareAccelerationWarning.click();
+        }
+
+        await use(page);
+    },
+    createItem: async ({ authenticatedPage: page }, use) => {
+        const createdItems: ItemSheetRef[] = [];
+        const factory = async (name: string, type: ItemType) => {
+            const itemSheetRefData = await ItemSheetRef.create(
+                page,
+                name,
+                type,
+            );
+            const itemSheetRef = new ItemSheetRef(page, itemSheetRefData);
+            createdItems.push(itemSheetRef);
+            return itemSheetRef;
+        };
+
+        await use(factory);
+
+        for (const item of createdItems) {
+            await item.delete();
+        }
+    },
+    createActor: async ({ authenticatedPage: page }, use) => {
+        const createdActors: ActorSheetRef[] = [];
+        const factory = async (name: string, type: ActorType) => {
+            const actorSheetRefData = await ActorSheetRef.create(
+                page,
+                name,
+                type,
+            );
+            const actorSheetRef = new ActorSheetRef(page, actorSheetRefData);
+            createdActors.push(actorSheetRef);
+            return actorSheetRef;
+        };
+
+        await use(factory);
+
+        for (const actor of createdActors) {
+            await actor.delete();
+        }
+    },
+});
+
+export { expect };

--- a/src/system/tests/playwright/global-setup.ts
+++ b/src/system/tests/playwright/global-setup.ts
@@ -1,0 +1,26 @@
+import { execSync } from 'child_process';
+import { chromium, type FullConfig } from '@playwright/test';
+
+async function globalSetup(config: FullConfig) {
+    // Shutdown Docker container if one is already running
+    execSync('npm run docker:down', { stdio: 'inherit' });
+    // Start Docker container and wait for healthcheck to pass
+    execSync('npm run docker:up -- --wait', { stdio: 'inherit' });
+
+    const browser = await chromium.launch();
+    const page = await browser.newPage();
+
+    // Navigate to FoundryVTT and join as Gamemaster
+    await page.goto('http://localhost:30000');
+    console.log('Joining as Gamemaster...');
+    await page.selectOption('select[name="userid"]', { label: 'Gamemaster' });
+    await page.click('button[name="join"]');
+
+    // Save signed-in state so tests can reuse it
+    await page
+        .context()
+        .storageState({ path: './playwright/.auth/state.json' });
+    await browser.close();
+}
+
+export default globalSetup;

--- a/src/system/tests/playwright/global-teardown.ts
+++ b/src/system/tests/playwright/global-teardown.ts
@@ -1,0 +1,7 @@
+import { execSync } from 'child_process';
+
+function globalTeardown() {
+    execSync('npm run docker:down', { stdio: 'inherit' });
+}
+
+export default globalTeardown;

--- a/src/system/tests/playwright/helpers/actor.ts
+++ b/src/system/tests/playwright/helpers/actor.ts
@@ -1,0 +1,155 @@
+import { expect, Locator, Page } from '@playwright/test';
+import {
+    ActorType,
+    Attribute,
+    AttributeGroup,
+} from '@src/system/types/cosmere';
+import { paramsFromHook } from './hooks';
+
+interface ActorSheetRefData {
+    id: string;
+    uuid: string;
+    name: string;
+    type: ActorType;
+}
+
+export class ActorSheetRef {
+    public readonly locator: Locator;
+    public readonly id: string;
+    public readonly uuid: string;
+    public readonly name: string;
+    public readonly type: ActorType;
+
+    constructor(
+        private readonly page: Page,
+        sheetRefData: ActorSheetRefData,
+    ) {
+        this.id = sheetRefData.id;
+        this.uuid = sheetRefData.uuid;
+        this.name = sheetRefData.name;
+        this.type = sheetRefData.type;
+        if (this.type == ActorType.Character) {
+            this.locator = page.locator(`#CharacterSheet-Actor-${this.id}`);
+        } else {
+            this.locator = page.locator(`#AdversarySheet-Actor-${this.id}`);
+        }
+    }
+
+    public static async create(
+        page: Page,
+        name: string,
+        type: ActorType,
+    ): Promise<ActorSheetRefData> {
+        await page.getByRole('tab', { name: 'Actors' }).click();
+        await page.getByRole('button', { name: ' Create Actor' }).click();
+        await page.getByRole('textbox', { name: 'Character' }).click();
+        await page.getByRole('textbox', { name: 'Character' }).fill(name);
+        await page.getByRole('combobox').selectOption(type);
+        const newActorPromise = paramsFromHook(page, 'createActor');
+        await page.getByRole('button', { name: ' Create Actor' }).click();
+        const [createdActor, createOptions, id] = await newActorPromise;
+        expect(createdActor.name == name);
+        expect(createdActor.type == type);
+        expect(createdActor.id);
+        expect(createdActor.uuid);
+        const actorSheetRef = {
+            id: createdActor.id!,
+            uuid: createdActor.uuid,
+            name: createdActor.name,
+            type: createdActor.type as ActorType,
+        };
+        let locString;
+
+        if (createdActor.type == ActorType.Character) {
+            locString = `#CharacterSheet-Actor-${createdActor.id}`;
+        } else {
+            locString = `#AdversarySheet-Actor-${createdActor.id}`;
+        }
+        await expect(page.locator(locString)).toHaveCount(1);
+        return actorSheetRef;
+    }
+
+    public async delete() {
+        await this.page.evaluate(async (id) => {
+            await game.actors?.get(id)?.delete();
+        }, this.id);
+    }
+
+    public async checkResource(
+        resourceLabel: string,
+        expectedVal: number,
+        expectedMax: number,
+    ) {
+        const resourceBar = this.locator
+            .locator('app-actor-resource')
+            .filter({ hasText: resourceLabel });
+        await expect(resourceBar).toHaveCount(1);
+        await expect(resourceBar).toContainText(
+            `${expectedVal}\n/\n${expectedMax}`,
+        );
+    }
+
+    public async checkAttribute(attribute: Attribute, expectedVal: number) {
+        const attributeInput = this.locator.locator(
+            `input[name="system.attributes.${attribute}.value"]`,
+        );
+        await expect(attributeInput).toHaveCount(1);
+        await expect(attributeInput).toHaveValue(`${expectedVal}`);
+    }
+
+    public async checkDefense(
+        attributeGroup: AttributeGroup,
+        expectedVal: number,
+    ) {
+        const defenseDisplay = this.locator
+            .locator(`div.attribute-group[data-id=${attributeGroup}]`)
+            .locator(`div.sheet-stack.defense`);
+        await expect(defenseDisplay).toHaveCount(1);
+        await expect(defenseDisplay).toContainText(`${expectedVal}`);
+    }
+
+    public async updateAttribute(attribute: Attribute, newVal: number) {
+        await this.locator
+            .locator(`input[name="system.attributes.${attribute}.value"]`)
+            .click();
+        await this.locator
+            .locator(`input[name="system.attributes.${attribute}.value"]`)
+            .fill(`${newVal}`);
+        await this.locator.getByRole('banner').click();
+    }
+
+    public async updateResource(resourceLabel: string, newVal: number) {
+        const resourceBar = this.locator
+            .locator('app-actor-resource')
+            .filter({ hasText: resourceLabel });
+        await resourceBar.click();
+        const resourceBarInput = resourceBar.locator(`input`);
+        await resourceBarInput.fill(`${newVal}`);
+        await this.locator.getByRole('banner').click();
+    }
+
+    public async switchToActionsTab() {
+        await this.locator.locator('a').filter({ hasText: '3' }).click();
+    }
+
+    public async checkHasAction(
+        name: string,
+        cost: string,
+        consume = '—',
+        resources = '—',
+    ) {
+        await expect(
+            this.locator
+                .locator('app-actor-actions-list')
+                .getByText(`${name} ${cost} ${consume} ${resources}`),
+        ).toBeVisible();
+    }
+
+    public async actionLocator(name: string) {
+        const actionLocator = this.locator
+            .locator('app-actor-actions-list li')
+            .filter({ has: this.page.locator('span.name', { hasText: name }) });
+        await expect(actionLocator).toHaveCount(1);
+        return actionLocator;
+    }
+}

--- a/src/system/tests/playwright/helpers/chat.ts
+++ b/src/system/tests/playwright/helpers/chat.ts
@@ -1,0 +1,5 @@
+import { Locator, Page } from '@playwright/test';
+
+export function mostRecentChatMessage(page: Page): Locator {
+    return page.locator('#chat .chat-message').last();
+}

--- a/src/system/tests/playwright/helpers/drag-drop.ts
+++ b/src/system/tests/playwright/helpers/drag-drop.ts
@@ -1,0 +1,16 @@
+import { Page, Locator } from '@playwright/test';
+
+export async function html5DragAndDrop(
+    page: Page,
+    source: Locator,
+    target: Locator,
+) {
+    // One shared DataTransfer object travels from dragstart to drop
+    const dataTransfer = await page.evaluateHandle(() => new DataTransfer());
+
+    await source.dispatchEvent('dragstart', { dataTransfer });
+    await target.dispatchEvent('dragenter', { dataTransfer });
+    await target.dispatchEvent('dragover', { dataTransfer });
+    await target.dispatchEvent('drop', { dataTransfer });
+    await source.dispatchEvent('dragend', { dataTransfer });
+}

--- a/src/system/tests/playwright/helpers/hooks.ts
+++ b/src/system/tests/playwright/helpers/hooks.ts
@@ -1,0 +1,85 @@
+import { Page } from '@playwright/test';
+
+export async function paramsFromHook<K extends Hooks.HookName>(
+    page: Page,
+    hookName: K,
+    timeout = 3000,
+) {
+    // Create a promise which will resolve to the args of whatever hook we're waiting on
+    return await page.evaluate(
+        ({ hookName, timeout }) => {
+            let done = false;
+            return new Promise<Hooks.HookParameters<K>>((resolve, reject) => {
+                // Create a handler which will be called by the hook so we can type it as a hook function
+                const handler = ((...hookArgs: Hooks.HookParameters<K>) => {
+                    done = true;
+
+                    // Ensure that any id/uuid getters are serialized before returning to the playwright context.
+                    const findGetter = (obj: object, prop: string) => {
+                        let current: object | null = obj;
+                        while (current) {
+                            const descriptor = Object.getOwnPropertyDescriptor(
+                                current,
+                                prop,
+                            );
+                            if (descriptor)
+                                return typeof descriptor.get === 'function'
+                                    ? descriptor
+                                    : undefined;
+                            current = Object.getPrototypeOf(current) as
+                                | object
+                                | null;
+                        }
+                        return undefined;
+                    };
+
+                    for (const hookArg of hookArgs) {
+                        if (typeof hookArg !== 'object' || hookArg === null)
+                            continue;
+
+                        for (const prop of ['id', 'uuid'] as const) {
+                            if (!findGetter(hookArg, prop)) continue;
+
+                            const value = (hookArg as Record<string, unknown>)[
+                                prop
+                            ];
+                            Object.defineProperty(hookArg, prop, {
+                                value,
+                                writable: true,
+                                enumerable: true,
+                                configurable: true,
+                            });
+                        }
+                    }
+                    resolve(hookArgs);
+                    console.log('Parameters in Foundry context:');
+                    console.log(hookArgs);
+                    Hooks.off(hookName, hookId);
+                    return true;
+                }) as Hooks.Function<K>;
+
+                const hookId = Hooks.on(hookName as K, handler);
+
+                setTimeout(function () {
+                    if (done) return;
+                    Hooks.off(hookName as K, hookId);
+                    reject(Error(`await ${hookName} timed out`));
+                }, timeout);
+            });
+        },
+        { hookName, timeout },
+    );
+}
+
+export async function getLocatorForNextWindowToOpen(
+    page: Page,
+    timeout = 3000,
+) {
+    const [application] = await paramsFromHook(
+        page,
+        'renderApplicationV2',
+        timeout,
+    );
+
+    return page.locator(`#${application.id}`);
+}

--- a/src/system/tests/playwright/helpers/item.ts
+++ b/src/system/tests/playwright/helpers/item.ts
@@ -1,0 +1,95 @@
+import { expect, Locator, Page } from '@playwright/test';
+
+import { ItemType } from '@src/system/types/cosmere';
+import { paramsFromHook } from './hooks';
+
+interface ItemSheetRefData {
+    id: string;
+    uuid: string;
+    name: string;
+    type: ItemType;
+    typeLabel: string;
+}
+
+export class ItemSheetRef {
+    public readonly locator: Locator;
+    public readonly id: string;
+    public readonly uuid: string;
+    public readonly name: string;
+    public readonly type: ItemType;
+
+    constructor(
+        private readonly page: Page,
+        sheetRefData: ItemSheetRefData,
+    ) {
+        this.id = sheetRefData.id;
+        this.uuid = sheetRefData.uuid;
+        this.name = sheetRefData.name;
+        this.type = sheetRefData.type;
+        const sheetUuidString = sheetRefData.uuid.replaceAll('.', '-');
+        this.locator = page.locator(
+            `#${sheetRefData.typeLabel}ItemSheet-${sheetUuidString}`,
+        );
+    }
+
+    public static async create(
+        page: Page,
+        name: string,
+        type: ItemType,
+    ): Promise<ItemSheetRefData> {
+        await page.getByRole('tab', { name: 'Items' }).click();
+        await page.getByRole('button', { name: ' Create Item' }).click();
+        await page.getByRole('combobox').selectOption(type);
+
+        await page.locator(`input[name="name"]`).click();
+        await page.locator(`input[name="name"]`).fill(name);
+        await page.getByRole('heading', { name: 'Create Item' }).click();
+        const newItemPromise = paramsFromHook(page, 'createItem');
+        await page.getByRole('button', { name: ' Create Item' }).click();
+        return newItemPromiseToSheetRef(newItemPromise, {
+            expectedName: name,
+            expectedType: type,
+        });
+    }
+
+    public async delete() {
+        await this.page.evaluate(async (id) => {
+            await game.items?.get(id)?.delete();
+        }, this.id);
+    }
+
+    public async createEmbeddedItem() {
+        const embeddedActionPromise = paramsFromHook(this.page, 'createItem');
+        await this.locator.locator('.controls > a').first().click();
+        const embeddedAction = await newItemPromiseToSheetRef(
+            embeddedActionPromise,
+            { expectedType: ItemType.Action },
+        );
+        return new ItemSheetRef(this.page, embeddedAction);
+    }
+}
+
+async function newItemPromiseToSheetRef(
+    newItemPromise: Promise<Hooks.HookParameters<'createItem'>>,
+    expectedVals?: { expectedName?: string; expectedType: ItemType },
+) {
+    const [createdItem, createOptions, id] = await newItemPromise;
+    if (expectedVals?.expectedName) {
+        expect(createdItem.name == expectedVals.expectedName);
+    }
+    if (expectedVals?.expectedType) {
+        expect(createdItem.type == expectedVals.expectedType);
+    }
+    expect(createdItem.id);
+    expect(createdItem.uuid);
+    const typeLabel =
+        createdItem.type.charAt(0).toUpperCase() + createdItem.type.slice(1);
+    const itemSheetRefData = {
+        id: createdItem.id!,
+        uuid: createdItem.uuid,
+        name: createdItem.name,
+        type: createdItem.type,
+        typeLabel,
+    };
+    return itemSheetRefData;
+}

--- a/src/system/tests/playwright/helpers/notifications.ts
+++ b/src/system/tests/playwright/helpers/notifications.ts
@@ -1,0 +1,9 @@
+import { Page } from '@playwright/test';
+
+export async function clearNotifications(page: Page) {
+    const notifications = page.locator('.notification');
+
+    while ((await notifications.count()) > 0) {
+        await notifications.first().click();
+    }
+}

--- a/src/system/tests/playwright/initialization.spec.ts
+++ b/src/system/tests/playwright/initialization.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from './fixtures';
+
+test('Foundry accessible, System loaded, Stormlight Starter Rules Present', async ({
+    authenticatedPage: page,
+}) => {
+    await expect(page).toHaveTitle('Foundry Virtual Tabletop');
+    await page.getByRole('tab', { name: 'Game Settings' }).click();
+    await expect(
+        page.locator('#settings').getByText('Cosmere Roleplaying Game'),
+    ).toBeVisible();
+    await page.getByRole('tab', { name: 'Compendium Packs' }).click();
+    await expect(
+        page.locator('a').filter({ hasText: 'Stormlight Starter Rules' }),
+    ).toBeVisible();
+    await page
+        .locator('a')
+        .filter({ hasText: 'Stormlight Starter Rules' })
+        .click();
+    await expect(
+        page
+            .locator('#compendium-cosmere-rpg_starter-rules')
+            .getByRole('strong'),
+    ).toBeVisible();
+    await expect(
+        page.locator('#compendium-cosmere-rpg_starter-rules'),
+    ).toContainText('Stormlight Starter Rules');
+});

--- a/src/system/types/cosmere.ts
+++ b/src/system/types/cosmere.ts
@@ -341,3 +341,11 @@ export const enum TurnSpeed {
 export const enum Theme {
     Default = 'default',
 }
+
+/**
+ * The unit system used to display distances and weights throughout the system.
+ */
+export const enum UnitSystem {
+    Imperial = 'imperial',
+    Metric = 'metric',
+}

--- a/src/system/utils/handlebars/index.ts
+++ b/src/system/utils/handlebars/index.ts
@@ -27,12 +27,16 @@ import { ItemContext, ItemContextOptions } from './types';
 import { TEMPLATES } from '../templates';
 import { SYSTEM_ID } from '@system/constants';
 import { ActionItemDataModel } from '@system/data/item/action';
+import { getUnitLabel } from '@system/settings';
 
 Handlebars.registerHelper('add', (a: number, b: number) => a + b);
 Handlebars.registerHelper('sub', (a: number, b: number) => a - b);
 Handlebars.registerHelper('multi', (a: number, b: number) => a * b);
 Handlebars.registerHelper('divide', (a: number, b: number) => a / b);
 Handlebars.registerHelper('mod', (a: number, b: number) => a % b);
+
+Handlebars.registerHelper('distanceUnit', () => getUnitLabel('distance'));
+Handlebars.registerHelper('weightUnit', () => getUnitLabel('weight'));
 
 Handlebars.registerHelper('default', (v: unknown, defaultVal: unknown) => {
     return v ? v : defaultVal;

--- a/src/system/utils/macros/starting-path.ts
+++ b/src/system/utils/macros/starting-path.ts
@@ -45,7 +45,7 @@ export async function set(
 
     if (options?.notify !== false) {
         ui.notifications.info(
-            game.i18n.format('STORMLIGHT.Macro.StartingPath.Set', {
+            game.i18n.format('COSMERE.Objects.Stormlight.Macro.StartingPath.Set', {
                 path: item.name,
                 actor: actor.name,
                 skill: game.i18n.localize(
@@ -90,8 +90,8 @@ export async function unset(
         ui.notifications.info(
             game.i18n.format(
                 newStartingPath
-                    ? 'STORMLIGHT.Macro.StartingPath.Replaced'
-                    : 'STORMLIGHT.Macro.StartingPath.Unset',
+                    ? 'COSMERE.Objects.Stormlight.Macro.StartingPath.Replaced'
+                    : 'COSMERE.Objects.Stormlight.Macro.StartingPath.Unset',
                 {
                     actor: actor.name,
                     skill: game.i18n.localize(

--- a/src/templates/actors/components/details.hbs
+++ b/src/templates/actors/components/details.hbs
@@ -53,7 +53,7 @@
             <div class="background"></div>
             <div class="border"></div>
             <span class="value">{{derived (lookup (lookup actor.system.movement preferredMovementType) "rate")}}</span>
-            <span class="unit">ft</span>
+            <span class="unit">{{distanceUnit}}</span>
         </div>
         <span class="label">
             {{localize "COSMERE.Actor.Statistics.MovementRate"}}
@@ -120,7 +120,7 @@
             <span class="value">—</span>
             {{else}}
             <span class="value">{{range}}</span>
-            <span class="unit">ft</span>
+            <span class="unit">{{distanceUnit}}</span>
             {{/if}}
             {{/with}}
         </div>
@@ -143,11 +143,11 @@
             <div class="border"></div>
             {{#with (derived actor.system.encumbrance.lift) as |lift|}}
             <span class="value">{{lift}}</span>
-            <span class="unit">lbs</span>
+            <span class="unit">{{weightUnit}}</span>
             {{/with}}
         </div>
         <span class="label">
-            Lift
+            {{localize "COSMERE.Actor.Statistics.LiftingCapactiy"}}
             {{#if isEditMode}}
             <a data-action="configure-lifting-capacity"
                 data-tooltip="COSMERE.Actor.Sheet.ConfigureLiftingCapacity"


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes a few issues. 
One regarding how we check for pierce on the actor when applying damage. 
One issue on the item on getting itemSource where it ignores embedded items
And lastly an issue where isDefaultAction checks its own default action, instead of the parent's default action.

**Related Issue**  
Closes #934 

**How Has This Been Tested?**  
1. Create a new character
2. set deflect to 5
3. give new character grandbow and ensure pierce is an expert trait and that the character has grandbow expertise
4. drag character token to scene
5. equip grandbow and use strike action
6. Apply damage to own character and see that deflect is no longer applied on pierce applicable weapons

**Screenshots (if applicable)**  
<img width="289" height="437" alt="image" src="https://github.com/user-attachments/assets/9378b869-29cc-4731-bab1-46cff87f53b4" />

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.

**Additional context**  
_Add any other context or information here that would be useful for reviewers._
