### PR TITLE
fix: defaults to default theme if chosen theme is not valid

### DIFF
--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -289,7 +289,15 @@ export function registerDeferredSettings() {
         onChange: (s) => setTheme(document.body, s),
     });
 
-    setTheme(document.body, getSystemSetting(SETTINGS.SYSTEM_THEME));
+    const theme: Theme = getSystemSetting(SETTINGS.SYSTEM_THEME);
+
+    // Sets theme to default if selected theme option is no longer available
+    setTheme(
+        document.body,
+        theme in CONFIG.COSMERE.themes
+            ? theme
+            : (Object.keys(CONFIG.COSMERE.themes)[0] as Theme),
+    );
 
     // UNIT SYSTEM SETTING
     game.settings.register(SYSTEM_ID, SETTINGS.MEASUREMENT_UNIT_SYSTEM, {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue where if you remove a module that adds a new system theme, and you had set the system theme to said theme, it would make the sheets partially invisible.

It does this by making the displayed system theme automatically default to "default" if the chosen theme is not a valid option.

This fix also makes it so once you reenable the module that adds the system theme, it'll go back to that theme given the theme was chosen before the module was removed

**Related Issue**  
Closes #949 

**How Has This Been Tested?**  
1. Create new world
2. Create new character
3. Add Stormlight Handbook
4. Set system theme to Stormlight Archive
5. Look at character and see it has the correct theme
6. Remove handbook from world
7. Look at character and see the theme is back to Cosmere
8. Add handbook to world
9. Look at character and see the theme is back to Stormlight Archive.

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.

