### PR TITLE
fix(actor sheet): Default Resource Mode #956

### DIFF
--- a/src/system/applications/actor/dialogs/configure-resource.ts
+++ b/src/system/applications/actor/dialogs/configure-resource.ts
@@ -1,4 +1,4 @@
-import { Resource } from '@system/types/cosmere';
+import { ActorType, Resource } from '@system/types/cosmere';
 import { CosmereActor } from '@system/documents';
 import { AnyObject } from '@system/types/utils';
 import { SYSTEM_ID } from '@src/system/constants';
@@ -238,28 +238,14 @@ export class ConfigureResourceDialog extends HandlebarsApplicationMixin(
     protected _prepareContext() {
         // Get config
         const config = CONFIG.COSMERE.resources[this.resourceId];
+        const actorType = this.actor.isAdversary()
+            ? ActorType.Adversary
+            : ActorType.Character;
+        const modeConfig = config.modes[actorType];
 
-        type CharacterModes = typeof Derived.Modes;
-        type AdversaryModes = Omit<
-            typeof Derived.Modes,
-            Derived.Mode.Derived
-        > & {
-            range?: string;
-        };
-
-        let modes: CharacterModes | AdversaryModes = Derived.Modes;
-
-        // Set the available modes for adversaries
-        if (this.actor.isAdversary()) {
-            const { derived, ...adversaryModes } = Derived.Modes;
-
-            modes = {
-                ...(this.resourceId === Resource.Health
-                    ? { range: 'GENERIC.DerivedValue.Mode.Range' }
-                    : {}),
-                ...adversaryModes,
-            };
-        }
+        const modes = Object.fromEntries(
+            modeConfig.valid.map((mode) => [mode, Derived.Modes[mode]]),
+        );
 
         return Promise.resolve({
             actor: this.actor,

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -1,5 +1,7 @@
 import type { CosmereRPGConfig } from '@system/types/config';
 
+import { Derived } from './data/fields';
+
 // Types
 import {
     Size,
@@ -35,6 +37,7 @@ import {
     Theme,
     MovementType,
     ImmunityType,
+    ActorType,
 } from './types/cosmere';
 import { AdvantageMode } from './types/roll';
 
@@ -364,15 +367,45 @@ const COSMERE: CosmereRPGConfig = {
             label: 'COSMERE.Actor.Resource.Health',
             deflect: true,
             formula: '10 + @attr.str + @bonus',
+            modes: {
+                [ActorType.Character]: {
+                    default: Derived.Mode.Derived,
+                    valid: [Derived.Mode.Derived, Derived.Mode.Override],
+                },
+                [ActorType.Adversary]: {
+                    default: Derived.Mode.Range,
+                    valid: [Derived.Mode.Range, Derived.Mode.Override],
+                },
+            },
         },
         [Resource.Focus]: {
             key: Resource.Focus,
             label: 'COSMERE.Actor.Resource.Focus',
             formula: '2 + @attr.wil + @bonus',
+            modes: {
+                [ActorType.Character]: {
+                    default: Derived.Mode.Derived,
+                    valid: [Derived.Mode.Derived, Derived.Mode.Override],
+                },
+                [ActorType.Adversary]: {
+                    default: Derived.Mode.Override,
+                    valid: [Derived.Mode.Override],
+                },
+            },
         },
         [Resource.Investiture]: {
             key: Resource.Investiture,
             label: 'COSMERE.Actor.Resource.Investiture',
+            modes: {
+                [ActorType.Character]: {
+                    default: Derived.Mode.Override,
+                    valid: [Derived.Mode.Override],
+                },
+                [ActorType.Adversary]: {
+                    default: Derived.Mode.Override,
+                    valid: [Derived.Mode.Override],
+                },
+            },
         },
     },
 

--- a/src/system/data/actor/common.ts
+++ b/src/system/data/actor/common.ts
@@ -679,6 +679,80 @@ export class CommonActorDataModel<
     }
 
     /**
+     * If Resource mode is not valid for that resource, set it back to the resource's default mode.
+     * This also sets the default given Derived isn't valid and not the default.
+     */
+    private sanitizeResourceModes(): void {
+        const health = this.resources[Resource.Health].max;
+        const focus = this.resources[Resource.Focus].max;
+        const investiture = this.resources[Resource.Investiture].max;
+
+        switch (this.parent.type) {
+            case 'character':
+                // Character Health
+                if (
+                    !CONFIG.COSMERE.resources.hea.modes.character.valid.includes(
+                        health.mode,
+                    )
+                ) {
+                    health.mode =
+                        CONFIG.COSMERE.resources.hea.modes.character.default;
+                }
+                // Character Focus
+                if (
+                    !CONFIG.COSMERE.resources.foc.modes.character.valid.includes(
+                        focus.mode,
+                    )
+                ) {
+                    health.mode =
+                        CONFIG.COSMERE.resources.foc.modes.character.default;
+                }
+                // Character Investiture
+                if (
+                    !CONFIG.COSMERE.resources.inv.modes.character.valid.includes(
+                        investiture.mode,
+                    )
+                ) {
+                    investiture.mode =
+                        CONFIG.COSMERE.resources.inv.modes.character.default;
+                }
+                break;
+            case 'adversary':
+                // Adversary Health
+                if (
+                    !CONFIG.COSMERE.resources.hea.modes.adversary.valid.includes(
+                        health.mode,
+                    )
+                ) {
+                    health.mode =
+                        CONFIG.COSMERE.resources.hea.modes.adversary.default;
+                }
+                // Adversary Focus
+                if (
+                    !CONFIG.COSMERE.resources.foc.modes.adversary.valid.includes(
+                        focus.mode,
+                    )
+                ) {
+                    focus.mode =
+                        CONFIG.COSMERE.resources.foc.modes.adversary.default;
+                }
+                // Adversary Investiture
+                if (
+                    !CONFIG.COSMERE.resources.inv.modes.adversary.valid.includes(
+                        investiture.mode,
+                    )
+                ) {
+                    investiture.mode =
+                        CONFIG.COSMERE.resources.inv.modes.adversary.default;
+                }
+                break;
+            default:
+                console.warn(`Unknown actor type: ${this.parent.type}`);
+                break;
+        }
+    }
+
+    /**
      * Apply secondary data derivations to this Data Model.
      * This is called after Active Effects are applied.
      */
@@ -788,6 +862,9 @@ export class CommonActorDataModel<
             // Derive deflect
             this.deflect.derived = Math.max(natural, armorDeflect);
         }
+
+        // Set resource mode to default for each resource if the current mode is invalid.
+        this.sanitizeResourceModes();
 
         // Clamp resource values to their max values
         (Object.keys(this.resources) as Resource[]).forEach((key) => {

--- a/src/system/data/actor/common.ts
+++ b/src/system/data/actor/common.ts
@@ -684,72 +684,24 @@ export class CommonActorDataModel<
      */
     private sanitizeResourceModes(): void {
         const health = this.resources[Resource.Health].max;
+        const healthConfig =
+            CONFIG.COSMERE.resources.hea.modes[this.parent.type as ActorType];
         const focus = this.resources[Resource.Focus].max;
+        const focusConfig =
+            CONFIG.COSMERE.resources.foc.modes[this.parent.type as ActorType];
         const investiture = this.resources[Resource.Investiture].max;
+        const investitureConfig =
+            CONFIG.COSMERE.resources.inv.modes[this.parent.type as ActorType];
 
-        switch (this.parent.type) {
-            case 'character':
-                // Character Health
-                if (
-                    !CONFIG.COSMERE.resources.hea.modes.character.valid.includes(
-                        health.mode,
-                    )
-                ) {
-                    health.mode =
-                        CONFIG.COSMERE.resources.hea.modes.character.default;
-                }
-                // Character Focus
-                if (
-                    !CONFIG.COSMERE.resources.foc.modes.character.valid.includes(
-                        focus.mode,
-                    )
-                ) {
-                    health.mode =
-                        CONFIG.COSMERE.resources.foc.modes.character.default;
-                }
-                // Character Investiture
-                if (
-                    !CONFIG.COSMERE.resources.inv.modes.character.valid.includes(
-                        investiture.mode,
-                    )
-                ) {
-                    investiture.mode =
-                        CONFIG.COSMERE.resources.inv.modes.character.default;
-                }
-                break;
-            case 'adversary':
-                // Adversary Health
-                if (
-                    !CONFIG.COSMERE.resources.hea.modes.adversary.valid.includes(
-                        health.mode,
-                    )
-                ) {
-                    health.mode =
-                        CONFIG.COSMERE.resources.hea.modes.adversary.default;
-                }
-                // Adversary Focus
-                if (
-                    !CONFIG.COSMERE.resources.foc.modes.adversary.valid.includes(
-                        focus.mode,
-                    )
-                ) {
-                    focus.mode =
-                        CONFIG.COSMERE.resources.foc.modes.adversary.default;
-                }
-                // Adversary Investiture
-                if (
-                    !CONFIG.COSMERE.resources.inv.modes.adversary.valid.includes(
-                        investiture.mode,
-                    )
-                ) {
-                    investiture.mode =
-                        CONFIG.COSMERE.resources.inv.modes.adversary.default;
-                }
-                break;
-            default:
-                console.warn(`Unknown actor type: ${this.parent.type}`);
-                break;
-        }
+        health.mode = healthConfig.valid.includes(health.mode)
+            ? health.mode
+            : healthConfig.default;
+        focus.mode = focusConfig.valid.includes(focus.mode)
+            ? focus.mode
+            : focusConfig.default;
+        investiture.mode = investitureConfig.valid.includes(investiture.mode)
+            ? investiture.mode
+            : investitureConfig.default;
     }
 
     /**

--- a/src/system/data/fields/derived-value-field.ts
+++ b/src/system/data/fields/derived-value-field.ts
@@ -22,6 +22,7 @@ export namespace Derived {
     export const Modes = {
         [Mode.Derived]: 'GENERIC.DerivedValue.Mode.Derived',
         [Mode.Override]: 'GENERIC.DerivedValue.Mode.Override',
+        [Mode.Range]: 'GENERIC.DerivedValue.Mode.Range',
     };
 }
 

--- a/src/system/types/config.ts
+++ b/src/system/types/config.ts
@@ -36,6 +36,7 @@ import {
     ActorType,
 } from './cosmere';
 import { AdvantageMode } from './roll';
+import { Derived } from '../data/fields';
 
 import { Talent, TalentTree, EventSystem as ItemEventSystem } from './item';
 
@@ -113,6 +114,11 @@ export interface SkillConfig {
     hiddenUntilAcquired?: boolean;
 }
 
+export interface ResourceModeConfig {
+    default: Derived.Mode;
+    valid: Derived.Mode[];
+}
+
 export interface ResourceConfig {
     key: string;
     label: string;
@@ -122,6 +128,7 @@ export interface ResourceConfig {
      * The formula used to derive the max value
      */
     formula?: string;
+    modes: Record<ActorType, ResourceModeConfig>;
 }
 
 export interface PathTypeConfig {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Other (please describe): Chore

**Description**  
Fixes an issue where currently we do not properly set the default mode for resources, but do limit the available modes. Causing an issue where you can't set the resource.

It fixes the issue by making sure the current mode is one of the valid modes for the resource. If it isn't then it sets it to default which each value now has its own default mode based on whether the actor is a Character or Actor

**Related Issue**  
Closes #956 

**How Has This Been Tested?**  
1. Create new character
2. Configure all resources and see that
- Health contains Derived (default) and Override for Characters.
- Focus contains Derived (default) and Override for Characters.
- Investiture contains Override (default) for Characters
- Health contains Range (default) and Override for Adversaries.
- Focus contains Override (default) for Adversaries.
- Investiture contains Override (default) for both Adversaries.
3. See that each of these resources behave as they should according to their set mode.
4. Create new adversary
5. Repeat steps 2-3 for the adversary

Also been tested like so
1. Create new character and adversary on main branch
2. Check resource modes and see that everything is on derived by default, even if mode says something different
3. Go back to this branch, build and refresh
4. See that resource modes are properly set to the default. (See step 2 on first numbered list)

**Screenshots (if applicable)**  
_Add screenshots or GIFs that help illustrate the changes, especially if they affect the UI or user-facing aspects of the system._

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.

**Additional context**  
Currently this assumes Derived.Mode.Derived is always the "default" if its a valid option. I assume this isn't changing any time soon, but if it is or we would rather prepare for that, it is easily solved by adding a "none" option in the Derived.Mode enum at the top.
"None" would then be acting as the new default for the enum which will always be invalid and thus trigger the sanitization for the resource modes and set it to the proper default.

This will be a draft PR until Khu has created a new release 3.1.1 branch which this will target.