### PR TITLE
Fix/weapon traits behavior do not apply properly #934

### DIFF
--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -641,7 +641,12 @@ export class CosmereActor<
         const parsedUuid = foundry.utils.parseUuid(uuid);
         const documentId = parsedUuid?.id ?? uuid;
         for (const [, document] of this.traverseEmbeddedDocuments()) {
-            if (document.uuid != uuid && document.id != documentId) continue;
+            // Go to next document if current document does not share UUID and if provided uuid is a partial id and the id does not match
+            if (
+                document.uuid != uuid &&
+                (parsedUuid?.embedded.length !== 0 || document.id != documentId)
+            )
+                continue;
 
             if (
                 document instanceof CosmereActiveEffect ||

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -25,6 +25,7 @@ import {
     TalentTreeItem,
     ActionItem,
     EffectsContainerItem,
+    WeaponItem,
 } from '@system/documents/item';
 import { CosmereActiveEffect } from '@system/documents/active-effect';
 
@@ -851,9 +852,13 @@ export class CosmereActor<
                 ? CONFIG.COSMERE.damageTypes[instance.type]
                 : { ignoreDeflect: false };
 
+            const originatingItem = options.originatingItem as ActionItem;
+            const originatingItemParent = originatingItem?.parent as WeaponItem;
+
             const pierce =
-                options.originatingItem?.isWeapon() &&
-                (options.originatingItem?.system?.traits?.pierce?.active ??
+                originatingItem?.isStrikeAction &&
+                originatingItemParent?.isWeapon() &&
+                (originatingItemParent?.system?.traits?.pierce?.active ??
                     false);
 
             // Checks if damage should be deflected or not

--- a/src/system/documents/chat-message.ts
+++ b/src/system/documents/chat-message.ts
@@ -60,11 +60,9 @@ export class CosmereChatMessage<
     }
 
     public get itemSource(): CosmereItem | null {
-        return this.actorSource
-            ? (this.actorSource.items.get(
-                  this.getFlag(SYSTEM_ID, 'message.item'),
-              ) ?? null)
-            : null;
+        const id = this.getFlag(SYSTEM_ID, 'message.item');
+        if (!id) return null;
+        return this.actorSource?.getEmbeddedDocumentFromUuid(id) as CosmereItem;
     }
 
     public get d20Rolls(): D20Roll[] {

--- a/src/system/documents/chat-message.ts
+++ b/src/system/documents/chat-message.ts
@@ -60,9 +60,11 @@ export class CosmereChatMessage<
     }
 
     public get itemSource(): CosmereItem | null {
-        const id = this.getFlag(SYSTEM_ID, 'message.item');
-        if (!id) return null;
-        return this.actorSource?.getEmbeddedDocumentFromUuid(id) as CosmereItem;
+        const uuid = this.getFlag(SYSTEM_ID, 'message.item');
+        if (!uuid) return null;
+        return this.actorSource?.getEmbeddedDocumentFromUuid(
+            uuid,
+        ) as CosmereItem;
     }
 
     public get d20Rolls(): D20Roll[] {

--- a/src/system/documents/ephemeral-embeds/mixin.ts
+++ b/src/system/documents/ephemeral-embeds/mixin.ts
@@ -78,9 +78,11 @@ export function EphemeralEmbeddedDocumentsMixin<
                             const data = foundry.utils.mergeObject(
                                 doc.toObject(),
                                 {
+                                    // Assign random id. There is a 1 in 3.7 quadrillion chance that this
+                                    // can share an ID with another item. Which is basically zero.
                                     _id:
                                         `ephdoc` +
-                                        foundry.utils.randomID().slice(6), // Assign random id. There is a 1 in 3.7 quadrillion chance that this can share an ID with another item. Which is basically zero.
+                                        foundry.utils.randomID().slice(6),
                                 },
                             );
 

--- a/src/system/documents/ephemeral-embeds/mixin.ts
+++ b/src/system/documents/ephemeral-embeds/mixin.ts
@@ -78,11 +78,9 @@ export function EphemeralEmbeddedDocumentsMixin<
                             const data = foundry.utils.mergeObject(
                                 doc.toObject(),
                                 {
-                                    // Assign random id. There is a 1 in 3.7 quadrillion chance that this
-                                    // can share an ID with another item. Which is basically zero.
                                     _id:
                                         `ephdoc` +
-                                        foundry.utils.randomID().slice(6),
+                                        foundry.utils.randomID().slice(6), // Assign random id. There is a 1 in 3.7 quadrillion chance that this can share an ID with another item. Which is basically zero.
                                 },
                             );
 

--- a/src/system/documents/ephemeral-embeds/mixin.ts
+++ b/src/system/documents/ephemeral-embeds/mixin.ts
@@ -78,7 +78,9 @@ export function EphemeralEmbeddedDocumentsMixin<
                             const data = foundry.utils.mergeObject(
                                 doc.toObject(),
                                 {
-                                    _id: `ephdoc${i.toFixed().padStart(10, '0')}`, // Assign deterministic id
+                                    _id:
+                                        `ephdoc` +
+                                        foundry.utils.randomID().slice(6), // Assign random id. There is a 1 in 3.7 quadrillion chance that this can share an ID with another item. Which is basically zero.
                                 },
                             );
 

--- a/src/system/documents/ephemeral-embeds/mixin.ts
+++ b/src/system/documents/ephemeral-embeds/mixin.ts
@@ -78,9 +78,7 @@ export function EphemeralEmbeddedDocumentsMixin<
                             const data = foundry.utils.mergeObject(
                                 doc.toObject(),
                                 {
-                                    _id:
-                                        `ephdoc` +
-                                        foundry.utils.randomID().slice(6), // Assign random id. There is a 1 in 3.7 quadrillion chance that this can share an ID with another item. Which is basically zero.
+                                    _id: `ephdoc${i.toFixed().padStart(10, '0')}`, // Assign deterministic id
                                 },
                             );
 

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -516,7 +516,7 @@ export class CosmereItem<
             !(this.parent instanceof CosmereItem)
         )
             return false;
-        return this.defaultAction?.id === this.id;
+        return this.parent.defaultAction?.id === this.id;
     }
 
     /**

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -1456,7 +1456,7 @@ export class CosmereItem<
                 type: MESSAGE_TYPES.ACTION,
                 description: await this.getDescriptionHTML(),
                 targets: getTargetDescriptors(),
-                item: this.id,
+                item: this.uuid,
             },
         };
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes a few issues. 
One regarding how we check for pierce on the actor when applying damage. 
One issue on the item on getting itemSource where it ignores embedded items
And lastly an issue where isDefaultAction checks its own default action, instead of the parent's default action.

**Related Issue**  
Closes #934 

**How Has This Been Tested?**  
1. Create a new character
2. set deflect to 5
3. give new character grandbow and ensure pierce is an expert trait and that the character has grandbow expertise
4. drag character token to scene
5. equip grandbow and use strike action
6. Apply damage to own character and see that deflect is no longer applied on pierce applicable weapons

**Screenshots (if applicable)**  
<img width="289" height="437" alt="image" src="https://github.com/user-attachments/assets/9378b869-29cc-4731-bab1-46cff87f53b4" />

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.

**Additional context**  
_Add any other context or information here that would be useful for reviewers._